### PR TITLE
docs(assistant): write down the context rules so they need not be re-derived

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ lib/
     task_queue_service.dart       # concurrency queue, Stream<TaskEvent>, ETA estimation
     prompt_optimizer_agent.dart   # Prompt Assistant agent: tool loop, modes (system prompt / knowledge base), session persistence + compaction
     knowledge_base_service.dart   # local knowledge-base folder access (README.md entry, paged reads)
+    llm/context_budget.dart       # sole interpreter of a model's context window (see architecture note below)
     web_scraper_service.dart      # HTML image extraction with cookie support
   screens/              # workbench · browser · batch · downloader · prompts · settings · metrics · models · wizard
   models/               # LLMModel, LLMChannel, PricingGroup, Prompt, PromptTag, AppImage, BrowserFile, LogEntry
@@ -40,6 +41,13 @@ lib/
 **Task types:** `imageProcess` · `imageDownload` · `promptRefine` · `aiRename` · `videoGenerate`  
 **LLM providers (registered in `main.dart`):** `google-genai` · `openai-api`  
 **Key dependencies:** see `pubspec.yaml` — `provider`, `sqflite`, `http`, `shelf`, `shelf_router`, `photo_view`, `extended_image`, `video_player`, `desktop_drop`, `file_picker`, `image`, `local_notifier`, `gal`
+
+## Architecture Notes
+
+Read the relevant note before changing that subsystem — each records invariants
+that fail silently when broken, and alternatives already tried and rejected.
+
+- **[Prompt Assistant context management](docs/architecture/assistant-context.md)** — elide/compact layers, the `context_window` tri-state, knowledge-read budgeting and paging. Required reading before touching `prompt_optimizer_agent.dart`, `context_budget.dart`, or `knowledge_base_service.dart`.
 
 ## Development Rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,15 +14,19 @@ Welcome to the documentation directory of the Joycai Image AI Toolkits project. 
 *   **[Google Veo Video cURL examples](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/api/veo.md)**: Examples for text-to-video, reference image matching, frame interpolation, and resolution settings.
 *   **[Gemini Image REST specification](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/api/google-api-standard.md)**: Detailed JSON-RPC response schemas, Base64 decoding guides, and safety interception behaviors.
 
-### 3. 🎨 Design & Implementation Notes
+### 3. 🏛️ Architecture Notes
+Living descriptions of how a subsystem works today — invariants, accepted limits, and rejected alternatives. Unlike the design notes below, these are maintained alongside the code rather than dated to a phase.
+*   **[Prompt Assistant context management](architecture/assistant-context.md)**: The elide/compact layers, the `context_window` tri-state, and how knowledge-base reads are budgeted and paged.
+
+### 4. 🎨 Design & Implementation Notes
 *   **[Workflow Efficiency (Phase 1)](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/design_notes/workflow-efficiency.md)**: Design notes on gallery context-menu shortcuts, unified search bar styling, and bulk prompt tags/deletion.
 *   **[Layout Polish (Phase 2)](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/design_notes/layout-polish.md)**: Notes on expanding the resizable workbench divider's hit box, hover animations, and smooth collapsible card transitions.
 *   **[Mobile Optimization (Phase 3)](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/design_notes/mobile-optimization.md)**: Adaptations for smaller screens, including mobile task queue sheets, click-to-pick slots, and quick concurrency controls.
 
-### 4. 🛡️ Quality & Audit Reports
+### 5. 🛡️ Quality & Audit Reports
 *   **[Code Review Report (June 13, 2026)](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/reports/code-review-report-20260613.md)**: An in-depth security, performance, and logic audit of the Dart codebase.
 
-### 5. 🏷️ Release Notes History
+### 6. 🏷️ Release Notes History
 *   **[v2.3.0 Release Notes (Latest)](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/release_notes/RELEASE_NOTES_v2.3.0.md)**
 *   **[v2.2.0 Release Notes](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/release_notes/RELEASE_NOTES_v2.2.0.md)**
 *   **[v2.1.1 Release Notes](file:///d:/github/Joycai-Image-Ai-Toolkits/docs/release_notes/RELEASE_NOTES_v2.1.1.md)**

--- a/docs/architecture/assistant-context.md
+++ b/docs/architecture/assistant-context.md
@@ -1,0 +1,136 @@
+# Prompt Assistant: context management
+
+How the Prompt Assistant decides what to send the model, when to summarize, and
+how much of a knowledge file it may read at once.
+
+This is the map and the rules. The reasoning for each individual constant and
+branch lives in the dartdoc next to it — that is deliberate, so it cannot drift
+away from the code it explains. What is written here is what the code *cannot*
+say locally: how the pieces fit, which invariants span more than one file, and
+which alternatives were tried and rejected (so they don't get "fixed" back in).
+
+## The shape
+
+Two layers and one gate. All three measure the same way, with
+`PromptOptimizerAgent.occupiedChars`.
+
+| | When it runs | Lossy? | Code |
+|---|---|---|---|
+| **Layer 1 — elide** | Before every request | No — the outgoing copy only; the DB keeps the original | `_trimForSend` / `_elide` |
+| **Layer 2 — compact** | Once per turn, *outside* the tool loop | Yes — history is really replaced by an LLM summary | `_maybeCompact` |
+| **Gate — read cap** | Before every `read_knowledge_file` call | n/a — it bounds what enters | `_readCapNow` → `ContextBudget.readCapChars` |
+
+Layer 1 protects the last `_keepRecentTurns` **user** turns and stubs out bulky
+knowledge reads before them. Layer 2 folds everything before that boundary into
+a summary. The gate is what keeps a single turn from overflowing on its own,
+because neither layer can help mid-loop (see *Accepted limits*).
+
+Per turn, in order: build the system prompt once → warn if it is oversized →
+persist → maybe compact → loop { trim, request, calibrate, execute tools }.
+
+## The window tri-state
+
+`llm_models.context_window` is one nullable int encoding three states.
+[`ContextBudget`](../../lib/services/llm/context_budget.dart) is the **only**
+place that decodes it — two unrelated consumers (this agent, and image batching
+in `web_scraper_service.dart`) must not drift on what `null` or `0` mean.
+
+| Stored | Means | Set by |
+|---|---|---|
+| `null` | unset — assume a conservative default | never picking the control |
+| `<= 0` | user asserts no practical limit | "unlimited" |
+| `> 0` | an explicit token count | the 9-notch preset slider |
+
+Use `ContextBudget.modeOf` / `.store` rather than comparing to `0` by hand.
+
+## Why characters, not tokens
+
+Budgets are computed in the character domain and converted with
+`ContextBudget.charsPerToken`. **The conversion is not a safety factor — a
+larger value is more permissive** (`budget = tokens × ratio × charsPerToken`).
+The pre-3.5 threshold implicitly assumed ~4 chars/token (an English figure);
+against a Chinese knowledge base that let the budget run several times past the
+real window, and requests failed before compaction ever fired.
+
+When the provider reports `usage`, `ContextBudget.calibrate` divides the chars
+actually sent by the tokens actually billed and the session switches to that
+measured ratio. When it doesn't, the conservative default stands.
+
+## Invariants
+
+Each of these is load-bearing, and breaking any of them fails *silently* —
+nothing throws, the numbers just quietly stop meaning what they claim.
+
+1. **`occupiedChars` includes the system prompt.** It is both the budget basis
+   and the divisor in `calibrate`, so it must measure the same request the
+   provider billed. It also counts attachments and tool-call argument JSON: a
+   content-only tally misses a staged `write_knowledge_file` body entirely and
+   over-grants the read budget by exactly that much.
+2. **The read cap is recomputed per tool call, never per turn.** One assistant
+   message routinely carries several `read_knowledge_file` calls. Computed once,
+   every call in the batch claims the same remaining window — an *n*-fold
+   overflow. Reading occupancy from `session.history` makes this fall out for
+   free: each result is appended before the next call runs.
+3. **Page size is determined by the file, not by the call.** Page numbers are
+   cache keys (see invariant 4), so the same page must always mean the same
+   bytes. A file that fits comes back whole as `1/1`; one that doesn't uses the
+   constant `KnowledgeBaseService.pageSize`. Making the page size track the
+   remaining window would make page 1 mean different things at different times.
+4. **"Already read?" is derived from history, never tracked in a set.** It scans
+   tool **results**, not the assistant's tool **calls** — the assistant message
+   is appended to history *before* its calls execute, so matching on calls finds
+   the read currently being executed and reports every read as a cache hit.
+   Results also make failed reads (no `content` key) correctly not count.
+5. **Compaction measures the trimmed history**, not the raw one, or layer 1 is
+   pointless.
+6. **The unlimited budget is a constant, not derived.** `0 × ratio == 0`, so a
+   derived ratio trigger would fire on every single turn.
+7. **An oversized system prompt warns, it does not throw.** The window is a
+   preset off a slider; a hard failure line would break setups that work today.
+
+## Accepted limits
+
+- **No mid-loop compaction, structurally.** `_maybeCompact` runs outside the
+  tool loop, `_recentBoundary` counts only user messages (so the current turn's
+  tool results are always inside the protected window), and `_maybeCompact`
+  early-returns at `boundary <= 1` anyway. **A single turn can pin the context at
+  `window − reserve` until it ends.** The read cap and dropping
+  `read_knowledge_file` from the tool list once exhausted are the only brakes.
+- **Compaction can never rescue the system prompt** — it only folds history. The
+  file map lives in the system prompt and is re-sent in full every request, so
+  past ~half the window the turn is doomed and the warning is the only signal.
+- `charsPerToken` is a heuristic, and the first request of a session has no
+  calibration yet. A very large single-shot read of pure CJK can still overflow.
+
+## Rejected, and why
+
+- **Reading token counts from provider metadata as the occupancy basis.**
+  `usage` is optional in the OpenAI-compatible response; llama.cpp, LM Studio
+  and various proxies omit it, which reads as *zero* occupancy — on exactly the
+  small local models that overflow first. It is used opportunistically for
+  calibration, never as the basis.
+- **Offset-based cache keys / range-containment checks.** Only needed if page
+  size were dynamic; invariant 3 removes the dynamism instead, at the cost of a
+  20K file paging as 3 pages rather than 2. No new correctness surface.
+- **A `Set` of read pages.** This was the pre-3.5 implementation and it
+  deadlocked: nothing invalidated the key when `_elide` or `_maybeCompact`
+  removed the content it pointed at, so the model was told "already in the
+  conversation — refer to the earlier result" about content that no longer
+  existed, with no way to recover. Restarting the app fixed it (restore rebuilt
+  the set from surviving rows), which is why it was hard to reproduce. Deriving
+  liveness means there is nothing to invalidate.
+
+## Tests
+
+Pure functions are pinned directly; prefer adding to these over end-to-end runs.
+
+| File | Covers |
+|---|---|
+| `test/context_budget_test.dart` | tri-state, ratio math, reserve scaling, `budgetChars < window` for every preset |
+| `test/optimizer_context_budget_test.dart` | `shouldCompact`, `occupiedChars`, per-call cap, exhaustion |
+| `test/optimizer_kb_liveness_test.dart` | the three deadlock scenarios (elided / compacted / in-flight) |
+| `test/knowledge_base_paging_test.dart` | boundary snapping, determinism, degenerate input |
+| `test/knowledge_base_read_cap_test.dart` | whole-file vs paged, undersized windows |
+
+**Not covered end-to-end:** the model dialog's tri-state control and the
+Settings summary-ratio dropdown have never been driven through a real UI run.


### PR DESCRIPTION
Records how the Prompt Assistant manages context, so it doesn't have to be re-derived from three files every time someone touches it.

Docs only — no code changes. `flutter analyze` clean.

## What's here

| File | |
|---|---|
| `docs/architecture/assistant-context.md` | new — the note |
| `CLAUDE.md` | new "Architecture Notes" section + `context_budget.dart` added to the project map |
| `docs/README.md` | new "Architecture Notes" category in the index |

## What it does and doesn't duplicate

The per-declaration reasoning stays in the dartdoc, where it can't drift from the code it explains. Constants are **not** copied in — that would become a lie the day someone changes `_keepRecentTurns`.

What the note adds is what the code can't say locally:

- **The map** — two layers (`_trimForSend` elide, `_maybeCompact` summarize) plus one gate (`_readCapNow`), all measured with `occupiedChars`, and the per-turn order they run in.
- **7 invariants**, each of which fails *silently* when broken. E.g. the read cap must be recomputed per tool call, not per turn — one assistant message routinely carries several `read_knowledge_file` calls, and computed once they each claim the same remaining window.
- **Accepted limits** — chiefly that mid-loop compaction is structurally impossible, so a single turn can pin the context at `window − reserve` until it ends. Worth recording as a known limit rather than leaving it to be rediscovered as a bug.
- **Rejected alternatives, with the reasons.** This is the highest-value part. Deriving read-liveness from history reads as a detour unless you know it replaced a `Set` that deadlocked (#46): nothing invalidated the key when elision or compaction removed the content, so the model was told "already in the conversation" about content that no longer existed, and only an app restart cleared it. Undocumented, the obvious "optimization" is to cache it again.

## Placement

Linked from `CLAUDE.md`, not just filed under `docs/` — CLAUDE.md is what actually gets loaded at the start of a session, so an unlinked note is one nobody opens.

Kept out of `docs/design_notes/`, which are dated snapshots of what a given phase changed. This is a living description of what's true now; the index states the distinction so the two genres don't merge.

## Verified

- Every test file and code symbol referenced in the note exists.
- Relative links resolve.
- Line endings are LF (`.gitattributes` from #48 holding).
- `flutter analyze` → `No issues found!`

The note also carries forward the one honest caveat from #47: the model dialog's tri-state control and the Settings ratio dropdown have never been driven end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)