### PR TITLE
chore: ignore develop_src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 # additional
 /feature_plan/
+/develop_src/


### PR DESCRIPTION
`develop_src/` 存放的是 Prompt Assistant 知识库模式的本地知识库内容（16 个 markdown 文件）。它此前是 untracked 但**没有被 ignore**，所以任何一次 `git add -A` 都会把它们全部提交进去——本次开发中就实际踩到了一次。

按 `.gitignore` 里既有的 `/feature_plan/` 同样风格，加一条根锚定的 `/develop_src/`。

已验证：加之前 `git add -A` 会 stage 16 个文件；加之后只 stage `.gitignore`，`develop_src/` 完全不再出现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
