### PR TITLE
ci: build releases from a manually selected branch

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1,10 +1,6 @@
 name: '🔨 Multi-Platform Build'
 
 on:
-  push:
-    tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
-      - 'v[0-9]*.[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 jobs:
@@ -111,11 +107,18 @@ jobs:
   release:
     name: Create GitHub Release
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Read Version from pubspec.yaml'
+        id: version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version:[[:space:]]*//' | cut -d '+' -f1)
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: 'Download All Artifacts'
         uses: actions/download-artifact@v4
         with:
@@ -125,6 +128,8 @@ jobs:
       - name: 'Create Release'
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           files: |
             artifacts/*.zip
             artifacts/*.tar.gz


### PR DESCRIPTION
## Summary
- Replace the tag-push trigger on the multi-platform build workflow with `workflow_dispatch` only — picking a branch in the Actions UI ("Use workflow from") now kicks off the build for that branch.
- The `release` job no longer gates on `refs/tags/v*`; it always runs after `build` succeeds, checks out the selected branch, reads the version from that branch's `pubspec.yaml` (stripping the `+build` suffix), and passes `vX.Y.Z` as `tag_name` to `softprops/action-gh-release`, which creates the tag/release automatically (or updates it if it already exists) and attaches all platform artifacts (`.zip`, `.tar.gz`, `.dmg`, `.apk`, `.exe`, `.msix`) exactly as before.

## Test plan
- [ ] Manually run "🔨 Multi-Platform Build" from the Actions tab, selecting a branch, and confirm a release/tag matching that branch's `pubspec.yaml` version is created with all artifacts attached.
- [ ] Re-run for the same version and confirm it updates the existing release/tag rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)