### PR TITLE
fix: restore the DEBUG banner in debug builds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,6 @@ class MyApp extends StatelessWidget {
 
     return MaterialApp(
       onGenerateTitle: (context) => '${AppLocalizations.of(context)!.appTitle} v$version',
-      debugShowCheckedModeBanner: false,
       themeMode: themeMode,
       locale: locale,
       theme: buildAppTheme(


### PR DESCRIPTION
## What changed

Removed `debugShowCheckedModeBanner: false` from the main `MaterialApp` in `lib/main.dart`, restoring the framework default (`true`).

## Why

The red DEBUG banner no longer appeared in the top-right corner when running the app in debug mode, making it easy to mistake a debug build for a release build. The flag was explicitly disabling it.

## Notes for reviewers

- This is the only `debugShowCheckedModeBanner` usage in the repo, and the only app entry point (no secondary windows/apps affected).
- Release builds are unaffected — the banner never shows in release mode.
- `flutter analyze`: No issues found.
- Verify with `flutter run` (default debug mode): the DEBUG ribbon should appear top-right. On macOS, note the known Flutter 3.38+ debug-build crash documented in CLAUDE.md (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)