### PR TITLE
feat(prompts): Prompt Library UI & responsive overhaul

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -384,6 +384,60 @@
   "editCategory": "Edit Category",
   "library": "Library",
   "refiner": "Refiner",
+  "selectionMode": "Selection Mode",
+  "selectionModeCount": "Selection Mode ({count})",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "nSelected": "{count} Selected",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "categorize": "Categorize",
+  "bulkCategorize": "Bulk Categorize",
+  "selectCategoriesToApply": "Select categories to apply to the selected prompts:",
+  "deleteNPromptsConfirm": "Delete {count} prompts?",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "actionCannotBeUndone": "This action cannot be undone.",
+  "deleteCategoryConfirmMessage": "Delete category \"{name}\"? Prompts will be moved to General.",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "moveToTop": "Move to Top",
+  "moveToBottom": "Move to Bottom",
+  "addSystemTemplateHint": "Add system templates for the Refiner or Batch Rename here.",
+  "importFailed": "Import failed: {error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "filterAll": "All",
+  "newTemplate": "New Template",
+  "reorderDisabledWhileFiltered": "Reordering is unavailable while a filter or search is active",
+  "matchModeLabel": "Match",
+  "matchAny": "Any",
+  "matchAllTags": "All",
   "settings": "Settings",
   "appearance": "Appearance",
   "connectivity": "Connectivity",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -250,6 +250,60 @@
   "editCategory": "カテゴリを編集",
   "library": "ライブラリ",
   "refiner": "リファイナー",
+  "selectionMode": "選択モード",
+  "selectionModeCount": "選択モード（{count}）",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "nSelected": "{count} 件を選択",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "categorize": "分類",
+  "bulkCategorize": "一括分類",
+  "selectCategoriesToApply": "選択したプロンプトに適用するカテゴリを選択：",
+  "deleteNPromptsConfirm": "{count} 件のプロンプトを削除しますか？",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "actionCannotBeUndone": "この操作は取り消せません。",
+  "deleteCategoryConfirmMessage": "カテゴリ「{name}」を削除しますか？プロンプトは General に移動されます。",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "moveToTop": "先頭へ移動",
+  "moveToBottom": "末尾へ移動",
+  "addSystemTemplateHint": "リファイナーまたは一括名前変更用のシステムテンプレートをここに追加します。",
+  "importFailed": "インポートに失敗しました：{error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "filterAll": "すべて",
+  "newTemplate": "新しいテンプレート",
+  "reorderDisabledWhileFiltered": "フィルターまたは検索中は並べ替えできません",
+  "matchModeLabel": "一致",
+  "matchAny": "いずれか",
+  "matchAllTags": "すべて",
   "settings": "設定",
   "appearance": "外観",
   "connectivity": "接続性",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1613,6 +1613,120 @@ abstract class AppLocalizations {
   /// **'Refiner'**
   String get refiner;
 
+  /// No description provided for @selectionMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Selection Mode'**
+  String get selectionMode;
+
+  /// No description provided for @selectionModeCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Selection Mode ({count})'**
+  String selectionModeCount(int count);
+
+  /// No description provided for @nSelected.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} Selected'**
+  String nSelected(int count);
+
+  /// No description provided for @categorize.
+  ///
+  /// In en, this message translates to:
+  /// **'Categorize'**
+  String get categorize;
+
+  /// No description provided for @bulkCategorize.
+  ///
+  /// In en, this message translates to:
+  /// **'Bulk Categorize'**
+  String get bulkCategorize;
+
+  /// No description provided for @selectCategoriesToApply.
+  ///
+  /// In en, this message translates to:
+  /// **'Select categories to apply to the selected prompts:'**
+  String get selectCategoriesToApply;
+
+  /// No description provided for @deleteNPromptsConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete {count} prompts?'**
+  String deleteNPromptsConfirm(int count);
+
+  /// No description provided for @actionCannotBeUndone.
+  ///
+  /// In en, this message translates to:
+  /// **'This action cannot be undone.'**
+  String get actionCannotBeUndone;
+
+  /// No description provided for @deleteCategoryConfirmMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete category \"{name}\"? Prompts will be moved to General.'**
+  String deleteCategoryConfirmMessage(String name);
+
+  /// No description provided for @moveToTop.
+  ///
+  /// In en, this message translates to:
+  /// **'Move to Top'**
+  String get moveToTop;
+
+  /// No description provided for @moveToBottom.
+  ///
+  /// In en, this message translates to:
+  /// **'Move to Bottom'**
+  String get moveToBottom;
+
+  /// No description provided for @addSystemTemplateHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add system templates for the Refiner or Batch Rename here.'**
+  String get addSystemTemplateHint;
+
+  /// No description provided for @importFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Import failed: {error}'**
+  String importFailed(String error);
+
+  /// No description provided for @filterAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get filterAll;
+
+  /// No description provided for @newTemplate.
+  ///
+  /// In en, this message translates to:
+  /// **'New Template'**
+  String get newTemplate;
+
+  /// No description provided for @reorderDisabledWhileFiltered.
+  ///
+  /// In en, this message translates to:
+  /// **'Reordering is unavailable while a filter or search is active'**
+  String get reorderDisabledWhileFiltered;
+
+  /// No description provided for @matchModeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Match'**
+  String get matchModeLabel;
+
+  /// No description provided for @matchAny.
+  ///
+  /// In en, this message translates to:
+  /// **'Any'**
+  String get matchAny;
+
+  /// No description provided for @matchAllTags.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get matchAllTags;
+
   /// No description provided for @settings.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -817,6 +817,76 @@ class AppLocalizationsEn extends AppLocalizations {
   String get refiner => 'Refiner';
 
   @override
+  String get selectionMode => 'Selection Mode';
+
+  @override
+  String selectionModeCount(int count) {
+    return 'Selection Mode ($count)';
+  }
+
+  @override
+  String nSelected(int count) {
+    return '$count Selected';
+  }
+
+  @override
+  String get categorize => 'Categorize';
+
+  @override
+  String get bulkCategorize => 'Bulk Categorize';
+
+  @override
+  String get selectCategoriesToApply =>
+      'Select categories to apply to the selected prompts:';
+
+  @override
+  String deleteNPromptsConfirm(int count) {
+    return 'Delete $count prompts?';
+  }
+
+  @override
+  String get actionCannotBeUndone => 'This action cannot be undone.';
+
+  @override
+  String deleteCategoryConfirmMessage(String name) {
+    return 'Delete category \"$name\"? Prompts will be moved to General.';
+  }
+
+  @override
+  String get moveToTop => 'Move to Top';
+
+  @override
+  String get moveToBottom => 'Move to Bottom';
+
+  @override
+  String get addSystemTemplateHint =>
+      'Add system templates for the Refiner or Batch Rename here.';
+
+  @override
+  String importFailed(String error) {
+    return 'Import failed: $error';
+  }
+
+  @override
+  String get filterAll => 'All';
+
+  @override
+  String get newTemplate => 'New Template';
+
+  @override
+  String get reorderDisabledWhileFiltered =>
+      'Reordering is unavailable while a filter or search is active';
+
+  @override
+  String get matchModeLabel => 'Match';
+
+  @override
+  String get matchAny => 'Any';
+
+  @override
+  String get matchAllTags => 'All';
+
+  @override
   String get settings => 'Settings';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -804,6 +804,73 @@ class AppLocalizationsJa extends AppLocalizations {
   String get refiner => 'リファイナー';
 
   @override
+  String get selectionMode => '選択モード';
+
+  @override
+  String selectionModeCount(int count) {
+    return '選択モード（$count）';
+  }
+
+  @override
+  String nSelected(int count) {
+    return '$count 件を選択';
+  }
+
+  @override
+  String get categorize => '分類';
+
+  @override
+  String get bulkCategorize => '一括分類';
+
+  @override
+  String get selectCategoriesToApply => '選択したプロンプトに適用するカテゴリを選択：';
+
+  @override
+  String deleteNPromptsConfirm(int count) {
+    return '$count 件のプロンプトを削除しますか？';
+  }
+
+  @override
+  String get actionCannotBeUndone => 'この操作は取り消せません。';
+
+  @override
+  String deleteCategoryConfirmMessage(String name) {
+    return 'カテゴリ「$name」を削除しますか？プロンプトは General に移動されます。';
+  }
+
+  @override
+  String get moveToTop => '先頭へ移動';
+
+  @override
+  String get moveToBottom => '末尾へ移動';
+
+  @override
+  String get addSystemTemplateHint => 'リファイナーまたは一括名前変更用のシステムテンプレートをここに追加します。';
+
+  @override
+  String importFailed(String error) {
+    return 'インポートに失敗しました：$error';
+  }
+
+  @override
+  String get filterAll => 'すべて';
+
+  @override
+  String get newTemplate => '新しいテンプレート';
+
+  @override
+  String get reorderDisabledWhileFiltered => 'フィルターまたは検索中は並べ替えできません';
+
+  @override
+  String get matchModeLabel => '一致';
+
+  @override
+  String get matchAny => 'いずれか';
+
+  @override
+  String get matchAllTags => 'すべて';
+
+  @override
   String get settings => '設定';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -803,6 +803,73 @@ class AppLocalizationsZh extends AppLocalizations {
   String get refiner => '优化器';
 
   @override
+  String get selectionMode => '选择模式';
+
+  @override
+  String selectionModeCount(int count) {
+    return '选择模式（$count）';
+  }
+
+  @override
+  String nSelected(int count) {
+    return '已选择 $count 项';
+  }
+
+  @override
+  String get categorize => '归类';
+
+  @override
+  String get bulkCategorize => '批量归类';
+
+  @override
+  String get selectCategoriesToApply => '选择要应用到所选提示词的分类：';
+
+  @override
+  String deleteNPromptsConfirm(int count) {
+    return '删除 $count 个提示词？';
+  }
+
+  @override
+  String get actionCannotBeUndone => '此操作无法撤销。';
+
+  @override
+  String deleteCategoryConfirmMessage(String name) {
+    return '删除分类“$name”？其中的提示词将移至 General。';
+  }
+
+  @override
+  String get moveToTop => '移到顶部';
+
+  @override
+  String get moveToBottom => '移到底部';
+
+  @override
+  String get addSystemTemplateHint => '在此添加用于优化器或批量重命名的系统模板。';
+
+  @override
+  String importFailed(String error) {
+    return '导入失败：$error';
+  }
+
+  @override
+  String get filterAll => '全部';
+
+  @override
+  String get newTemplate => '新建模板';
+
+  @override
+  String get reorderDisabledWhileFiltered => '筛选或搜索时无法拖动排序';
+
+  @override
+  String get matchModeLabel => '匹配';
+
+  @override
+  String get matchAny => '任一';
+
+  @override
+  String get matchAllTags => '全部';
+
+  @override
   String get settings => '设置';
 
   @override
@@ -2326,6 +2393,73 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get refiner => 'Refiner';
+
+  @override
+  String get selectionMode => '選擇模式';
+
+  @override
+  String selectionModeCount(int count) {
+    return '選擇模式（$count）';
+  }
+
+  @override
+  String nSelected(int count) {
+    return '已選擇 $count 項';
+  }
+
+  @override
+  String get categorize => '歸類';
+
+  @override
+  String get bulkCategorize => '批次歸類';
+
+  @override
+  String get selectCategoriesToApply => '選擇要套用到所選提示的類別：';
+
+  @override
+  String deleteNPromptsConfirm(int count) {
+    return '刪除 $count 個提示？';
+  }
+
+  @override
+  String get actionCannotBeUndone => '此操作無法復原。';
+
+  @override
+  String deleteCategoryConfirmMessage(String name) {
+    return '刪除類別「$name」？其中的提示將移至 General。';
+  }
+
+  @override
+  String get moveToTop => '移到頂部';
+
+  @override
+  String get moveToBottom => '移到底部';
+
+  @override
+  String get addSystemTemplateHint => '在此新增用於 Refiner 或批次重新命名的系統範本。';
+
+  @override
+  String importFailed(String error) {
+    return '匯入失敗：$error';
+  }
+
+  @override
+  String get filterAll => '全部';
+
+  @override
+  String get newTemplate => '新增範本';
+
+  @override
+  String get reorderDisabledWhileFiltered => '篩選或搜尋時無法拖曳排序';
+
+  @override
+  String get matchModeLabel => '符合';
+
+  @override
+  String get matchAny => '任一';
+
+  @override
+  String get matchAllTags => '全部';
 
   @override
   String get settings => '設定';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -384,6 +384,60 @@
   "editCategory": "编辑分类",
   "library": "提示词库",
   "refiner": "优化器",
+  "selectionMode": "选择模式",
+  "selectionModeCount": "选择模式（{count}）",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "nSelected": "已选择 {count} 项",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "categorize": "归类",
+  "bulkCategorize": "批量归类",
+  "selectCategoriesToApply": "选择要应用到所选提示词的分类：",
+  "deleteNPromptsConfirm": "删除 {count} 个提示词？",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "actionCannotBeUndone": "此操作无法撤销。",
+  "deleteCategoryConfirmMessage": "删除分类“{name}”？其中的提示词将移至 General。",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "moveToTop": "移到顶部",
+  "moveToBottom": "移到底部",
+  "addSystemTemplateHint": "在此添加用于优化器或批量重命名的系统模板。",
+  "importFailed": "导入失败：{error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "filterAll": "全部",
+  "newTemplate": "新建模板",
+  "reorderDisabledWhileFiltered": "筛选或搜索时无法拖动排序",
+  "matchModeLabel": "匹配",
+  "matchAny": "任一",
+  "matchAllTags": "全部",
   "settings": "设置",
   "appearance": "外观",
   "connectivity": "连接设置",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -250,6 +250,60 @@
   "editCategory": "編輯類別",
   "library": "媒體庫",
   "refiner": "Refiner",
+  "selectionMode": "選擇模式",
+  "selectionModeCount": "選擇模式（{count}）",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "nSelected": "已選擇 {count} 項",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "categorize": "歸類",
+  "bulkCategorize": "批次歸類",
+  "selectCategoriesToApply": "選擇要套用到所選提示的類別：",
+  "deleteNPromptsConfirm": "刪除 {count} 個提示？",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "actionCannotBeUndone": "此操作無法復原。",
+  "deleteCategoryConfirmMessage": "刪除類別「{name}」？其中的提示將移至 General。",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "moveToTop": "移到頂部",
+  "moveToBottom": "移到底部",
+  "addSystemTemplateHint": "在此新增用於 Refiner 或批次重新命名的系統範本。",
+  "importFailed": "匯入失敗：{error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "filterAll": "全部",
+  "newTemplate": "新增範本",
+  "reorderDisabledWhileFiltered": "篩選或搜尋時無法拖曳排序",
+  "matchModeLabel": "符合",
+  "matchAny": "任一",
+  "matchAllTags": "全部",
   "settings": "設定",
   "appearance": "外觀",
   "connectivity": "連線",

--- a/lib/l10n/src/en/prompts.arb
+++ b/lib/l10n/src/en/prompts.arb
@@ -31,5 +31,49 @@
   "addCategory": "Add Category",
   "editCategory": "Edit Category",
   "library": "Library",
-  "refiner": "Refiner"
+  "refiner": "Refiner",
+  "selectionMode": "Selection Mode",
+  "selectionModeCount": "Selection Mode ({count})",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "nSelected": "{count} Selected",
+  "@nSelected": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "categorize": "Categorize",
+  "bulkCategorize": "Bulk Categorize",
+  "selectCategoriesToApply": "Select categories to apply to the selected prompts:",
+  "deleteNPromptsConfirm": "Delete {count} prompts?",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "actionCannotBeUndone": "This action cannot be undone.",
+  "deleteCategoryConfirmMessage": "Delete category \"{name}\"? Prompts will be moved to General.",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "moveToTop": "Move to Top",
+  "moveToBottom": "Move to Bottom",
+  "addSystemTemplateHint": "Add system templates for the Refiner or Batch Rename here.",
+  "importFailed": "Import failed: {error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "filterAll": "All",
+  "newTemplate": "New Template",
+  "reorderDisabledWhileFiltered": "Reordering is unavailable while a filter or search is active",
+  "matchModeLabel": "Match",
+  "matchAny": "Any",
+  "matchAllTags": "All"
 }

--- a/lib/l10n/src/ja/prompts.arb
+++ b/lib/l10n/src/ja/prompts.arb
@@ -24,5 +24,49 @@
   "addCategory": "カテゴリを追加",
   "editCategory": "カテゴリを編集",
   "library": "ライブラリ",
-  "refiner": "リファイナー"
+  "refiner": "リファイナー",
+  "selectionMode": "選択モード",
+  "selectionModeCount": "選択モード（{count}）",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "nSelected": "{count} 件を選択",
+  "@nSelected": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "categorize": "分類",
+  "bulkCategorize": "一括分類",
+  "selectCategoriesToApply": "選択したプロンプトに適用するカテゴリを選択：",
+  "deleteNPromptsConfirm": "{count} 件のプロンプトを削除しますか？",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "actionCannotBeUndone": "この操作は取り消せません。",
+  "deleteCategoryConfirmMessage": "カテゴリ「{name}」を削除しますか？プロンプトは General に移動されます。",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "moveToTop": "先頭へ移動",
+  "moveToBottom": "末尾へ移動",
+  "addSystemTemplateHint": "リファイナーまたは一括名前変更用のシステムテンプレートをここに追加します。",
+  "importFailed": "インポートに失敗しました：{error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "filterAll": "すべて",
+  "newTemplate": "新しいテンプレート",
+  "reorderDisabledWhileFiltered": "フィルターまたは検索中は並べ替えできません",
+  "matchModeLabel": "一致",
+  "matchAny": "いずれか",
+  "matchAllTags": "すべて"
 }

--- a/lib/l10n/src/zh/prompts.arb
+++ b/lib/l10n/src/zh/prompts.arb
@@ -31,5 +31,49 @@
   "addCategory": "添加分类",
   "editCategory": "编辑分类",
   "library": "提示词库",
-  "refiner": "优化器"
+  "refiner": "优化器",
+  "selectionMode": "选择模式",
+  "selectionModeCount": "选择模式（{count}）",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "nSelected": "已选择 {count} 项",
+  "@nSelected": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "categorize": "归类",
+  "bulkCategorize": "批量归类",
+  "selectCategoriesToApply": "选择要应用到所选提示词的分类：",
+  "deleteNPromptsConfirm": "删除 {count} 个提示词？",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "actionCannotBeUndone": "此操作无法撤销。",
+  "deleteCategoryConfirmMessage": "删除分类“{name}”？其中的提示词将移至 General。",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "moveToTop": "移到顶部",
+  "moveToBottom": "移到底部",
+  "addSystemTemplateHint": "在此添加用于优化器或批量重命名的系统模板。",
+  "importFailed": "导入失败：{error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "filterAll": "全部",
+  "newTemplate": "新建模板",
+  "reorderDisabledWhileFiltered": "筛选或搜索时无法拖动排序",
+  "matchModeLabel": "匹配",
+  "matchAny": "任一",
+  "matchAllTags": "全部"
 }

--- a/lib/l10n/src/zh_Hant/prompts.arb
+++ b/lib/l10n/src/zh_Hant/prompts.arb
@@ -24,5 +24,49 @@
   "addCategory": "新增類別",
   "editCategory": "編輯類別",
   "library": "媒體庫",
-  "refiner": "Refiner"
+  "refiner": "Refiner",
+  "selectionMode": "選擇模式",
+  "selectionModeCount": "選擇模式（{count}）",
+  "@selectionModeCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "nSelected": "已選擇 {count} 項",
+  "@nSelected": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "categorize": "歸類",
+  "bulkCategorize": "批次歸類",
+  "selectCategoriesToApply": "選擇要套用到所選提示的類別：",
+  "deleteNPromptsConfirm": "刪除 {count} 個提示？",
+  "@deleteNPromptsConfirm": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "actionCannotBeUndone": "此操作無法復原。",
+  "deleteCategoryConfirmMessage": "刪除類別「{name}」？其中的提示將移至 General。",
+  "@deleteCategoryConfirmMessage": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "moveToTop": "移到頂部",
+  "moveToBottom": "移到底部",
+  "addSystemTemplateHint": "在此新增用於 Refiner 或批次重新命名的系統範本。",
+  "importFailed": "匯入失敗：{error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "filterAll": "全部",
+  "newTemplate": "新增範本",
+  "reorderDisabledWhileFiltered": "篩選或搜尋時無法拖曳排序",
+  "matchModeLabel": "符合",
+  "matchAny": "任一",
+  "matchAllTags": "全部"
 }

--- a/lib/screens/prompts/prompts_screen.dart
+++ b/lib/screens/prompts/prompts_screen.dart
@@ -36,6 +36,8 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
   String _searchQuery = "";
   String _selectedSystemType = 'refiner'; // 'refiner' or 'rename'
   final Set<int> _selectedFilterTagIds = {};
+  // When multiple categories are selected: false = match any (OR), true = match all (AND).
+  bool _filterMatchAll = false;
 
   final Set<int> _selectedIds = {};
   bool get _isSelectionMode => _selectedIds.isNotEmpty;
@@ -120,6 +122,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
 
   Widget _buildBulkActionFAB(AppLocalizations l10n) {
     final colorScheme = Theme.of(context).colorScheme;
+    final isNarrow = Responsive.isMobile(context);
     return Card(
       elevation: 6,
       margin: const EdgeInsets.symmetric(horizontal: 16),
@@ -135,29 +138,42 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
               onPressed: _clearSelection,
               tooltip: l10n.cancel,
             ),
-            const SizedBox(width: 8),
+            const SizedBox(width: 4),
             Text(
-              "${_selectedIds.length} Selected",
+              l10n.nSelected(_selectedIds.length),
               style: TextStyle(
                 color: colorScheme.onPrimaryContainer,
                 fontWeight: FontWeight.bold,
               ),
             ),
-            const SizedBox(width: 16),
+            const SizedBox(width: 12),
             const VerticalDivider(width: 1, indent: 8, endIndent: 8),
-            const SizedBox(width: 8),
-            TextButton.icon(
-              icon: const Icon(Icons.category_outlined),
-              label: const Text("Categorize"),
-              onPressed: _handleBulkCategorize,
-            ),
-            const SizedBox(width: 8),
-            TextButton.icon(
-              icon: const Icon(Icons.delete_outline, color: Colors.red),
-              label: const Text("Delete", style: TextStyle(color: Colors.red)),
-              onPressed: _handleBulkDelete,
-            ),
-            const SizedBox(width: 8),
+            const SizedBox(width: 4),
+            if (isNarrow) ...[
+              IconButton(
+                icon: const Icon(Icons.category_outlined),
+                tooltip: l10n.categorize,
+                onPressed: _handleBulkCategorize,
+              ),
+              IconButton(
+                icon: Icon(Icons.delete_outline, color: colorScheme.error),
+                tooltip: l10n.delete,
+                onPressed: _handleBulkDelete,
+              ),
+            ] else ...[
+              TextButton.icon(
+                icon: const Icon(Icons.category_outlined),
+                label: Text(l10n.categorize),
+                onPressed: _handleBulkCategorize,
+              ),
+              const SizedBox(width: 8),
+              TextButton.icon(
+                icon: Icon(Icons.delete_outline, color: colorScheme.error),
+                label: Text(l10n.delete, style: TextStyle(color: colorScheme.error)),
+                onPressed: _handleBulkDelete,
+              ),
+              const SizedBox(width: 8),
+            ],
           ],
         ),
       ),
@@ -166,15 +182,19 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
 
   Future<void> _handleBulkDelete() async {
     final l10n = AppLocalizations.of(context)!;
+    final colorScheme = Theme.of(context).colorScheme;
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text("Delete ${_selectedIds.length} Prompts?"),
-        content: Text("This action cannot be undone."),
+        title: Text(l10n.deleteNPromptsConfirm(_selectedIds.length)),
+        content: Text(l10n.actionCannotBeUndone),
         actions: [
           TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
           FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
             onPressed: () => Navigator.pop(context, true),
             child: Text(l10n.delete),
           ),
@@ -195,18 +215,19 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
   }
 
   Future<void> _handleBulkCategorize() async {
+    final l10n = AppLocalizations.of(context)!;
     final Set<int> targetTagIds = {};
-    
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => StatefulBuilder(
         builder: (context, setDialogState) => AlertDialog(
-          title: const Text("Bulk Categorize"),
+          title: Text(l10n.bulkCategorize),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Text("Select categories to apply to selected prompts:"),
+              Text(l10n.selectCategoriesToApply),
               const SizedBox(height: 16),
               Wrap(
                 spacing: 8,
@@ -231,10 +252,10 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
             ],
           ),
           actions: [
-            TextButton(onPressed: () => Navigator.pop(context, false), child: const Text("Cancel")),
+            TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
             FilledButton(
               onPressed: () => Navigator.pop(context, true),
-              child: const Text("Apply"),
+              child: Text(l10n.apply),
             ),
           ],
         ),
@@ -260,7 +281,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
       body: NestedScrollView(
         headerSliverBuilder: (context, innerBoxIsScrolled) => [
           SliverAppBar(
-            title: Text(_isSelectionMode ? "Selection Mode" : l10n.promptLibrary),
+            title: Text(_isSelectionMode ? l10n.selectionMode : l10n.promptLibrary),
             pinned: true,
             floating: true,
             snap: true,
@@ -306,12 +327,20 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
   }
 
   // --- Desktop/Tablet Layout ---
-  Widget _buildDesktopLayout(AppLocalizations l10n, {bool isTablet = false}) {  
+  Widget _buildDesktopLayout(AppLocalizations l10n, {bool isTablet = false}) {
     final colorScheme = Theme.of(context).colorScheme;
+
+    // Per-category counts for the User Prompts list (tag filter applies there).
+    final tagCounts = _computeTagCounts();
+
+    final bool showSidebar = !isTablet && _tabController.index == 0;
+    final bool showTabletFilter =
+        isTablet && _tabController.index == 0 && _tags.isNotEmpty;
+
     return Scaffold(
       backgroundColor: colorScheme.surface,
       appBar: AppBar(
-        title: Text(_isSelectionMode ? "Selection Mode (${_selectedIds.length})" : l10n.promptLibrary, 
+        title: Text(_isSelectionMode ? l10n.selectionModeCount(_selectedIds.length) : l10n.promptLibrary,
             style: const TextStyle(fontWeight: FontWeight.bold)),
         elevation: 0,
         scrolledUnderElevation: 0,
@@ -319,17 +348,23 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
         centerTitle: false,
         leading: _isSelectionMode ? IconButton(icon: const Icon(Icons.close), onPressed: _clearSelection) : null,
         actions: _isSelectionMode ? [] : [
-          _buildSearchField(l10n),
+          _buildSearchField(l10n, width: isTablet ? 200 : 300),
           const SizedBox(width: 8),
           _buildImportExportActions(l10n),
           const SizedBox(width: 8),
           Padding(
-            padding: const EdgeInsets.only(right: 16),
-            child: FilledButton.icon(
-              onPressed: _handleAddAction,
-              icon: const Icon(Icons.add, size: 18),
-              label: Text(l10n.add),
-            ),
+            padding: EdgeInsets.only(right: isTablet ? 12 : 16),
+            child: isTablet
+                ? IconButton.filled(
+                    onPressed: _handleAddAction,
+                    icon: const Icon(Icons.add),
+                    tooltip: _addLabel(l10n),
+                  )
+                : FilledButton.icon(
+                    onPressed: _handleAddAction,
+                    icon: const Icon(Icons.add, size: 18),
+                    label: Text(_addLabel(l10n)),
+                  ),
           ),
         ],
         bottom: PreferredSize(
@@ -348,17 +383,21 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
             destinations: [
               NavigationRailDestination(icon: const Icon(Icons.person_outline), selectedIcon: const Icon(Icons.person), label: Text(l10n.userPrompts)),
               NavigationRailDestination(icon: const Icon(Icons.auto_fix_high_outlined), selectedIcon: const Icon(Icons.auto_fix_high), label: Text(l10n.systemTemplates)),
-              NavigationRailDestination(icon: const Icon(Icons.category_outlined), selectedIcon: const Icon(Icons.category), label: Text(l10n.categoriesTab)),  
+              NavigationRailDestination(icon: const Icon(Icons.category_outlined), selectedIcon: const Icon(Icons.category), label: Text(l10n.categoriesTab)),
             ],
           ),
           const VerticalDivider(width: 1),
-          // Tag Sidebar (Only for Prompts)
-          if (_tabController.index != 2) ...[
+          // Tag Sidebar — desktop only, User Prompts tab only
+          if (showSidebar) ...[
             SizedBox(
-              width: isTablet ? 200 : 260,
+              width: 260,
               child: PromptsSidebar(
                 tags: _tags,
                 selectedFilterTagIds: _selectedFilterTagIds,
+                tagCounts: tagCounts,
+                totalCount: _userPrompts.length,
+                matchAll: _filterMatchAll,
+                onMatchModeChanged: (val) => setState(() => _filterMatchAll = val),
                 onTagToggle: (id) {
                   setState(() {
                     if (_selectedFilterTagIds.contains(id)) {
@@ -368,7 +407,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
                     }
                   });
                 },
-                onClear: () => setState(() => _selectedFilterTagIds.clear()),   
+                onClear: () => setState(() => _selectedFilterTagIds.clear()),
               ),
             ),
             const VerticalDivider(width: 1),
@@ -377,12 +416,50 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
           Expanded(
             child: Container(
               color: colorScheme.surface,
-              child: _buildTabViews(l10n)[_tabController.index],
+              child: Column(
+                children: [
+                  // Tablet: horizontal category filter replaces the sidebar
+                  if (showTabletFilter) _buildMobileFilterBar(colorScheme),
+                  Expanded(
+                    child: _buildConstrainedContent(
+                      _buildTabViews(l10n)[_tabController.index],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ],
       ),
     );
+  }
+
+  /// Number of user prompts carrying each tag id.
+  Map<int, int> _computeTagCounts() => {
+        for (final t in _tags)
+          t.id!: _userPrompts.where((p) => p.tags.any((pt) => pt.id == t.id)).length,
+      };
+
+  /// Caps content width on ultra-wide screens for readability, top-aligned.
+  Widget _buildConstrainedContent(Widget child) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 920),
+        child: child,
+      ),
+    );
+  }
+
+  String _addLabel(AppLocalizations l10n) {
+    switch (_tabController.index) {
+      case 1:
+        return l10n.newTemplate;
+      case 2:
+        return l10n.addCategory;
+      default:
+        return l10n.newPrompt;
+    }
   }
 
   List<Widget> _buildTabViews(AppLocalizations l10n) {
@@ -391,7 +468,10 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
                             p.content.toLowerCase().contains(_searchQuery);     
       if (_selectedFilterTagIds.isEmpty) return matchesSearch;
       final promptTagIds = p.tags.map((t) => t.id!).toSet();
-      return matchesSearch && _selectedFilterTagIds.every((id) => promptTagIds.contains(id));
+      final matchesTags = _filterMatchAll
+          ? _selectedFilterTagIds.every((id) => promptTagIds.contains(id))
+          : _selectedFilterTagIds.any((id) => promptTagIds.contains(id));
+      return matchesSearch && matchesTags;
     }).toList();
 
     final filteredSystem = _systemPrompts.where((p) {
@@ -430,6 +510,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
       ),
       TagManagementList(
         tags: _tags,
+        promptCounts: _computeTagCounts(),
         onRefresh: _loadData,
         onShowEditDialog: (l, {tag}) => _showTagDialog(l, tag: tag),
         onConfirmDelete: _confirmDeleteTag,
@@ -437,9 +518,9 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
     ];
   }
 
-  Widget _buildSearchField(AppLocalizations l10n, {bool isMobile = false}) {    
+  Widget _buildSearchField(AppLocalizations l10n, {bool isMobile = false, double width = 300}) {
     return Container(
-      width: isMobile ? double.infinity : 300,
+      width: isMobile ? double.infinity : width,
       height: 40,
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerHighest.withAlpha(100),
@@ -516,10 +597,34 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
       ),
       child: ListView.separated(
         scrollDirection: Axis.horizontal,
-        itemCount: _tags.length,
+        // +1 for the leading "All" chip that clears the filter.
+        itemCount: _tags.length + 1,
         separatorBuilder: (context, index) => const SizedBox(width: 8),
         itemBuilder: (context, index) {
-          final tag = _tags[index];
+          final l10n = AppLocalizations.of(context)!;
+
+          // Leading "All" chip.
+          if (index == 0) {
+            final allSelected = _selectedFilterTagIds.isEmpty;
+            return FilterChip(
+              label: Text(l10n.filterAll, style: TextStyle(
+                fontSize: 12,
+                color: allSelected ? colorScheme.onPrimary : colorScheme.onSurfaceVariant,
+                fontWeight: allSelected ? FontWeight.bold : FontWeight.normal,
+              )),
+              selected: allSelected,
+              onSelected: (_) => setState(() => _selectedFilterTagIds.clear()),
+              selectedColor: colorScheme.primary,
+              checkmarkColor: colorScheme.onPrimary,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+                side: BorderSide(color: colorScheme.outlineVariant),
+              ),
+              visualDensity: VisualDensity.compact,
+            );
+          }
+
+          final tag = _tags[index - 1];
           final id = tag.id!;
           final isSelected = _selectedFilterTagIds.contains(id);
           final color = Color(tag.color);
@@ -528,7 +633,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
             label: Text(tag.name, style: TextStyle(
               fontSize: 12,
               color: isSelected ? Colors.white : color,
-              fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,     
+              fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
             )),
             selected: isSelected,
             onSelected: (val) {
@@ -581,6 +686,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
   }
 
   void _confirmDelete(AppLocalizations l10n, dynamic prompt, {required bool isSystem}) {
+    final colorScheme = Theme.of(context).colorScheme;
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -588,10 +694,13 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
         content: Text(l10n.deletePromptConfirmMessage(prompt.title)),
         actions: [
           TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),       
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
             onPressed: () async {
-              final appState = Provider.of<AppState>(context, listen: false);   
+              final appState = Provider.of<AppState>(context, listen: false);
               if (isSystem) {
                 await appState.deleteSystemPrompt(prompt.id);
               } else {
@@ -602,7 +711,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
                 _loadData();
               }
             },
-            child: Text(l10n.delete, style: const TextStyle(color: Colors.white)),
+            child: Text(l10n.delete),
           ),
         ],
       ),
@@ -610,24 +719,28 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
   }
 
   void _confirmDeleteTag(AppLocalizations l10n, PromptTag tag) {
+    final colorScheme = Theme.of(context).colorScheme;
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
         title: Text(l10n.delete),
-        content: Text("Are you sure you want to delete category \"${tag.name}\"? Prompts will be moved to General."),
+        content: Text(l10n.deleteCategoryConfirmMessage(tag.name)),
         actions: [
           TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),       
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+            ),
             onPressed: () async {
-              final appState = Provider.of<AppState>(context, listen: false);   
+              final appState = Provider.of<AppState>(context, listen: false);
               await appState.deletePromptTag(tag.id!);
               if (context.mounted) {
                 Navigator.pop(context);
                 _loadData();
               }
             },
-            child: Text(l10n.delete, style: const TextStyle(color: Colors.white)),
+            child: Text(l10n.delete),
           ),
         ],
       ),
@@ -969,6 +1082,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
     final appState = Provider.of<AppState>(context, listen: false);
     final messenger = ScaffoldMessenger.of(context);
     final successMsg = l10n.settingsImported;
+    final errorColor = Theme.of(context).colorScheme.error;
 
     FilePickerResult? result = await FilePicker.pickFiles(type: FileType.custom, allowedExtensions: ['json']);
     if (!mounted || result == null) return;
@@ -984,7 +1098,10 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
             child: Text(l10n.merge),
           ),
           FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+              foregroundColor: Theme.of(context).colorScheme.onError,
+            ),
             onPressed: () => Navigator.pop(context, 'replace'),
             child: Text(l10n.replaceAll),
           ),
@@ -1013,7 +1130,10 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
       }
     } catch (e) {
       if (mounted) {
-        messenger.showSnackBar(SnackBar(content: Text("Import failed: $e"), backgroundColor: Colors.red));
+        messenger.showSnackBar(SnackBar(
+          content: Text(l10n.importFailed(e.toString())),
+          backgroundColor: errorColor,
+        ));
       }
     }
   }

--- a/lib/screens/prompts/widgets/prompts_sidebar.dart
+++ b/lib/screens/prompts/widgets/prompts_sidebar.dart
@@ -9,29 +9,43 @@ class PromptsSidebar extends StatelessWidget {
   final ValueChanged<int> onTagToggle;
   final VoidCallback onClear;
 
+  /// Number of prompts in the active list per tag id.
+  final Map<int, int> tagCounts;
+
+  /// Total number of prompts in the active list (the "All" entry count).
+  final int totalCount;
+
+  /// When multiple categories are selected: false = match any, true = match all.
+  final bool matchAll;
+  final ValueChanged<bool>? onMatchModeChanged;
+
   const PromptsSidebar({
     super.key,
     required this.tags,
     required this.selectedFilterTagIds,
     required this.onTagToggle,
     required this.onClear,
+    this.tagCounts = const {},
+    this.totalCount = 0,
+    this.matchAll = false,
+    this.onMatchModeChanged,
   });
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
+    final allSelected = selectedFilterTagIds.isEmpty;
 
     return Container(
-      width: 250,
       color: colorScheme.surfaceContainerLow,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: const EdgeInsets.all(16.0),
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
             child: Text(
-              l10n.categoriesTab,
+              l10n.categoriesTab.toUpperCase(),
               style: TextStyle(
                 fontWeight: FontWeight.bold,
                 color: colorScheme.primary,
@@ -41,25 +55,68 @@ class PromptsSidebar extends StatelessWidget {
             ),
           ),
           Expanded(
-            child: ListView.builder(
-              itemCount: tags.length,
-              itemBuilder: (context, index) {
-                final tag = tags[index];
-                final isSelected = selectedFilterTagIds.contains(tag.id);
-                return ListTile(
-                  dense: true,
+            child: ListView(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              children: [
+                _SidebarTile(
                   leading: Icon(
-                    isSelected ? Icons.label : Icons.label_outline,
-                    color: Color(tag.color),
+                    Icons.layers_outlined,
+                    color: allSelected ? colorScheme.primary : colorScheme.onSurfaceVariant,
                     size: 18,
                   ),
-                  title: Text(tag.name),
-                  selected: isSelected,
-                  onTap: () => onTagToggle(tag.id!),
-                );
-              },
+                  label: l10n.filterAll,
+                  count: totalCount,
+                  selected: allSelected,
+                  onTap: onClear,
+                ),
+                Divider(height: 12, color: colorScheme.outlineVariant.withAlpha(80)),
+                ...tags.map((tag) {
+                  final isSelected = selectedFilterTagIds.contains(tag.id);
+                  return _SidebarTile(
+                    leading: Icon(
+                      isSelected ? Icons.label : Icons.label_outline,
+                      color: Color(tag.color),
+                      size: 18,
+                    ),
+                    label: tag.name,
+                    count: tagCounts[tag.id] ?? 0,
+                    selected: isSelected,
+                    onTap: () => onTagToggle(tag.id!),
+                  );
+                }),
+              ],
             ),
           ),
+          // Match mode toggle — only relevant when filtering by 2+ categories.
+          if (selectedFilterTagIds.length >= 2 && onMatchModeChanged != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
+              child: Row(
+                children: [
+                  Text(
+                    '${l10n.matchModeLabel}:',
+                    style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: SegmentedButton<bool>(
+                      style: ButtonStyle(
+                        visualDensity: VisualDensity.compact,
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        textStyle: WidgetStatePropertyAll(TextStyle(fontSize: 12)),
+                      ),
+                      segments: [
+                        ButtonSegment(value: false, label: Text(l10n.matchAny)),
+                        ButtonSegment(value: true, label: Text(l10n.matchAllTags)),
+                      ],
+                      selected: {matchAll},
+                      onSelectionChanged: (s) => onMatchModeChanged!(s.first),
+                      showSelectedIcon: false,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           if (selectedFilterTagIds.isNotEmpty)
             Padding(
               padding: const EdgeInsets.all(8.0),
@@ -70,6 +127,67 @@ class PromptsSidebar extends StatelessWidget {
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _SidebarTile extends StatelessWidget {
+  final Widget leading;
+  final String label;
+  final int count;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _SidebarTile({
+    required this.leading,
+    required this.label,
+    required this.count,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            color: selected ? colorScheme.primary.withAlpha(28) : null,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+          margin: const EdgeInsets.symmetric(vertical: 1),
+          child: Row(
+            children: [
+              leading,
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  label,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+                    color: selected ? colorScheme.primary : colorScheme.onSurface,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '$count',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: selected ? colorScheme.primary : colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/prompts/widgets/system_template_list.dart
+++ b/lib/screens/prompts/widgets/system_template_list.dart
@@ -52,16 +52,17 @@ class _SystemTemplateListState extends State<SystemTemplateList> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.auto_fix_high, size: 64, color: Colors.grey.shade400),   
+            Icon(Icons.auto_fix_high, size: 64, color: Theme.of(context).colorScheme.outlineVariant),
             const SizedBox(height: 16),
             Text(
               l10n.noPromptsSaved,
               style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold) 
             ),
             const SizedBox(height: 8),
-            const Text(
-              "Add system templates for the Refiner or Batch Rename here.",     
-              style: TextStyle(color: Colors.grey)
+            Text(
+              l10n.addSystemTemplateHint,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Theme.of(context).colorScheme.outline),
             ),
             const SizedBox(height: 24),
             ElevatedButton.icon(
@@ -78,7 +79,12 @@ class _SystemTemplateListState extends State<SystemTemplateList> {
         itemCount: prompts.length,
         // ignore: deprecated_member_use
         onReorder: (oldIndex, newIndex) async {
-          if (widget.searchQuery.isNotEmpty) return;
+          if (widget.searchQuery.isNotEmpty) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(l10n.reorderDisabledWhileFiltered)),
+            );
+            return;
+          }
           setState(() {
             if (newIndex > oldIndex) newIndex -= 1;
             final item = prompts.removeAt(oldIndex);
@@ -141,7 +147,7 @@ class _SystemTemplateListState extends State<SystemTemplateList> {
                     onPressed: () => widget.onShowEditDialog(l10n, prompt: systemPrompt),
                   ),
                   IconButton(
-                    icon: const Icon(Icons.delete_outline, size: 18, color: Colors.red),
+                    icon: Icon(Icons.delete_outline, size: 18, color: Theme.of(context).colorScheme.error),
                     onPressed: () => widget.onConfirmDelete(l10n, systemPrompt, isSystem: true),
                   ),
                 ],

--- a/lib/screens/prompts/widgets/tag_management_list.dart
+++ b/lib/screens/prompts/widgets/tag_management_list.dart
@@ -10,12 +10,16 @@ class TagManagementList extends StatefulWidget {
   final Function(AppLocalizations, {PromptTag? tag}) onShowEditDialog;
   final Function(AppLocalizations, PromptTag tag) onConfirmDelete;
 
+  /// Number of prompts in each category, keyed by tag id.
+  final Map<int, int> promptCounts;
+
   const TagManagementList({
     super.key,
     required this.tags,
     required this.onRefresh,
     required this.onShowEditDialog,
     required this.onConfirmDelete,
+    this.promptCounts = const {},
   });
 
   @override
@@ -28,6 +32,7 @@ class _TagManagementListState extends State<TagManagementList> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+    final colorScheme = Theme.of(context).colorScheme;
     final tags = widget.tags;
 
     return ReorderableListView.builder(
@@ -45,26 +50,55 @@ class _TagManagementListState extends State<TagManagementList> {
       },
       itemBuilder: (context, index) {
         final tag = tags[index];
+        final color = Color(tag.color);
+        final count = widget.promptCounts[tag.id] ?? 0;
         return Card(
           key: ValueKey('tag_${tag.id}'),
+          elevation: 0,
+          color: colorScheme.surfaceContainerLow,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: colorScheme.outlineVariant.withAlpha(120)),
+          ),
+          margin: const EdgeInsets.only(bottom: 8),
           child: ListTile(
-            leading: ReorderableDragStartListener(
-              index: index,
-              child: CircleAvatar(
-                backgroundColor: Color(tag.color),
-                radius: 12,
-              ),
+            leading: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ReorderableDragStartListener(
+                  index: index,
+                  child: Icon(Icons.drag_indicator, color: colorScheme.outline, size: 20),
+                ),
+                const SizedBox(width: 8),
+                CircleAvatar(backgroundColor: color, radius: 12),
+              ],
             ),
             title: Text(tag.name),
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: color.withAlpha(24),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    '$count',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: color.withAlpha(230),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 4),
                 IconButton(
                   icon: const Icon(Icons.edit_outlined),
                   onPressed: () => widget.onShowEditDialog(l10n, tag: tag),
                 ),
                 IconButton(
-                  icon: const Icon(Icons.delete_outline),
+                  icon: Icon(Icons.delete_outline, color: colorScheme.error),
                   onPressed: () => widget.onConfirmDelete(l10n, tag),
                 ),
               ],

--- a/lib/screens/prompts/widgets/user_prompt_list.dart
+++ b/lib/screens/prompts/widgets/user_prompt_list.dart
@@ -51,16 +51,17 @@ class _UserPromptListState extends State<UserPromptList> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.notes, size: 64, color: Colors.grey[400]),
+            Icon(Icons.notes, size: 64, color: Theme.of(context).colorScheme.outlineVariant),
             const SizedBox(height: 16),
             Text(
               l10n.noPromptsSaved,
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold) 
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)
             ),
             const SizedBox(height: 8),
             Text(
               l10n.saveFavoritePrompts,
-              style: const TextStyle(color: Colors.grey)
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
             const SizedBox(height: 24),
             ElevatedButton.icon(
@@ -78,7 +79,12 @@ class _UserPromptListState extends State<UserPromptList> {
       itemCount: prompts.length,
       // ignore: deprecated_member_use
       onReorder: (oldIndex, newIndex) async {
-        if (widget.searchQuery.isNotEmpty || widget.selectedFilterTagIds.isNotEmpty) return;
+        if (widget.searchQuery.isNotEmpty || widget.selectedFilterTagIds.isNotEmpty) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(l10n.reorderDisabledWhileFiltered)),
+          );
+          return;
+        }
 
         setState(() {
           if (newIndex > oldIndex) newIndex -= 1;
@@ -154,7 +160,7 @@ class _UserPromptListState extends State<UserPromptList> {
                   onPressed: () => widget.onShowEditDialog(l10n, prompt: prompt), 
                 ),
                 IconButton(
-                  icon: const Icon(Icons.delete_outline, size: 18, color: Colors.red),
+                  icon: Icon(Icons.delete_outline, size: 18, color: Theme.of(context).colorScheme.error),
                   onPressed: () => widget.onConfirmDelete(l10n, prompt, isSystem: false),
                 ),
               ],

--- a/lib/widgets/prompt_card.dart
+++ b/lib/widgets/prompt_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
+import '../l10n/app_localizations.dart';
 import '../models/prompt.dart';
 
 class PromptCard extends StatelessWidget {
@@ -115,7 +116,7 @@ class PromptCard extends StatelessWidget {
 
             // Reordering actions
             if (onMoveToTop != null || onMoveToBottom != null)
-              _buildSortActions(colorScheme),
+              _buildSortActions(context, colorScheme),
 
             ...?actions,
           ],
@@ -124,7 +125,8 @@ class PromptCard extends StatelessWidget {
     );
   }
 
-  Widget _buildSortActions(ColorScheme colorScheme) {
+  Widget _buildSortActions(BuildContext context, ColorScheme colorScheme) {
+    final l10n = AppLocalizations.of(context)!;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -132,7 +134,7 @@ class PromptCard extends StatelessWidget {
           IconButton(
             icon: const Icon(Icons.vertical_align_top_rounded, size: 18),
             visualDensity: VisualDensity.compact,
-            tooltip: "Move to Top",
+            tooltip: l10n.moveToTop,
             onPressed: onMoveToTop,
             color: colorScheme.outline,
           ),
@@ -140,7 +142,7 @@ class PromptCard extends StatelessWidget {
           IconButton(
             icon: const Icon(Icons.vertical_align_bottom_rounded, size: 18),
             visualDensity: VisualDensity.compact,
-            tooltip: "Move to Bottom",
+            tooltip: l10n.moveToBottom,
             onPressed: onMoveToBottom,
             color: colorScheme.outline,
           ),


### PR DESCRIPTION
## Summary

Review-driven redesign of the **Prompt Library** module, focused on UI consistency, theming, and responsive layout. `flutter analyze` → **No issues found!**

## What changed

### 🔴 P0 — fixes / project-rule compliance
- **Localization**: every previously hard-coded English string is now localized (selection mode title, bulk action bar, bulk delete/categorize dialogs, category delete, card reorder tooltips, system-template empty hint, import failure). Adds **19 keys × 4 languages** (en/zh/zh_Hant/ja), via the standard `merge_l10n` + `gen-l10n` flow.
- **Bulk action FAB overflow**: the floating bulk-action bar is now responsive — icon-only buttons on narrow screens — preventing `RenderFlex overflowed` on small phones.
- **Destructive-action theming**: 9 raw `Colors.red`/`Colors.white` usages replaced with `colorScheme.error`/`onError` so delete affordances respect the theme and dark mode.

### 🟡 Responsive layout
- **Tablet sidebar merge**: tablets no longer render two parallel vertical bars. `NavigationRail` keeps tab switching; category filtering moves to a horizontal chip row atop the content. The dedicated tag sidebar is desktop-only (≥1000px).
- **Content width cap**: lists/cards are constrained to `maxWidth: 920` (top-aligned) so long prompts stay readable on ultra-wide screens.
- **Adaptive AppBar**: narrower search field + icon-only Add button on tablet to avoid crowding/overflow.
- Removed dead hard-coded `width` inside `PromptsSidebar`.

### 🟢 Friendliness
- Sidebar gains a persistent **"All"** entry and **per-category prompt counts**.
- Mobile/tablet filter row gains an **"All" chip** to clear filters in one tap (previously only possible by deselecting each chip).
- **Drag-reorder while filtering/searching** now shows a SnackBar instead of silently doing nothing.
- Empty states use theme colors instead of `Colors.grey`.
- Category management: explicit **drag handle** + per-category **count badge**.
- **Context-aware Add label** (New Prompt / New Template / Add Category).

### Filter semantics
- Multi-category filtering is now an explicit **Any / All** toggle (defaults to **Any**/OR), replacing the previous implicit AND behavior that was counter-intuitive.

## ⚠️ Behavior change to note
The category sidebar/filter is now limited to the **User Prompts** tab. Tag filtering never actually applied to System Templates (the system list ignored the selected tag ids), so showing it there was a no-op and confusing.

## Testing
- `flutter analyze` → No issues found.
- Suggested manual check: run `flutter run --release` and eyeball the Prompt Library at mobile (<600px), tablet (600–1000px), and desktop (≥1000px) widths.

## Files
4× source `.arb` + regenerated `app_*.arb`/`app_localizations*.dart`, `prompts_screen.dart`, `prompts_sidebar.dart`, `tag_management_list.dart`, `user_prompt_list.dart`, `system_template_list.dart`, `prompt_card.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)