### PR TITLE
fix(assistant): stop the knowledge cache claiming content it lost

### DIFF
--- a/lib/services/prompt_optimizer_agent.dart
+++ b/lib/services/prompt_optimizer_agent.dart
@@ -126,10 +126,13 @@ class PromptOptimizerSession extends ChangeNotifier {
   /// True when the agent may propose knowledge-base edits.
   bool get canWriteKnowledge => mode == AssistantMode.knowledgeEdit;
 
-  /// Knowledge pages already returned to the model ('relPath#page'), so
-  /// repeated reads return a short "already in context" note instead of the
-  /// full content again.
-  final Set<String> readKnowledgePages = {};
+  /// [history] length at the moment each knowledge file was last written, so
+  /// reads recorded before the write stop counting as current.
+  ///
+  /// A plain "is stale" flag would be unsatisfiable: the read-before-write
+  /// rail would reject the very re-read that is supposed to clear it, and the
+  /// model could never edit the same file twice in one session.
+  final Map<String, int> knowledgeStaleAt = {};
 
   List<OptimizerChatEntry> _transcript = [];
   List<OptimizerChatEntry> get transcript => _transcript;
@@ -240,10 +243,10 @@ class PromptOptimizerSession extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Rebuilds a session (transcript, viewed images, staged prompt, knowledge
-  /// read cache) from persisted [history]. The transcript is derived rather
-  /// than stored: user/assistant text maps 1:1 and tool activity is recovered
-  /// from the assistant messages' tool calls.
+  /// Rebuilds a session (transcript, viewed images, staged prompt) from
+  /// persisted [history]. The transcript is derived rather than stored:
+  /// user/assistant text maps 1:1 and tool activity is recovered from the
+  /// assistant messages' tool calls.
   factory PromptOptimizerSession.fromStored({
     required String id,
     required AssistantMode mode,
@@ -263,7 +266,8 @@ class PromptOptimizerSession extends ChangeNotifier {
       entries.add(OptimizerChatEntry(kind: OptimizerEntryKind.notice, text: compactedNoticeText));
     }
     bool anyImageMissing = false;
-    for (final msg in history) {
+    for (int msgIndex = 0; msgIndex < history.length; msgIndex++) {
+      final msg = history[msgIndex];
       switch (msg.role) {
         case LLMRole.user:
           if (msg.content.startsWith(PromptOptimizerAgent.viewResultMarker)) {
@@ -305,12 +309,11 @@ class PromptOptimizerSession extends ChangeNotifier {
                   toolName: 'view_image',
                 ));
               case 'read_knowledge_file':
-                final path = call.arguments['path']?.toString() ?? '';
-                final page = call.arguments['page']?.toString() ?? '1';
-                session.readKnowledgePages.add('$path#${int.tryParse(page) ?? 1}');
+                // No cache to rebuild: whether a read is still readable is
+                // derived from the restored history by _liveReadPages.
                 entries.add(OptimizerChatEntry(
                   kind: OptimizerEntryKind.tool,
-                  text: path,
+                  text: call.arguments['path']?.toString() ?? '',
                   toolName: 'read_knowledge_file',
                 ));
               case 'write_knowledge_file':
@@ -320,9 +323,18 @@ class PromptOptimizerSession extends ChangeNotifier {
                 // happened), and oldContent was captured at staging time — so
                 // re-offering Apply after a restart could overwrite newer
                 // content against a stale preview.
+                final writtenPath = call.arguments['path']?.toString() ?? '';
+                // For the same reason the card is inert, we cannot know whether
+                // this edit was applied — so assume it was. Treating earlier
+                // reads of the file as current would let the model overwrite
+                // it while diffing against pre-edit content; the cost of being
+                // wrong is one redundant re-read.
+                if (writtenPath.isNotEmpty) {
+                  session.knowledgeStaleAt[writtenPath] = msgIndex;
+                }
                 entries.add(OptimizerChatEntry(
                   kind: OptimizerEntryKind.tool,
-                  text: call.arguments['path']?.toString() ?? '',
+                  text: writtenPath,
                   toolName: 'write_knowledge_file',
                 ));
               case 'list_knowledge_files':
@@ -733,6 +745,54 @@ class PromptOptimizerAgent {
     return 0;
   }
 
+  /// Pages of [relPath] whose content the model can still read in what will be
+  /// sent next.
+  ///
+  /// Derived from the live history rather than tracked in a set. A set has to
+  /// be told when its content disappears, and nothing told it: [_elide]
+  /// replaces a read's result with a stub and [_maybeCompact] folds it into a
+  /// summary that drops tool results outright, yet the key survived both — so
+  /// the model asking to re-read was answered "already in the conversation"
+  /// pointing at content that no longer existed, with no way to recover. The
+  /// question is only ever "is it still in context", which the history answers
+  /// directly.
+  ///
+  /// Scans tool *results*, not the assistant's tool *calls*: the assistant
+  /// message is appended to history before its calls execute, so matching on
+  /// calls would find the very read being executed and report it as cached.
+  /// Results also make failed reads (no `content` key) correctly not count.
+  static Set<int> _liveReadPages(PromptOptimizerSession session, String relPath) {
+    final history = session.history;
+    // Reads before the recent boundary are elided by _trimForSend; reads
+    // before the file was last written no longer describe what is on disk.
+    final boundary = _recentBoundary(history);
+    final staleAt = session.knowledgeStaleAt[relPath] ?? 0;
+    final from = boundary > staleAt ? boundary : staleAt;
+    final pages = <int>{};
+    for (int i = from; i < history.length; i++) {
+      final m = history[i];
+      if (m.role != LLMRole.tool || m.toolName != 'read_knowledge_file') continue;
+      final Object? decoded;
+      try {
+        decoded = jsonDecode(m.content);
+      } catch (_) {
+        continue;
+      }
+      if (decoded is! Map) continue;
+      if (decoded['path'] != relPath) continue;
+      // Errors and the "already in context" note carry no content, so they are
+      // not evidence the model has ever seen the file.
+      if (decoded['content'] == null) continue;
+      final page = decoded['page'];
+      if (page is int) pages.add(page);
+    }
+    return pages;
+  }
+
+  @visibleForTesting
+  static Set<int> liveReadPagesForTest(PromptOptimizerSession session, String relPath) =>
+      _liveReadPages(session, relPath);
+
   /// Layer-1 (lossless in DB, per-request) trimming: before the recent
   /// window, bulky knowledge-file tool results are elided and viewed-image
   /// attachments dropped. User/assistant text and submit_prompt results are
@@ -939,8 +999,7 @@ class PromptOptimizerAgent {
         final rawPage = call.arguments['page'];
         final page = rawPage is int ? rawPage : int.tryParse(rawPage?.toString() ?? '') ?? 1;
         onLog?.call('Tool call: read_knowledge_file $relPath (page $page)');
-        final cacheKey = '$relPath#$page';
-        if (session.readKnowledgePages.contains(cacheKey)) {
+        if (_liveReadPages(session, relPath).contains(page)) {
           return {
             'status': 'ok',
             'note': 'This page is already in the conversation — refer to the earlier result instead of re-reading it.',
@@ -948,7 +1007,6 @@ class PromptOptimizerAgent {
         }
         try {
           final result = KnowledgeBaseService().readFile(knowledgeRoot, relPath, page: page);
-          session.readKnowledgePages.add(cacheKey);
           session._addEntry(OptimizerChatEntry(
             kind: OptimizerEntryKind.tool,
             text: result.totalPages > 1 ? '$relPath (${result.page}/${result.totalPages})' : relPath,
@@ -996,9 +1054,11 @@ class PromptOptimizerAgent {
           final existing = kb.readFullFile(knowledgeRoot, writePath);
           // Read-before-write rail, enforced here rather than left to the
           // system prompt: overwriting a file the model has not read is the
-          // cheapest way for it to silently destroy the user's rules.
-          if (existing != null &&
-              !session.readKnowledgePages.any((k) => k.startsWith('$writePath#'))) {
+          // cheapest way for it to silently destroy the user's rules. Keyed on
+          // a *live* read, so a read that has since been elided or compacted
+          // away no longer licenses a write — the model must fetch the file
+          // again and diff against what it can actually see.
+          if (existing != null && _liveReadPages(session, writePath).isEmpty) {
             return {
               'status': 'error',
               'message': 'Read $writePath with read_knowledge_file first — you '
@@ -1139,11 +1199,12 @@ class PromptOptimizerAgent {
       final root = await KnowledgeBaseService().getRoot();
       if (root == null) throw KbPathException('The knowledge base folder is not configured.');
       await KnowledgeBaseService().writeFile(root, relPath, entry.newContent!);
-      // The file changed, so every cached page of it is now wrong — and page
-      // boundaries move on a rewrite, so partial eviction is meaningless.
-      // Without this the agent would be told "already in the conversation" and
-      // never see its own edit.
-      session.readKnowledgePages.removeWhere((k) => k.startsWith('$relPath#'));
+      // The file changed, so every read of it recorded so far describes content
+      // that no longer exists — and page boundaries move on a rewrite, so
+      // invalidating single pages would be meaningless. Marking the point in
+      // history rather than dropping a flag keeps the re-read that follows
+      // able to satisfy the read-before-write rail again.
+      session.knowledgeStaleAt[relPath] = session.history.length;
       session._resolveKbEdit(editId, KbEditState.applied);
     } catch (_) {
       session._resolveKbEdit(editId, KbEditState.failed);

--- a/test/knowledge_base_write_test.dart
+++ b/test/knowledge_base_write_test.dart
@@ -1,12 +1,43 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/services/knowledge_base_service.dart';
 import 'package:joycai_image_ai_toolkits/services/knowledge_base_starter.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
 import 'package:joycai_image_ai_toolkits/services/prompt_optimizer_agent.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// Appends the call/result pair the agent writes for one `read_knowledge_file`,
+/// so liveness derives from the same shape production builds.
+void recordRead(PromptOptimizerSession session, String path, int page,
+    {String? content}) {
+  final callId = 'call_${session.history.length}';
+  session.history.add(LLMMessage(
+    role: LLMRole.assistant,
+    content: '',
+    toolCalls: [
+      LLMToolCall(
+        id: callId,
+        name: 'read_knowledge_file',
+        arguments: {'path': path, 'page': page},
+      ),
+    ],
+  ));
+  session.history.add(LLMMessage(
+    role: LLMRole.tool,
+    content: jsonEncode({
+      'path': path,
+      'page': page,
+      'total_pages': 1,
+      'content': content ?? 'body of $path page $page',
+    }),
+    toolCallId: callId,
+    toolName: 'read_knowledge_file',
+  ));
+}
 
 void main() {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -296,13 +327,15 @@ void main() {
   });
 
   group('applyStagedKbEdit', () {
-    test('writes the staged content and evicts every cached page of that file', () async {
+    test('writes the staged content and stops earlier reads of that file counting', () async {
       await kb.setRoot(root.path);
       await kb.writeFile(root.path, 'a.md', 'old body');
 
       final session = PromptOptimizerSession(mode: AssistantMode.knowledgeEdit);
       // Pretend the agent read the file across two pages, plus an unrelated one.
-      session.readKnowledgePages.addAll({'a.md#1', 'a.md#2', 'b.md#1'});
+      recordRead(session, 'a.md', 1);
+      recordRead(session, 'a.md', 2);
+      recordRead(session, 'b.md', 1);
       final id = session.stageKbEditForTest(
         relPath: 'a.md',
         newContent: 'new body',
@@ -314,11 +347,29 @@ void main() {
       expect(kb.readFullFile(root.path, 'a.md'), 'new body');
       expect(session.transcript.firstWhere((e) => e.editId == id).editState,
           KbEditState.applied);
-      // A rewrite moves page boundaries, so every page of a.md must go or the
-      // agent would be told its own edit is "already in the conversation".
-      expect(session.readKnowledgePages, isNot(contains('a.md#1')));
-      expect(session.readKnowledgePages, isNot(contains('a.md#2')));
-      expect(session.readKnowledgePages, contains('b.md#1'));
+      // A rewrite moves page boundaries, so no page of a.md may still count or
+      // the agent would be told its own edit is "already in the conversation".
+      expect(PromptOptimizerAgent.liveReadPagesForTest(session, 'a.md'), isEmpty);
+      expect(PromptOptimizerAgent.liveReadPagesForTest(session, 'b.md'), {1});
+    });
+
+    test('a re-read after an applied edit counts again, so the file stays editable', () async {
+      await kb.setRoot(root.path);
+      await kb.writeFile(root.path, 'a.md', 'old body');
+
+      final session = PromptOptimizerSession(mode: AssistantMode.knowledgeEdit);
+      recordRead(session, 'a.md', 1);
+      final id = session.stageKbEditForTest(
+        relPath: 'a.md', newContent: 'new body', oldContent: 'old body');
+      await PromptOptimizerAgent.applyStagedKbEdit(session: session, editId: id);
+      expect(PromptOptimizerAgent.liveReadPagesForTest(session, 'a.md'), isEmpty);
+
+      // Marking the write's position in history rather than setting a sticky
+      // flag is what makes this recoverable: a flag would make the
+      // read-before-write rail reject the very re-read meant to clear it, and
+      // the model could never edit the same file twice in one session.
+      recordRead(session, 'a.md', 1, content: 'new body');
+      expect(PromptOptimizerAgent.liveReadPagesForTest(session, 'a.md'), {1});
     });
 
     test('creates a file that did not exist', () async {

--- a/test/optimizer_kb_edit_ui_test.dart
+++ b/test/optimizer_kb_edit_ui_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/l10n/app_localizations.dart';
@@ -78,9 +80,15 @@ void main() {
       expect(applied, id);
     });
 
-    test('rejecting flips the card without touching the read cache', () {
+    test('rejecting flips the card without invalidating earlier reads', () {
       final session = PromptOptimizerSession(mode: AssistantMode.knowledgeEdit);
-      session.readKnowledgePages.add('a.md#1');
+      session.history.add(LLMMessage(
+        role: LLMRole.tool,
+        content: jsonEncode(
+            {'path': 'a.md', 'page': 1, 'total_pages': 1, 'content': 'old'}),
+        toolCallId: 'c1',
+        toolName: 'read_knowledge_file',
+      ));
       final id = session.stageKbEditForTest(
         relPath: 'a.md',
         newContent: 'new',
@@ -91,8 +99,10 @@ void main() {
 
       final entry = session.transcript.firstWhere((e) => e.editId == id);
       expect(entry.editState, KbEditState.rejected);
-      // The file never changed, so a re-read would still be redundant.
-      expect(session.readKnowledgePages, contains('a.md#1'));
+      // Nothing reached disk, so the earlier read still describes the file and
+      // a re-read would be redundant.
+      expect(session.knowledgeStaleAt, isEmpty);
+      expect(PromptOptimizerAgent.liveReadPagesForTest(session, 'a.md'), {1});
     });
 
     test('rejecting twice is a no-op rather than an error', () {

--- a/test/optimizer_kb_liveness_test.dart
+++ b/test/optimizer_kb_liveness_test.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
+import 'package:joycai_image_ai_toolkits/services/prompt_optimizer_agent.dart';
+
+/// Whether the model can still *read* a knowledge page it was given earlier.
+///
+/// This used to be tracked in a `Set<String>` of `'path#page'` keys that nobody
+/// invalidated when the content it pointed at was removed. `_elide` swaps a
+/// read's result for a stub once it falls out of the recent window, and
+/// `_maybeCompact` folds it into a summary that drops tool results outright —
+/// but the key survived both, so the model asking to re-read was answered
+/// "already in the conversation — refer to the earlier result" pointing at
+/// content that no longer existed. It had no way to recover, and restarting the
+/// app fixed it (restore rebuilt the cache from the surviving rows), which is
+/// exactly why it was hard to reproduce.
+///
+/// Liveness is now derived from the history itself, so these pin the property
+/// directly: "does what the model will actually be sent still contain this?"
+void main() {
+  /// Appends the assistant call + tool result pair the agent writes for one
+  /// `read_knowledge_file`, matching production's shape.
+  void recordRead(PromptOptimizerSession session, String path, int page,
+      {String content = 'rule body'}) {
+    final callId = 'call_${session.history.length}';
+    session.history.add(LLMMessage(
+      role: LLMRole.assistant,
+      content: '',
+      toolCalls: [
+        LLMToolCall(
+          id: callId,
+          name: 'read_knowledge_file',
+          arguments: {'path': path, 'page': page},
+        ),
+      ],
+    ));
+    session.history.add(LLMMessage(
+      role: LLMRole.tool,
+      content: jsonEncode({
+        'path': path,
+        'page': page,
+        'total_pages': 1,
+        'content': content,
+      }),
+      toolCallId: callId,
+      toolName: 'read_knowledge_file',
+    ));
+  }
+
+  PromptOptimizerSession newSession() =>
+      PromptOptimizerSession(mode: AssistantMode.knowledgeBase);
+
+  Set<int> live(PromptOptimizerSession s, String path) =>
+      PromptOptimizerAgent.liveReadPagesForTest(s, path);
+
+  group('_liveReadPages', () {
+    test('a fresh read counts, and only for the page actually read', () {
+      final session = newSession();
+      session.addUserTurn('优化这个提示词');
+      recordRead(session, 'a.md', 2);
+
+      expect(live(session, 'a.md'), {2});
+      expect(live(session, 'b.md'), isEmpty);
+    });
+
+    test('a read whose result carries no content never counts', () {
+      final session = newSession();
+      session.addUserTurn('go');
+      // What a failed read leaves behind. Restore used to replay tool *calls*
+      // rather than results, resurrecting these as cache hits.
+      session.history.add(LLMMessage(
+        role: LLMRole.tool,
+        content: jsonEncode({'status': 'error', 'message': 'File not found: a.md'}),
+        toolCallId: 'c0',
+        toolName: 'read_knowledge_file',
+      ));
+
+      expect(live(session, 'a.md'), isEmpty);
+    });
+
+    test('the read being executed right now does not count as already read', () {
+      // The agent appends the assistant message *with its tool calls* to
+      // history before executing them, so anything matching on calls rather
+      // than results would find the in-flight read and answer "already in the
+      // conversation" for every single read.
+      final session = newSession();
+      session.addUserTurn('go');
+      session.history.add(LLMMessage(
+        role: LLMRole.assistant,
+        content: '',
+        toolCalls: [
+          LLMToolCall(
+            id: 'c0',
+            name: 'read_knowledge_file',
+            arguments: {'path': 'a.md', 'page': 1},
+          ),
+        ],
+      ));
+
+      expect(live(session, 'a.md'), isEmpty);
+    });
+
+    test('reads elided out of the recent window stop counting', () {
+      final session = newSession();
+      session.addUserTurn('turn 1');
+      recordRead(session, 'a.md', 1);
+      // _keepRecentTurns is 6; push the read well past it. This is the elide
+      // deadlock: the result the model is told to "refer to" has been replaced
+      // by a "Content elided to save context" stub.
+      for (int i = 2; i <= 8; i++) {
+        session.addUserTurn('turn $i');
+      }
+
+      expect(live(session, 'a.md'), isEmpty,
+          reason: 'the model can no longer see this read, so it must be allowed '
+              'to fetch the file again');
+    });
+
+    test('a read still inside the recent window keeps counting', () {
+      final session = newSession();
+      session.addUserTurn('turn 1');
+      recordRead(session, 'a.md', 1);
+      session.addUserTurn('turn 2');
+
+      expect(live(session, 'a.md'), {1});
+    });
+
+    test('reads folded away by compaction stop counting', () {
+      final session = newSession();
+      session.addUserTurn('turn 1');
+      recordRead(session, 'a.md', 1);
+
+      // What _maybeCompact leaves behind: the head is gone, replaced by a
+      // summary that deliberately drops raw tool results.
+      session.history
+        ..clear()
+        ..add(LLMMessage(
+          role: LLMRole.user,
+          content: '${PromptOptimizerAgent.summaryMarker}\nEarlier: read a.md.',
+        ));
+
+      expect(live(session, 'a.md'), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 问题

提示词助手的知识库去重缓存是一个 `Set<String>`,键为 `'path#page'`,但**没有任何人在它指向的内容被移除时通知它**:

- `_elide` 在读取滑出保留窗口后,把结果换成 `"Content elided to save context"` 占位符;
- `_maybeCompact` 把它折叠进摘要,而摘要**明确清掉原始工具结果**(`the summary needs decisions, not raw file contents`)。

两种情况下键都存活。于是模型请求重读 → 被告知 `"already in the conversation — refer to the earlier result"` → 而它指向的内容已经不存在了。**模型无法自救。**

重启 App 反而能修好(restore 从存活的行重建缓存),这正是它难以复现的原因。

## 改动

把"是否还在上下文里"**从历史派生**,而不是在旁边维护状态——这样就没有东西需要失效:

- 新增 `_liveReadPages(session, relPath)`:直接问"这次读取是否还在模型接下来真正会收到的内容里"。省略与压缩自动成立,无需任何驱逐逻辑。
- **扫描工具结果而非 assistant 的工具调用**:assistant 消息在其调用执行**之前**就被追加进 history(`:632-636` → `:648`),按调用匹配会命中正在执行的那次读取,导致**每一次读取都被报告为已缓存**。
- 返回错误的读取不带 `content`,因此正确地不计数——顺带修掉了 restore 重放**调用**而非**结果**、把失败读取复活成缓存命中的问题。

写入仍然需要状态(磁盘变化在 history 里看不见):`knowledgeStaleAt` 记录每个文件最后一次被写入时的 history 位置。**粘性的"已失效"标志会无解**——读后写护栏会拒绝那次本该用来清除它的重读,模型将永远无法在一个会话里编辑同一个文件两次。

护栏现在要求一次**存活的**读取,这是收紧:被省略或压缩掉的读取不再授权覆写。

## 测试

新增 `test/optimizer_kb_liveness_test.dart`,覆盖六个场景,其中三个是这个 bug 的直接复现:
- 省略出保留窗口后停止计数(死锁场景一)
- 被压缩折叠后停止计数(死锁场景二)
- **正在执行的读取不算已读**(会让每次读取都失效的陷阱)
- 无 content 的失败读取不计数
- 新鲜读取按页精确计数
- 保留窗口内的读取继续计数

改写了 `knowledge_base_write_test.dart` 与 `optimizer_kb_edit_ui_test.dart` 中直接写 Set 的用例,并新增"应用编辑后重读能恢复可编辑性"。

`flutter analyze` 无问题;全量 210 个测试通过。

## 验证说明

核心逻辑由单测直接覆盖(测试调用的是生产函数 `_liveReadPages`,通过 `@visibleForTesting` 访问器)。端到端复现需要一段长到触发压缩的真实对话 + 已配置的模型与知识库,单测精确复现了同样的历史形态。

🤖 Generated with [Claude Code](https://claude.com/claude-code)