### PR TITLE
feat(llm): compress oversized reference images before sending

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -937,6 +937,8 @@
   },
   "useStreaming": "Use Streaming",
   "useStreamingDesc": "Real-time AI response (if supported)",
+  "compressReferenceImages": "Compress Reference Images",
+  "compressReferenceImagesDesc": "Re-encode images over 3MB to JPEG before sending, to reduce request size",
   "taskSubmitted": "Task submitted to queue",
   "comparator": "Comparator",
   "compareModeSync": "Sync Mode",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -797,6 +797,8 @@
   },
   "useStreaming": "ストリーミングを使用",
   "useStreamingDesc": "リアルタイム AI 応答（対応時）",
+  "compressReferenceImages": "参考画像を圧縮",
+  "compressReferenceImagesDesc": "送信前に3MBを超える画像をJPEGに再エンコードし、リクエストサイズを削減します",
   "taskSubmitted": "タスクがキューに送信されました",
   "comparator": "比較ツール",
   "compareModeSync": "同期モード",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3485,6 +3485,18 @@ abstract class AppLocalizations {
   /// **'Real-time AI response (if supported)'**
   String get useStreamingDesc;
 
+  /// No description provided for @compressReferenceImages.
+  ///
+  /// In en, this message translates to:
+  /// **'Compress Reference Images'**
+  String get compressReferenceImages;
+
+  /// No description provided for @compressReferenceImagesDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-encode images over 3MB to JPEG before sending, to reduce request size'**
+  String get compressReferenceImagesDesc;
+
   /// No description provided for @taskSubmitted.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1869,6 +1869,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get useStreamingDesc => 'Real-time AI response (if supported)';
 
   @override
+  String get compressReferenceImages => 'Compress Reference Images';
+
+  @override
+  String get compressReferenceImagesDesc =>
+      'Re-encode images over 3MB to JPEG before sending, to reduce request size';
+
+  @override
   String get taskSubmitted => 'Task submitted to queue';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1826,6 +1826,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get useStreamingDesc => 'リアルタイム AI 応答（対応時）';
 
   @override
+  String get compressReferenceImages => '参考画像を圧縮';
+
+  @override
+  String get compressReferenceImagesDesc =>
+      '送信前に3MBを超える画像をJPEGに再エンコードし、リクエストサイズを削減します';
+
+  @override
   String get taskSubmitted => 'タスクがキューに送信されました';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1813,6 +1813,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get useStreamingDesc => '实时 AI 响应（如果支持）';
 
   @override
+  String get compressReferenceImages => '压缩参考图';
+
+  @override
+  String get compressReferenceImagesDesc => '发送前将超过 3MB 的图片重新编码为 JPEG，以减小请求体积';
+
+  @override
   String get taskSubmitted => '任务已提交至队列';
 
   @override
@@ -4113,6 +4119,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get useStreamingDesc => '即時 AI 回應（若支援）';
+
+  @override
+  String get compressReferenceImages => '壓縮參考圖';
+
+  @override
+  String get compressReferenceImagesDesc => '傳送前將超過 3MB 的圖片重新編碼為 JPEG，以縮小請求體積';
 
   @override
   String get taskSubmitted => '任務已提交至佇列';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -923,6 +923,8 @@
   },
   "useStreaming": "使用流式传输",
   "useStreamingDesc": "实时 AI 响应（如果支持）",
+  "compressReferenceImages": "压缩参考图",
+  "compressReferenceImagesDesc": "发送前将超过 3MB 的图片重新编码为 JPEG，以减小请求体积",
   "taskSubmitted": "任务已提交至队列",
   "comparator": "对比器",
   "compareModeSync": "同步模式",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -797,6 +797,8 @@
   },
   "useStreaming": "使用串流",
   "useStreamingDesc": "即時 AI 回應（若支援）",
+  "compressReferenceImages": "壓縮參考圖",
+  "compressReferenceImagesDesc": "傳送前將超過 3MB 的圖片重新編碼為 JPEG，以縮小請求體積",
   "taskSubmitted": "任務已提交至佇列",
   "comparator": "比較器",
   "compareModeSync": "同步模式",

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -128,6 +128,8 @@
   },
   "useStreaming": "Use Streaming",
   "useStreamingDesc": "Real-time AI response (if supported)",
+  "compressReferenceImages": "Compress Reference Images",
+  "compressReferenceImagesDesc": "Re-encode images over 3MB to JPEG before sending, to reduce request size",
   "taskSubmitted": "Task submitted to queue",
   "comparator": "Comparator",
   "compareModeSync": "Sync Mode",

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -128,6 +128,8 @@
   },
   "useStreaming": "ストリーミングを使用",
   "useStreamingDesc": "リアルタイム AI 応答（対応時）",
+  "compressReferenceImages": "参考画像を圧縮",
+  "compressReferenceImagesDesc": "送信前に3MBを超える画像をJPEGに再エンコードし、リクエストサイズを削減します",
   "taskSubmitted": "タスクがキューに送信されました",
   "comparator": "比較ツール",
   "compareModeSync": "同期モード",

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -128,6 +128,8 @@
   },
   "useStreaming": "使用流式传输",
   "useStreamingDesc": "实时 AI 响应（如果支持）",
+  "compressReferenceImages": "压缩参考图",
+  "compressReferenceImagesDesc": "发送前将超过 3MB 的图片重新编码为 JPEG，以减小请求体积",
   "taskSubmitted": "任务已提交至队列",
   "comparator": "对比器",
   "compareModeSync": "同步模式",

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -128,6 +128,8 @@
   },
   "useStreaming": "使用串流",
   "useStreamingDesc": "即時 AI 回應（若支援）",
+  "compressReferenceImages": "壓縮參考圖",
+  "compressReferenceImagesDesc": "傳送前將超過 3MB 的圖片重新編碼為 JPEG，以縮小請求體積",
   "taskSubmitted": "任務已提交至佇列",
   "comparator": "比較器",
   "compareModeSync": "同步模式",

--- a/lib/screens/workbench/widgets/video_config_panel.dart
+++ b/lib/screens/workbench/widgets/video_config_panel.dart
@@ -142,6 +142,15 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
           onChanged: (v) => appState.updateVideoConfig(prompt: v),
           expand: false,
         ),
+        SwitchListTile(
+          title: Text(l10n.compressReferenceImages, style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold)),
+          subtitle: Text(l10n.compressReferenceImagesDesc, style: const TextStyle(fontSize: 11)),
+          value: appState.compressReferenceImages,
+          onChanged: (v) => appState.updateWorkbenchConfig(compressReferenceImages: v),
+          secondary: const Icon(Icons.compress, size: 20),
+          contentPadding: EdgeInsets.zero,
+          dense: true,
+        ),
 
         ConfigSectionHeader(l10n.frames),
         const SizedBox(height: 6),

--- a/lib/screens/workbench/workbench_config_panel.dart
+++ b/lib/screens/workbench/workbench_config_panel.dart
@@ -63,7 +63,13 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
     }
   }
 
-  void _updateConfig({int? modelDbId, String? modelIdStr, String? prompt, bool? useStream}) {
+  void _updateConfig({
+    int? modelDbId,
+    String? modelIdStr,
+    String? prompt,
+    bool? useStream,
+    bool? compressReferenceImages,
+  }) {
     final appState = Provider.of<AppState>(context, listen: false);
 
     String? idToSave;
@@ -75,6 +81,7 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
       modelId: idToSave ?? modelIdStr,
       prompt: prompt,
       useStream: useStream,
+      compressReferenceImages: compressReferenceImages,
     );
   }
 
@@ -87,6 +94,7 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
     final lastSelectedModelId = context.select<AppState, String?>((s) => s.lastSelectedModelId);
     final lastPrompt = context.select<AppState, String>((s) => s.lastPrompt);
     final useStream = context.select<AppState, bool>((s) => s.useStream);
+    final compressReferenceImages = context.select<AppState, bool>((s) => s.compressReferenceImages);
     final promptHistory = context.select<AppState, List<PromptHistoryEntry>>((s) => s.imagePromptHistory);
     // Rebuild parameter controls when the stored image params change.
     context.select<AppState, int>((s) => s.imageParamsRevision);
@@ -184,6 +192,15 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
               value: useStream,
               onChanged: (v) => _updateConfig(useStream: v),
               secondary: const Icon(Icons.stream, size: 20),
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+            ),
+            SwitchListTile(
+              title: Text(l10n.compressReferenceImages, style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold)),
+              subtitle: Text(l10n.compressReferenceImagesDesc, style: const TextStyle(fontSize: 11)),
+              value: compressReferenceImages,
+              onChanged: (v) => _updateConfig(compressReferenceImages: v),
+              secondary: const Icon(Icons.compress, size: 20),
               contentPadding: EdgeInsets.zero,
               dense: true,
             ),

--- a/lib/services/llm/image_compression.dart
+++ b/lib/services/llm/image_compression.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+import 'llm_types.dart';
+
+/// Re-encodes oversized images before they go out over the wire.
+///
+/// Two independent eligibility paths call into [compress]:
+///  * [readForApi] — automatic, for [LLMReferenceType.viewOnly] attachments.
+///    Those exist purely so a model can describe what it sees (Prompt
+///    Assistant's `view_image`), so lossy recompression is always safe.
+///  * Task executors (`task_executors.dart`) — opt-in, gated by the
+///    workbench "compress reference images" toggle. Every other reference
+///    type (`media`, `asset`, `firstFrame`, `lastFrame`) is actual
+///    image-generation/editing input, so the original bytes reach the API
+///    untouched *unless* the user explicitly accepted the fidelity
+///    trade-off for smaller requests.
+class ImageCompressor {
+  static const int maxBytes = 3 * 1024 * 1024;
+  static const int _jpegQuality = 85;
+
+  /// Recompresses [original] to JPEG when it exceeds [maxBytes]. Falls back
+  /// to the original bytes/mimeType when already small enough or when
+  /// decoding fails — recompression is a size optimization, not a
+  /// requirement, so a decode failure should still reach the model rather
+  /// than drop the attachment.
+  static ({Uint8List bytes, String mimeType}) compress(Uint8List original, String mimeType) {
+    if (original.length <= maxBytes) return (bytes: original, mimeType: mimeType);
+
+    final decoded = img.decodeImage(original);
+    if (decoded == null) return (bytes: original, mimeType: mimeType);
+
+    final jpg = img.encodeJpg(decoded, quality: _jpegQuality);
+    return (bytes: Uint8List.fromList(jpg), mimeType: 'image/jpeg');
+  }
+
+  /// Reads [attachment]'s bytes, compressing them when its referenceType is
+  /// [LLMReferenceType.viewOnly] — see the class doc for why other
+  /// reference types are excluded here.
+  static ({Uint8List bytes, String mimeType}) readForApi(LLMAttachment attachment) {
+    final raw = attachment.path != null
+        ? File(attachment.path!).readAsBytesSync()
+        : (attachment.bytes ?? Uint8List(0));
+
+    if (attachment.referenceType != LLMReferenceType.viewOnly) {
+      return (bytes: raw, mimeType: attachment.mimeType);
+    }
+    return compress(raw, attachment.mimeType);
+  }
+}

--- a/lib/services/llm/llm_types.dart
+++ b/lib/services/llm/llm_types.dart
@@ -6,7 +6,17 @@ import 'package:http/io_client.dart';
 
 enum LLMRole { system, user, assistant, tool }
 
-enum LLMReferenceType { media, asset, firstFrame, lastFrame }
+enum LLMReferenceType {
+  media,
+  asset,
+  firstFrame,
+  lastFrame,
+
+  /// The model only looks at this attachment to describe it in text — it is
+  /// never fed into image generation/editing. Eligible for lossy
+  /// recompression when oversized; see [ImageCompressor].
+  viewOnly,
+}
 
 class LLMAttachment {
   final String? path;

--- a/lib/services/llm/providers/google_payload.dart
+++ b/lib/services/llm/providers/google_payload.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../../../core/safety_settings.dart';
+import '../image_compression.dart';
 import '../llm_types.dart';
 
 /// Pure request-payload builders and response parsing for the Google GenAI
@@ -277,21 +278,14 @@ Map<String, dynamic> prepareGooglePayload(List<LLMMessage> history, Map<String, 
     }
 
     for (var attachment in msg.attachments) {
-      String? b64Data;
-      if (attachment.path != null) {
-        b64Data = base64Encode(File(attachment.path!).readAsBytesSync());
-      } else if (attachment.bytes != null) {
-        b64Data = base64Encode(attachment.bytes!);
-      }
-
-      if (b64Data != null) {
-        parts.add({
-          "inline_data": {
-            "mime_type": attachment.mimeType,
-            "data": b64Data
-          }
-        });
-      }
+      if (attachment.path == null && attachment.bytes == null) continue;
+      final resolved = ImageCompressor.readForApi(attachment);
+      parts.add({
+        "inline_data": {
+          "mime_type": resolved.mimeType,
+          "data": base64Encode(resolved.bytes)
+        }
+      });
     }
 
     return {

--- a/lib/services/llm/providers/openai_api_provider.dart
+++ b/lib/services/llm/providers/openai_api_provider.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import '../../../core/safety_settings.dart';
 import '../../../state/app_state.dart';
 import '../channel_dialect.dart';
+import '../image_compression.dart';
 import '../llm_debug_logger.dart';
 import '../llm_provider_interface.dart';
 import '../llm_types.dart';
@@ -1291,21 +1292,14 @@ class OpenAIAPIProvider implements ILLMProvider, IModelDiscoveryProvider {
           parts.add({"type": "text", "text": msg.content});
         }
         for (var attachment in msg.attachments) {
-          String? b64Data;
-          if (attachment.path != null) {
-            b64Data = base64Encode(File(attachment.path!).readAsBytesSync());
-          } else if (attachment.bytes != null) {
-            b64Data = base64Encode(attachment.bytes!);
-          }
-
-          if (b64Data != null) {
-            parts.add({
-              "type": "image_url",
-              "image_url": {
-                "url": "data:${attachment.mimeType};base64,$b64Data"
-              }
-            });
-          }
+          if (attachment.path == null && attachment.bytes == null) continue;
+          final resolved = ImageCompressor.readForApi(attachment);
+          parts.add({
+            "type": "image_url",
+            "image_url": {
+              "url": "data:${resolved.mimeType};base64,${base64Encode(resolved.bytes)}"
+            }
+          });
         }
         content = parts;
       }

--- a/lib/services/prompt_optimizer_agent.dart
+++ b/lib/services/prompt_optimizer_agent.dart
@@ -1161,7 +1161,11 @@ class PromptOptimizerAgent {
             role: LLMRole.user,
             content: '$viewResultMarker Reference image #${view['id']} (${view['name']}) is attached.',
             attachments: [
-              LLMAttachment.fromFile(File(view['path']!), _mimeTypeFor(view['path']!)),
+              LLMAttachment.fromFile(
+                File(view['path']!),
+                _mimeTypeFor(view['path']!),
+                referenceType: LLMReferenceType.viewOnly,
+              ),
             ],
           ));
         }

--- a/lib/services/task_executors.dart
+++ b/lib/services/task_executors.dart
@@ -23,13 +23,35 @@ extension TaskExecutors on TaskQueueService {
     return true;
   }
 
+  /// Builds a reference-image attachment, optionally pre-compressing it when
+  /// the user opted in via the workbench "compress reference images" toggle
+  /// (`task.parameters['compressReferenceImages']`). [referenceType] is
+  /// preserved either way so Veo instance placement (first/last frame vs
+  /// asset) keeps working on the compressed bytes.
+  LLMAttachment _buildReferenceAttachment(
+    TaskItem task,
+    String path, {
+    LLMReferenceType referenceType = LLMReferenceType.media,
+  }) {
+    final mimeType = _getMimeType(path);
+    if (task.parameters['compressReferenceImages'] != true) {
+      return LLMAttachment.fromFile(File(path), mimeType, referenceType: referenceType);
+    }
+    final raw = File(path).readAsBytesSync();
+    if (raw.length <= ImageCompressor.maxBytes) {
+      return LLMAttachment.fromFile(File(path), mimeType, referenceType: referenceType);
+    }
+    final compressed = ImageCompressor.compress(raw, mimeType);
+    return LLMAttachment.fromBytes(compressed.bytes, compressed.mimeType, referenceType: referenceType);
+  }
+
   Future<void> _executeImageProcessTask(TaskItem task) async {
     task.addLog('Start processing with model: ${task.modelDbId ?? task.modelId}');
 
     final outputDir = await _getEffectiveOutputDir(task);
 
     final attachments = task.imagePaths.map((path) =>
-      LLMAttachment.fromFile(File(path), _getMimeType(path))
+      _buildReferenceAttachment(task, path)
     ).toList();
 
     final messages = [
@@ -305,14 +327,14 @@ extension TaskExecutors on TaskQueueService {
     // First frame
     final firstFramePath = task.parameters['firstFramePath'] as String?;
     if (firstFramePath != null && firstFramePath.isNotEmpty) {
-      attachments.add(LLMAttachment.fromFile(File(firstFramePath), _getMimeType(firstFramePath), referenceType: LLMReferenceType.firstFrame));
+      attachments.add(_buildReferenceAttachment(task, firstFramePath, referenceType: LLMReferenceType.firstFrame));
       task.addLog('Added first frame: ${p.basename(firstFramePath)}');
     }
 
     // Last frame
     final lastFramePath = task.parameters['lastFramePath'] as String?;
     if (lastFramePath != null && lastFramePath.isNotEmpty) {
-      attachments.add(LLMAttachment.fromFile(File(lastFramePath), _getMimeType(lastFramePath), referenceType: LLMReferenceType.lastFrame));
+      attachments.add(_buildReferenceAttachment(task, lastFramePath, referenceType: LLMReferenceType.lastFrame));
       task.addLog('Added last frame: ${p.basename(lastFramePath)}');
     }
 
@@ -321,7 +343,7 @@ extension TaskExecutors on TaskQueueService {
     if (referenceImagePaths != null) {
       for (var path in referenceImagePaths) {
         final pathStr = path as String;
-        attachments.add(LLMAttachment.fromFile(File(pathStr), _getMimeType(pathStr), referenceType: LLMReferenceType.asset));
+        attachments.add(_buildReferenceAttachment(task, pathStr, referenceType: LLMReferenceType.asset));
         task.addLog('Added reference image: ${p.basename(pathStr)}');
       }
     }

--- a/lib/services/task_queue_service.dart
+++ b/lib/services/task_queue_service.dart
@@ -13,6 +13,7 @@ import '../models/task_item.dart';
 import 'ai_rename_agent.dart';
 import 'database_service.dart';
 import 'knowledge_base_service.dart';
+import 'llm/image_compression.dart';
 import 'llm/llm_service.dart';
 import 'llm/llm_types.dart';
 import 'prompt_optimizer_agent.dart';

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -159,6 +159,10 @@ class AppState extends ChangeNotifier {
   List<PromptHistoryEntry> imagePromptHistory = [];
   List<PromptHistoryEntry> videoPromptHistory = [];
   bool useStream = true;
+  // Opt-in: recompress oversized (>3MB) reference/source images to JPEG
+  // before sending, trading fidelity for smaller requests. Off by default so
+  // existing behavior (original bytes reach the API) doesn't change silently.
+  bool compressReferenceImages = false;
   bool isMarkdownWorkbench = true;
   bool isMarkdownRefinerSource = true;
   bool isMarkdownRefinerTarget = true;
@@ -345,6 +349,7 @@ class AppState extends ChangeNotifier {
     lastPrompt = await _db.getSetting('last_prompt') ?? "";
     lastVideoPrompt = await _db.getSetting('last_video_prompt') ?? "";
     useStream = (await _db.getSetting('workbench_use_stream') ?? 'true') == 'true';
+    compressReferenceImages = (await _db.getSetting('workbench_compress_reference_images') ?? 'false') == 'true';
 
     final savedWorkbenchTab = await _db.getSetting('workbench_tab_index');      
     if (savedWorkbenchTab != null) {

--- a/lib/state/app_state_workbench.dart
+++ b/lib/state/app_state_workbench.dart
@@ -26,6 +26,7 @@ extension AppStateWorkbench on AppState {
     String? modelId,
     String? prompt,
     bool? useStream,
+    bool? compressReferenceImages,
   }) async {
     if (modelId != null) {
       lastSelectedModelId = modelId;
@@ -38,6 +39,10 @@ extension AppStateWorkbench on AppState {
     if (useStream != null) {
       this.useStream = useStream;
       await _db.saveSetting('workbench_use_stream', useStream.toString());
+    }
+    if (compressReferenceImages != null) {
+      this.compressReferenceImages = compressReferenceImages;
+      await _db.saveSetting('workbench_compress_reference_images', compressReferenceImages.toString());
     }
     notify();
   }
@@ -182,6 +187,7 @@ extension AppStateWorkbench on AppState {
 
     params['imagePrefix'] = galleryState.imagePrefix;
     params['retryCount'] = retryCount;
+    params['compressReferenceImages'] = compressReferenceImages;
     // Gemini safety thresholds travel with the task so payload builders can
     // apply them per request (Map<String,String>, JSON-safe for persistence).
     params[SafetySettings.paramKey] = Map<String, String>.from(safetyThresholds);


### PR DESCRIPTION
## Summary

- Prompt Assistant's `view_image` attachments could hit ~15MB for large generated PNGs. Some OpenAI-compatible relays (e.g. Claude accessed via a third-party proxy) mangle these into malformed tool-call JSON, which silently drops the `path` argument and sends the agent into an infinite "let me fix the path" retry loop.
- Added `LLMReferenceType.viewOnly` + `ImageCompressor` (`lib/services/llm/image_compression.dart`): automatically recompresses attachments over 3MB to JPEG (quality 85) before they go out, but **only** for `viewOnly` attachments — ones the model merely looks at and describes (Prompt Assistant's `view_image`). Attachments that are actual generation/editing input (`media`, `asset`, `firstFrame`, `lastFrame`) are never touched automatically, since the original bytes ARE the request.
- Added an opt-in **"Compress Reference Images"** toggle to the Image and Video workbench panels (off by default), for users who explicitly want to trade some fidelity on real generation/editing inputs for smaller request bodies. Wired through `task.parameters['compressReferenceImages']` into `task_executors.dart`.
- 4-language l10n (en/zh/zh_Hant/ja) added via the standard `merge_l10n` + `gen-l10n` workflow.

## Why JPEG, not WebP

The `image` package used by this project only supports **lossless** WebP encoding, which doesn't reliably shrink oversized, noisy Gemini-generated PNGs below the target size. JPEG's lossy encoder does, and is universally supported by both providers.

## Test plan

- [x] `flutter analyze` — no issues
- [ ] Manual: `flutter run --release`, feed the Prompt Assistant an oversized (>3MB) reference image via `view_image`, confirm the request no longer stalls/loops
- [ ] Manual: toggle "Compress Reference Images" on in the Image panel, run an image-edit task with a >3MB reference image, confirm output still looks reasonable
- [ ] Manual: same toggle in the Video panel with an oversized first/last frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)