### PR TITLE
fix(gallery): refresh temp workspace after saving a crop

### DIFF
--- a/lib/state/gallery_state.dart
+++ b/lib/state/gallery_state.dart
@@ -416,16 +416,14 @@ class GalleryState extends ChangeNotifier {
   }
 
   void addDroppedFiles(List<AppImage> files) {
-    for (var file in files) {
-      if (!droppedImages.any((img) => img.path == file.path)) {
-        droppedImages.add(file);
-      }
-    }
+    final existingPaths = droppedImages.map((img) => img.path).toSet();
+    final newFiles = files.where((file) => !existingPaths.contains(file.path));
+    droppedImages = [...droppedImages, ...newFiles];
     notifyListeners();
   }
 
   void clearDroppedImages() {
-    droppedImages.clear();
+    droppedImages = [];
     _cleanupSelection();
     notifyListeners();
   }


### PR DESCRIPTION
## Summary
- Cropping an image and choosing "save to workspace" while viewing the Temporary Workspace (临时工作区) source didn't show the new image until switching to another source and back.
- Root cause: `GalleryState`'s grouped/sorted image cache (`getGrouped`/`getGlobalIndex`/`getSortedPaths`) is memoized by `List` object *identity*, not content. `addDroppedFiles()` and `clearDroppedImages()` mutated `droppedImages` in place (`.add()`/`.clear()`), so the list's identity never changed and the stale cache kept being served. Switching sources happened to force a rebuild because it pointed the cache at a different list first.
- Fix: `addDroppedFiles`/`clearDroppedImages` now reassign `droppedImages` to a new list instance instead of mutating in place, so the identity check correctly detects the change.

## Test plan
- [x] `flutter analyze lib/state/gallery_state.dart` — No issues found!
- [ ] Manual: switch to Temporary Workspace, crop an image, save to workspace, confirm it appears immediately without switching sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)