### PR TITLE
refactor(ui): move every dialog onto the shared AppDialog shell

### DIFF
--- a/lib/screens/batch/task_queue_screen.dart
+++ b/lib/screens/batch/task_queue_screen.dart
@@ -10,6 +10,8 @@ import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../services/task_queue_service.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 import '../../widgets/app_icon_button.dart';
 import '../../widgets/dialogs/task_log_dialog.dart';
 
@@ -339,13 +341,16 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
   }
 
   void _showConcurrencyDialog(BuildContext context, AppLocalizations l10n, AppState appState) {
+    // AppDialog is built directly rather than via AppDialog.show: the heading
+    // carries the live value, so the whole dialog has to sit inside the
+    // StatefulBuilder.
     showDialog(
       context: context,
       builder: (dialogContext) => StatefulBuilder(
         builder: (dialogContext, setDialogState) {
           final queue = Provider.of<AppState>(dialogContext).taskQueue;
-          return AlertDialog(
-            title: Text(l10n.concurrencyLimit(queue.concurrencyLimit)),
+          return AppDialog(
+            title: l10n.concurrencyLimit(queue.concurrencyLimit),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -363,9 +368,10 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
               ],
             ),
             actions: [
-              TextButton(
+              AppButton(
+                label: l10n.close,
+                variant: AppButtonVariant.text,
                 onPressed: () => Navigator.pop(dialogContext),
-                child: Text(l10n.close),
               ),
             ],
           );

--- a/lib/screens/browser/ai_rename_dialog.dart
+++ b/lib/screens/browser/ai_rename_dialog.dart
@@ -6,13 +6,14 @@ import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
-import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/prompt.dart';
 import '../../services/ai_rename_agent.dart';
 import '../../services/database_service.dart';
 import '../../services/task_queue_service.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 import '../../widgets/chat_model_selector.dart';
 
 class AiRenameDialog extends StatefulWidget {
@@ -96,43 +97,35 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
     
     if (!mounted) return;
 
-    final SystemPrompt? selected = await showDialog<SystemPrompt>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.selectRenameTemplate),
-        // A tight (fixed) width lets AlertDialog's IntrinsicWidth
-        // short-circuit instead of recursing into the ListView below —
-        // scrollables don't support intrinsic-dimension queries and the
-        // dialog silently fails to lay out (empty barrier) otherwise.
-        content: SizedBox(
-          width: 420,
-          child: templates.isEmpty
-            ? Padding(
-                padding: const EdgeInsets.symmetric(vertical: 24),
-                child: Center(child: Text(l10n.noPromptsSaved)),
-              )
-            : ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.of(context).size.height * 0.6,
-                ),
-                child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: templates.length,
-                  itemBuilder: (context, index) {
-                    final t = templates[index];
-                    return ListTile(
-                      title: Text(t.title, style: const TextStyle(fontWeight: FontWeight.bold)),
-                      subtitle: Text(t.content, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 12)),
-                      onTap: () => Navigator.pop(context, t),
-                    );
-                  },
-                ),
-              ),
+    final SystemPrompt? selected = await AppDialog.show<SystemPrompt>(
+      context,
+      title: l10n.selectRenameTemplate,
+      maxWidth: 420,
+      maxHeight: MediaQuery.of(context).size.height * 0.6,
+      content: templates.isEmpty
+        ? Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: Text(l10n.noPromptsSaved)),
+          )
+        : ListView.builder(
+            shrinkWrap: true,
+            itemCount: templates.length,
+            itemBuilder: (context, index) {
+              final t = templates[index];
+              return ListTile(
+                title: Text(t.title, style: const TextStyle(fontWeight: FontWeight.bold)),
+                subtitle: Text(t.content, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 12)),
+                onTap: () => Navigator.pop(context, t),
+              );
+            },
+          ),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
         ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-        ],
-      ),
+      ],
     );
 
     if (selected != null) {
@@ -321,147 +314,115 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
     // Safety check: ensure the selected PK actually exists in the current list of chat models
     final effectiveModelDbId = chatModels.any((m) => m.id == _selectedModelDbId) ? _selectedModelDbId : null;
 
-    return AlertDialog(
-      title: Row(
+    return AppDialog(
+      icon: Icons.auto_fix_high,
+      title: l10n.aiBatchRename,
+      subtitle: l10n.imagesSelected(fileCount),
+      maxWidth: 640,
+      maxHeight: MediaQuery.of(context).size.height * 0.8,
+      scrollable: true,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            padding: const EdgeInsets.all(10),
-            decoration: BoxDecoration(
-              color: colorScheme.primaryContainer,
+          ChatModelSelector(
+            selectedModelId: effectiveModelDbId,
+            label: l10n.model,
+            onChanged: (v) => setState(() => _selectedModelDbId = v),
+          ),
+          const SizedBox(height: 16),
+
+          // System template: the whole card opens the picker.
+          Text(l10n.rulesInstructions, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+          const SizedBox(height: 8),
+          Material(
+            color: colorScheme.surfaceContainerHighest.withAlpha(80),
+            borderRadius: BorderRadius.circular(12),
+            child: InkWell(
               borderRadius: BorderRadius.circular(12),
-            ),
-            child: Icon(Icons.auto_fix_high, size: 22, color: colorScheme.onPrimaryContainer),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(l10n.aiBatchRename, overflow: TextOverflow.ellipsis),
-                const SizedBox(height: 2),
-                Text(
-                  l10n.imagesSelected(fileCount),
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.normal,
-                    color: colorScheme.outline,
-                  ),
+              onTap: _showTemplatePicker,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                child: Row(
+                  children: [
+                    Icon(Icons.psychology_outlined, size: 22, color: colorScheme.primary),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            _selectedSystemPrompt?.title ?? l10n.noTemplateSelected,
+                            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          if (_selectedSystemPrompt != null) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              _selectedSystemPrompt!.content,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Icon(Icons.unfold_more, size: 18, color: colorScheme.outline),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
+          const SizedBox(height: 16),
+
+          TextField(
+            controller: _instructionController,
+            minLines: 2,
+            maxLines: 3,
+            decoration: InputDecoration(
+              labelText: l10n.additionalInstructions,
+              hintText: l10n.aiRenameInstructionsHint,
+              alignLabelWithHint: true,
+              border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+              fillColor: colorScheme.surface,
+              filled: true,
+            ),
+          ),
+          const SizedBox(height: 20),
+
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: _isProcessing ? null : _generateSuggestions,
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              icon: _isProcessing
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.bolt),
+              label: Text(l10n.generateSuggestions),
+            ),
+          ),
+          const SizedBox(height: 20),
+
+          _buildPreviewSection(colorScheme, l10n),
         ],
       ),
-      content: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxWidth: 640,
-          maxHeight: MediaQuery.of(context).size.height * 0.8,
-          minWidth: Responsive.isMobile(context) ? 0 : 560,
-        ),
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              ChatModelSelector(
-                selectedModelId: effectiveModelDbId,
-                label: l10n.model,
-                onChanged: (v) => setState(() => _selectedModelDbId = v),
-              ),
-              const SizedBox(height: 16),
-
-              // System template: the whole card opens the picker.
-              Text(l10n.rulesInstructions, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
-              const SizedBox(height: 8),
-              Material(
-                color: colorScheme.surfaceContainerHighest.withAlpha(80),
-                borderRadius: BorderRadius.circular(12),
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(12),
-                  onTap: _showTemplatePicker,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-                    child: Row(
-                      children: [
-                        Icon(Icons.psychology_outlined, size: 22, color: colorScheme.primary),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                _selectedSystemPrompt?.title ?? l10n.noTemplateSelected,
-                                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                              if (_selectedSystemPrompt != null) ...[
-                                const SizedBox(height: 2),
-                                Text(
-                                  _selectedSystemPrompt!.content,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(fontSize: 11, color: colorScheme.outline),
-                                ),
-                              ],
-                            ],
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Icon(Icons.unfold_more, size: 18, color: colorScheme.outline),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-
-              TextField(
-                controller: _instructionController,
-                minLines: 2,
-                maxLines: 3,
-                decoration: InputDecoration(
-                  labelText: l10n.additionalInstructions,
-                  hintText: l10n.aiRenameInstructionsHint,
-                  alignLabelWithHint: true,
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
-                  fillColor: colorScheme.surface,
-                  filled: true,
-                ),
-              ),
-              const SizedBox(height: 20),
-
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: _isProcessing ? null : _generateSuggestions,
-                  style: FilledButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                  ),
-                  icon: _isProcessing
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.bolt),
-                  label: Text(l10n.generateSuggestions),
-                ),
-              ),
-              const SizedBox(height: 20),
-
-              _buildPreviewSection(colorScheme, l10n),
-            ],
-          ),
-        ),
-      ),
       actions: [
-        TextButton(
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
           onPressed: () => Navigator.pop(context),
-          child: Text(l10n.cancel),
         ),
-        FilledButton(
+        AppButton(
+          label: l10n.applyRenames,
           onPressed: (_proposedRenames.isEmpty || _conflicts.isNotEmpty || _isProcessing) ? null : _applyRenames,
-          child: Text(l10n.applyRenames),
         ),
       ],
     );

--- a/lib/screens/browser/widgets/browser_filter_bar.dart
+++ b/lib/screens/browser/widgets/browser_filter_bar.dart
@@ -5,6 +5,7 @@ import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/browser_file.dart';
 import '../../../state/file_browser_state.dart';
+import '../../../widgets/dialogs/thumbnail_size_dialog.dart';
 
 /// Single control row under the header: category chips on the left,
 /// sort control and thumbnail-size slider on the right.
@@ -154,34 +155,10 @@ class BrowserFilterBar extends StatelessWidget {
   }
 
   void _showThumbnailSizeDialog(BuildContext context, AppLocalizations l10n) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.thumbnailSize),
-        content: StatefulBuilder(
-          builder: (context, setState) {
-            double val = state.thumbnailSize;
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Slider(
-                  value: val,
-                  min: 80,
-                  max: 400,
-                  onChanged: (v) {
-                    state.setThumbnailSize(v);
-                    setState(() => val = v);
-                  },
-                ),
-                Text("${val.toInt()}px"),
-              ],
-            );
-          },
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text("OK")),
-        ],
-      ),
+    showThumbnailSizeDialog(
+      context,
+      initialSize: state.thumbnailSize,
+      onChanged: state.setThumbnailSize,
     );
   }
 

--- a/lib/screens/downloader/widgets/downloader_toolbar.dart
+++ b/lib/screens/downloader/widgets/downloader_toolbar.dart
@@ -6,6 +6,8 @@ import '../../../l10n/app_localizations.dart';
 import '../../../state/app_state.dart';
 import '../../../state/downloader_state.dart';
 import '../../../widgets/api_key_field.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import '../../../widgets/app_icon_button.dart';
 import '../../../widgets/chat_model_selector.dart';
 
@@ -318,72 +320,63 @@ Future<void> showDownloaderAdvancedDialog(
   final l10n = AppLocalizations.of(context)!;
   final state = Provider.of<AppState>(context, listen: false).downloaderState;
 
-  return showDialog(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Row(
-        children: [
-          const Icon(Icons.tune, size: 20),
-          const SizedBox(width: 10),
-          Text(l10n.advancedOptions),
-        ],
-      ),
-      content: SizedBox(
-        width: 440,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: prefixController,
-              decoration: InputDecoration(
-                labelText: l10n.filenamePrefix,
-                isDense: true,
-                border: const OutlineInputBorder(),
-                prefixIcon: const Icon(Icons.drive_file_rename_outline, size: 20),
-              ),
-            ),
-            const SizedBox(height: 16),
-            ApiKeyField(
-              controller: cookieController,
-              label: l10n.cookiesHint,
-              maxLines: 3,
-              onChanged: (v) => state.setState(cookies: v),
-            ),
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                TextButton.icon(
-                  onPressed: () {
-                    Navigator.pop(context);
-                    onImportCookie();
-                  },
-                  icon: const Icon(Icons.upload_file, size: 16),
-                  label: Text(l10n.importCookieFile,
-                      style: const TextStyle(fontSize: 12)),
-                ),
-                if (state.cookieHistory.isNotEmpty)
-                  TextButton.icon(
-                    onPressed: () {
-                      Navigator.pop(context);
-                      _showCookieHistory(context, state, cookieController);
-                    },
-                    icon: const Icon(Icons.history, size: 16),
-                    label: Text(l10n.cookieHistory,
-                        style: const TextStyle(fontSize: 12)),
-                  ),
-              ],
-            ),
-          ],
+  return AppDialog.show<void>(
+    context,
+    icon: Icons.tune,
+    title: l10n.advancedOptions,
+    maxWidth: 440,
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextField(
+          controller: prefixController,
+          decoration: InputDecoration(
+            labelText: l10n.filenamePrefix,
+            isDense: true,
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.drive_file_rename_outline, size: 20),
+          ),
         ),
-      ),
-      actions: [
-        FilledButton(
-          onPressed: () => Navigator.pop(context),
-          child: Text(l10n.finish),
+        const SizedBox(height: 16),
+        ApiKeyField(
+          controller: cookieController,
+          label: l10n.cookiesHint,
+          maxLines: 3,
+          onChanged: (v) => state.setState(cookies: v),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            TextButton.icon(
+              onPressed: () {
+                Navigator.pop(context);
+                onImportCookie();
+              },
+              icon: const Icon(Icons.upload_file, size: 16),
+              label: Text(l10n.importCookieFile,
+                  style: const TextStyle(fontSize: 12)),
+            ),
+            if (state.cookieHistory.isNotEmpty)
+              TextButton.icon(
+                onPressed: () {
+                  Navigator.pop(context);
+                  _showCookieHistory(context, state, cookieController);
+                },
+                icon: const Icon(Icons.history, size: 16),
+                label: Text(l10n.cookieHistory,
+                    style: const TextStyle(fontSize: 12)),
+              ),
+          ],
         ),
       ],
     ),
+    actions: [
+      AppButton(
+        label: l10n.finish,
+        onPressed: () => Navigator.pop(context),
+      ),
+    ],
   );
 }
 

--- a/lib/screens/metrics/widgets/usage_list.dart
+++ b/lib/screens/metrics/widgets/usage_list.dart
@@ -3,6 +3,8 @@ import 'package:intl/intl.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../services/database_service.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import 'usage_stats.dart';
 import 'usage_summary.dart';
 
@@ -247,26 +249,28 @@ class UsageList extends StatelessWidget {
 
   void _confirmDeleteModelData(BuildContext context, String modelId) {
     final l10n = AppLocalizations.of(context)!;
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.clearDataForModel(modelId)),
-        content: Text(l10n.clearModelDataWarning(modelId)),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
-            onPressed: () async {
-              await DatabaseService().clearTokenUsage(modelId: modelId);
-              if (context.mounted) {
-                Navigator.pop(context);
-                onRefresh();
-              }
-            },
-            child: Text(l10n.clearModelData),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.clearDataForModel(modelId),
+      content: Text(l10n.clearModelDataWarning(modelId)),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.clearModelData,
+          variant: AppButtonVariant.destructive,
+          onPressed: () async {
+            await DatabaseService().clearTokenUsage(modelId: modelId);
+            if (context.mounted) {
+              Navigator.pop(context);
+              onRefresh();
+            }
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/metrics/widgets/usage_view_desktop.dart
+++ b/lib/screens/metrics/widgets/usage_view_desktop.dart
@@ -7,6 +7,8 @@ import 'package:provider/provider.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/database_service.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import '../../../widgets/app_icon_button.dart';
 import '../../../widgets/app_segmented_control.dart';
 import '../../../widgets/panel_resizer.dart';
@@ -241,29 +243,28 @@ class _UsageViewDesktopState extends State<UsageViewDesktop> {
 
   void _confirmClearAll() {
     final l10n = AppLocalizations.of(context)!;
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.clearAllUsage),
-        content: Text(l10n.clearUsageWarning),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(l10n.cancel),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
-            onPressed: () async {
-              await _db.clearTokenUsage();
-              if (context.mounted) {
-                Navigator.pop(context);
-                _loadData(reset: true);
-              }
-            },
-            child: Text(l10n.clearAll),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.clearAllUsage,
+      content: Text(l10n.clearUsageWarning),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.clearAll,
+          variant: AppButtonVariant.destructive,
+          onPressed: () async {
+            await _db.clearTokenUsage();
+            if (mounted) {
+              Navigator.pop(context);
+              _loadData(reset: true);
+            }
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/metrics/widgets/usage_view_mobile.dart
+++ b/lib/screens/metrics/widgets/usage_view_mobile.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/database_service.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import 'usage_list.dart';
 import 'usage_range.dart';
 import 'usage_stats.dart';
@@ -104,26 +106,28 @@ class _UsageViewMobileState extends State<UsageViewMobile> {
 
   void _confirmClearAll() {
     final l10n = AppLocalizations.of(context)!;
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.clearAllUsage),
-        content: Text(l10n.clearUsageWarning),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
-            onPressed: () async {
-              await _db.clearTokenUsage();
-              if (context.mounted) {
-                Navigator.pop(context);
-                _loadData(reset: true);
-              }
-            },
-            child: Text(l10n.clearAll),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.clearAllUsage,
+      content: Text(l10n.clearUsageWarning),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.clearAll,
+          variant: AppButtonVariant.destructive,
+          onPressed: () async {
+            await _db.clearTokenUsage();
+            if (mounted) {
+              Navigator.pop(context);
+              _loadData(reset: true);
+            }
+          },
+        ),
+      ],
     );
   }
 

--- a/lib/screens/models/models_screen.dart
+++ b/lib/screens/models/models_screen.dart
@@ -10,6 +10,8 @@ import '../../services/database_service.dart';
 import '../../services/llm/channel_dialect.dart';
 import '../../services/llm/llm_types.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 import '../../widgets/models/channel_edit_dialog.dart';
 import '../../widgets/models/channel_wizard_dialog.dart';
 import '../../widgets/models/discovery_dialog.dart';
@@ -611,23 +613,25 @@ class _ModelsScreenState extends State<ModelsScreen> {
   }
 
   void _confirmDeleteModel(AppLocalizations l10n, LLMModel model, AppState appState) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.deleteModelConfirmTitle),
-        content: Text(l10n.deleteModelConfirmMessage(model.modelName)),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
-            onPressed: () async {
-              await appState.deleteModel(model.id!);
-              if (context.mounted) Navigator.pop(context);
-            },
-            child: Text(l10n.delete),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.deleteModelConfirmTitle,
+      content: Text(l10n.deleteModelConfirmMessage(model.modelName)),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.delete,
+          variant: AppButtonVariant.destructive,
+          onPressed: () async {
+            await appState.deleteModel(model.id!);
+            if (mounted) Navigator.pop(context);
+          },
+        ),
+      ],
     );
   }
 
@@ -653,23 +657,25 @@ class _ModelsScreenState extends State<ModelsScreen> {
   }
 
   void _confirmDeleteChannel(AppLocalizations l10n, LLMChannel channel, AppState appState) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.delete),
-        content: Text(l10n.deleteChannelConfirm(channel.displayName)),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
-            onPressed: () async {
-              await appState.deleteChannel(channel.id!);
-              if (context.mounted) Navigator.pop(context);
-            },
-            child: Text(l10n.delete),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.delete,
+      content: Text(l10n.deleteChannelConfirm(channel.displayName)),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.delete,
+          variant: AppButtonVariant.destructive,
+          onPressed: () async {
+            await appState.deleteChannel(channel.id!);
+            if (mounted) Navigator.pop(context);
+          },
+        ),
+      ],
     );
   }
 

--- a/lib/screens/prompts/prompts_io.dart
+++ b/lib/screens/prompts/prompts_io.dart
@@ -9,6 +9,8 @@ import '../../l10n/app_localizations.dart';
 import '../../models/prompt.dart';
 import '../../models/tag.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 
 /// Import / export helpers for the Prompt Library.
 ///
@@ -69,30 +71,27 @@ Future<bool> importPrompts(BuildContext context, AppLocalizations l10n) async {
   FilePickerResult? result = await FilePicker.pickFiles(type: FileType.custom, allowedExtensions: ['json']);
   if (!context.mounted || result == null) return false;
 
-  final String? importMode = await showDialog<String>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Text(l10n.importMode),
-      content: Text(l10n.importModeDesc),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context, 'merge'),
-          child: Text(l10n.merge),
-        ),
-        FilledButton(
-          style: FilledButton.styleFrom(
-            backgroundColor: Theme.of(context).colorScheme.error,
-            foregroundColor: Theme.of(context).colorScheme.onError,
-          ),
-          onPressed: () => Navigator.pop(context, 'replace'),
-          child: Text(l10n.replaceAll),
-        ),
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: Text(l10n.cancel),
-        ),
-      ],
-    ),
+  final String? importMode = await AppDialog.show<String>(
+    context,
+    title: l10n.importMode,
+    content: Text(l10n.importModeDesc),
+    actions: [
+      AppButton(
+        label: l10n.merge,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context, 'merge'),
+      ),
+      AppButton(
+        label: l10n.replaceAll,
+        variant: AppButtonVariant.destructive,
+        onPressed: () => Navigator.pop(context, 'replace'),
+      ),
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context),
+      ),
+    ],
   );
 
   if (importMode == null) return false;

--- a/lib/screens/prompts/widgets/prompt_dialogs.dart
+++ b/lib/screens/prompts/widgets/prompt_dialogs.dart
@@ -8,6 +8,8 @@ import '../../../l10n/app_localizations.dart';
 import '../../../models/prompt.dart';
 import '../../../models/tag.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import '../../../widgets/color_picker_widget.dart';
 import '../../../widgets/markdown_editor.dart';
 
@@ -46,48 +48,47 @@ Future<bool> showPromptEditDialog(
   final saved = await showDialog<bool>(
     context: context,
     builder: (context) => StatefulBuilder(
-      builder: (context, setDialogState) => AlertDialog(
-        title: Row(
-          children: [
-            Icon(prompt == null ? Icons.add_circle_outline : Icons.edit_note, color: Colors.blue),
-            const SizedBox(width: 12),
-            Text(prompt == null ? l10n.newPrompt : l10n.editPrompt),
-          ],
-        ),
-        content: SizedBox(
-          width: math.min(MediaQuery.of(context).size.width * 0.9, 800),
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                TextField(
-                  controller: titleCtrl,
-                  decoration: InputDecoration(
-                    labelText: l10n.title,
-                    border: const OutlineInputBorder(),
-                    prefixIcon: const Icon(Icons.title),
-                  ),
+      builder: (context, setDialogState) => AppDialog(
+        icon: prompt == null ? Icons.add_circle_outline : Icons.edit_note,
+        iconColor: Colors.blue,
+        title: prompt == null ? l10n.newPrompt : l10n.editPrompt,
+        maxWidth: 800,
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: titleCtrl,
+                decoration: InputDecoration(
+                  labelText: l10n.title,
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.title),
                 ),
-                const SizedBox(height: 16),
-                Text(l10n.tagCategory, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
-                const SizedBox(height: 8),
-                _TagChips(tags: tags, selectedTagIds: selectedTagIds, setDialogState: setDialogState),
-                const SizedBox(height: 16),
-                MarkdownEditor(
-                  controller: contentCtrl,
-                  label: l10n.promptContent,
-                  isMarkdown: isMarkdown,
-                  onMarkdownChanged: (v) => setDialogState(() => isMarkdown = v),
-                  initiallyPreview: false,
-                ),
-              ],
-            ),
+              ),
+              const SizedBox(height: 16),
+              Text(l10n.tagCategory, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+              const SizedBox(height: 8),
+              _TagChips(tags: tags, selectedTagIds: selectedTagIds, setDialogState: setDialogState),
+              const SizedBox(height: 16),
+              MarkdownEditor(
+                controller: contentCtrl,
+                label: l10n.promptContent,
+                isMarkdown: isMarkdown,
+                onMarkdownChanged: (v) => setDialogState(() => isMarkdown = v),
+                initiallyPreview: false,
+              ),
+            ],
           ),
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          FilledButton(
+          AppButton(
+            label: l10n.cancel,
+            variant: AppButtonVariant.text,
+            onPressed: () => Navigator.pop(context),
+          ),
+          AppButton(
+            label: prompt == null ? l10n.save : l10n.update,
             onPressed: () async {
               if (titleCtrl.text.isEmpty || contentCtrl.text.isEmpty) return;
 
@@ -105,7 +106,6 @@ Future<bool> showPromptEditDialog(
               }
               if (context.mounted) Navigator.pop(context, true);
             },
-            child: Text(prompt == null ? l10n.save : l10n.update),
           ),
         ],
       ),
@@ -138,61 +138,60 @@ Future<bool> showSystemPromptEditDialog(
   final saved = await showDialog<bool>(
     context: context,
     builder: (context) => StatefulBuilder(
-      builder: (context, setDialogState) => AlertDialog(
-        title: Row(
-          children: [
-            Icon(selectedType == 'refiner' ? Icons.auto_fix_high : Icons.drive_file_rename_outline, color: Colors.purple),
-            const SizedBox(width: 12),
-            Text(prompt == null ? l10n.add : l10n.editPrompt),
-          ],
-        ),
-        content: SizedBox(
-          width: math.min(MediaQuery.of(context).size.width * 0.9, 800),
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Expanded(
-                      flex: 2,
-                      child: TextField(controller: titleCtrl, decoration: InputDecoration(labelText: l10n.title, border: const OutlineInputBorder())),
+      builder: (context, setDialogState) => AppDialog(
+        icon: selectedType == 'refiner' ? Icons.auto_fix_high : Icons.drive_file_rename_outline,
+        iconColor: Colors.purple,
+        title: prompt == null ? l10n.add : l10n.editPrompt,
+        maxWidth: 800,
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    flex: 2,
+                    child: TextField(controller: titleCtrl, decoration: InputDecoration(labelText: l10n.title, border: const OutlineInputBorder())),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    flex: 1,
+                    child: DropdownButtonFormField<String>(
+                      initialValue: selectedType,
+                      decoration: InputDecoration(labelText: l10n.templateType, border: const OutlineInputBorder()),
+                      items: [
+                        DropdownMenuItem(value: 'refiner', child: Text(l10n.typeRefiner)),
+                        DropdownMenuItem(value: 'rename', child: Text(l10n.typeRename)),
+                      ],
+                      onChanged: (v) => setDialogState(() => selectedType = v!),
                     ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      flex: 1,
-                      child: DropdownButtonFormField<String>(
-                        initialValue: selectedType,
-                        decoration: InputDecoration(labelText: l10n.templateType, border: const OutlineInputBorder()),
-                        items: [
-                          DropdownMenuItem(value: 'refiner', child: Text(l10n.typeRefiner)),
-                          DropdownMenuItem(value: 'rename', child: Text(l10n.typeRename)),
-                        ],
-                        onChanged: (v) => setDialogState(() => selectedType = v!),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                Text(l10n.tagCategory, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
-                const SizedBox(height: 8),
-                _TagChips(tags: tags, selectedTagIds: selectedTagIds, setDialogState: setDialogState),
-                const SizedBox(height: 16),
-                MarkdownEditor(
-                  controller: contentCtrl,
-                  label: l10n.promptContent,
-                  isMarkdown: isMarkdown,
-                  onMarkdownChanged: (v) => setDialogState(() => isMarkdown = v),
-                  initiallyPreview: false,
-                ),
-              ],
-            ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text(l10n.tagCategory, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+              const SizedBox(height: 8),
+              _TagChips(tags: tags, selectedTagIds: selectedTagIds, setDialogState: setDialogState),
+              const SizedBox(height: 16),
+              MarkdownEditor(
+                controller: contentCtrl,
+                label: l10n.promptContent,
+                isMarkdown: isMarkdown,
+                onMarkdownChanged: (v) => setDialogState(() => isMarkdown = v),
+                initiallyPreview: false,
+              ),
+            ],
           ),
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          FilledButton(
+          AppButton(
+            label: l10n.cancel,
+            variant: AppButtonVariant.text,
+            onPressed: () => Navigator.pop(context),
+          ),
+          AppButton(
+            label: l10n.save,
             onPressed: () async {
               if (titleCtrl.text.isEmpty || contentCtrl.text.isEmpty) return;
               final appState = Provider.of<AppState>(context, listen: false);
@@ -210,7 +209,6 @@ Future<bool> showSystemPromptEditDialog(
               }
               if (context.mounted) Navigator.pop(context, true);
             },
-            child: Text(l10n.save),
           ),
         ],
       ),
@@ -233,31 +231,34 @@ Future<bool> showTagEditDialog(
     context: context,
     builder: (context) => StatefulBuilder(
       builder: (context, setDialogState) {
-        return AlertDialog(
-          title: Text(tag == null ? l10n.addCategory : l10n.editCategory),
-          content: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400),
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(controller: nameCtrl, decoration: InputDecoration(labelText: l10n.name)),
-                  const SizedBox(height: 24),
-                  ColorPickerWidget(
-                    selectedColor: selectedColor,
-                    onColorChanged: (color) {
-                      setDialogState(() => selectedColor = color);
-                    },
-                    showHexInput: true,
-                    showColorWheel: true,
-                  ),
-                ],
-              ),
+        return AppDialog(
+          title: tag == null ? l10n.addCategory : l10n.editCategory,
+          maxWidth: 400,
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(controller: nameCtrl, decoration: InputDecoration(labelText: l10n.name)),
+                const SizedBox(height: 24),
+                ColorPickerWidget(
+                  selectedColor: selectedColor,
+                  onColorChanged: (color) {
+                    setDialogState(() => selectedColor = color);
+                  },
+                  showHexInput: true,
+                  showColorWheel: true,
+                ),
+              ],
             ),
           ),
           actions: [
-            TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-            ElevatedButton(
+            AppButton(
+              label: l10n.cancel,
+              variant: AppButtonVariant.text,
+              onPressed: () => Navigator.pop(context),
+            ),
+            AppButton(
+              label: l10n.save,
               onPressed: () async {
                 final appState = Provider.of<AppState>(context, listen: false);
                 final data = {
@@ -272,7 +273,6 @@ Future<bool> showTagEditDialog(
                 }
                 if (context.mounted) Navigator.pop(context, true);
               },
-              child: Text(l10n.save),
             ),
           ],
         );
@@ -289,32 +289,30 @@ Future<bool> showDeletePromptConfirm(
   dynamic prompt, {
   required bool isSystem,
 }) async {
-  final colorScheme = Theme.of(context).colorScheme;
-  final deleted = await showDialog<bool>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Text(l10n.deletePromptConfirmTitle),
-      content: Text(l10n.deletePromptConfirmMessage(prompt.title)),
-      actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-        FilledButton(
-          style: FilledButton.styleFrom(
-            backgroundColor: colorScheme.error,
-            foregroundColor: colorScheme.onError,
-          ),
-          onPressed: () async {
-            final appState = Provider.of<AppState>(context, listen: false);
-            if (isSystem) {
-              await appState.deleteSystemPrompt(prompt.id);
-            } else {
-              await appState.deletePrompt(prompt.id);
-            }
-            if (context.mounted) Navigator.pop(context, true);
-          },
-          child: Text(l10n.delete),
-        ),
-      ],
-    ),
+  final deleted = await AppDialog.show<bool>(
+    context,
+    title: l10n.deletePromptConfirmTitle,
+    content: Text(l10n.deletePromptConfirmMessage(prompt.title)),
+    actions: [
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context),
+      ),
+      AppButton(
+        label: l10n.delete,
+        variant: AppButtonVariant.destructive,
+        onPressed: () async {
+          final appState = Provider.of<AppState>(context, listen: false);
+          if (isSystem) {
+            await appState.deleteSystemPrompt(prompt.id);
+          } else {
+            await appState.deletePrompt(prompt.id);
+          }
+          if (context.mounted) Navigator.pop(context, true);
+        },
+      ),
+    ],
   );
   return deleted ?? false;
 }
@@ -325,28 +323,26 @@ Future<bool> showDeleteTagConfirm(
   AppLocalizations l10n,
   PromptTag tag,
 ) async {
-  final colorScheme = Theme.of(context).colorScheme;
-  final deleted = await showDialog<bool>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Text(l10n.delete),
-      content: Text(l10n.deleteCategoryConfirmMessage(tag.name)),
-      actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-        FilledButton(
-          style: FilledButton.styleFrom(
-            backgroundColor: colorScheme.error,
-            foregroundColor: colorScheme.onError,
-          ),
-          onPressed: () async {
-            final appState = Provider.of<AppState>(context, listen: false);
-            await appState.deletePromptTag(tag.id!);
-            if (context.mounted) Navigator.pop(context, true);
-          },
-          child: Text(l10n.delete),
-        ),
-      ],
-    ),
+  final deleted = await AppDialog.show<bool>(
+    context,
+    title: l10n.delete,
+    content: Text(l10n.deleteCategoryConfirmMessage(tag.name)),
+    actions: [
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context),
+      ),
+      AppButton(
+        label: l10n.delete,
+        variant: AppButtonVariant.destructive,
+        onPressed: () async {
+          final appState = Provider.of<AppState>(context, listen: false);
+          await appState.deletePromptTag(tag.id!);
+          if (context.mounted) Navigator.pop(context, true);
+        },
+      ),
+    ],
   );
   return deleted ?? false;
 }
@@ -357,24 +353,22 @@ Future<bool> showBulkDeleteConfirm(
   AppLocalizations l10n,
   int count,
 ) async {
-  final colorScheme = Theme.of(context).colorScheme;
-  final confirmed = await showDialog<bool>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Text(l10n.deleteNPromptsConfirm(count)),
-      content: Text(l10n.actionCannotBeUndone),
-      actions: [
-        TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
-        FilledButton(
-          style: FilledButton.styleFrom(
-            backgroundColor: colorScheme.error,
-            foregroundColor: colorScheme.onError,
-          ),
-          onPressed: () => Navigator.pop(context, true),
-          child: Text(l10n.delete),
-        ),
-      ],
-    ),
+  final confirmed = await AppDialog.show<bool>(
+    context,
+    title: l10n.deleteNPromptsConfirm(count),
+    content: Text(l10n.actionCannotBeUndone),
+    actions: [
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context, false),
+      ),
+      AppButton(
+        label: l10n.delete,
+        variant: AppButtonVariant.destructive,
+        onPressed: () => Navigator.pop(context, true),
+      ),
+    ],
   );
   return confirmed ?? false;
 }
@@ -390,8 +384,8 @@ Future<List<int>?> showBulkCategorizeDialog(
   final confirmed = await showDialog<bool>(
     context: context,
     builder: (context) => StatefulBuilder(
-      builder: (context, setDialogState) => AlertDialog(
-        title: Text(l10n.bulkCategorize),
+      builder: (context, setDialogState) => AppDialog(
+        title: l10n.bulkCategorize,
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -421,10 +415,14 @@ Future<List<int>?> showBulkCategorizeDialog(
           ],
         ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
-          FilledButton(
+          AppButton(
+            label: l10n.cancel,
+            variant: AppButtonVariant.text,
+            onPressed: () => Navigator.pop(context, false),
+          ),
+          AppButton(
+            label: l10n.apply,
             onPressed: () => Navigator.pop(context, true),
-            child: Text(l10n.apply),
           ),
         ],
       ),

--- a/lib/screens/settings/widgets/application_section.dart
+++ b/lib/screens/settings/widgets/application_section.dart
@@ -12,6 +12,8 @@ import '../../../services/knowledge_base_service.dart';
 import '../../../services/llm/llm_debug_logger.dart';
 import '../../../services/prompt_optimizer_agent.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import '../../../widgets/app_section.dart';
 
 class ApplicationSection extends StatefulWidget {
@@ -232,19 +234,17 @@ class _ApplicationSectionState extends State<ApplicationSection> {
   }
 
   void _showRestartDialog(AppLocalizations l10n) {
-    showDialog(
-      context: context,
+    AppDialog.show<void>(
+      context,
       barrierDismissible: false,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.restartRequired),
-        content: Text(l10n.restartMessage),
-        actions: [
-          FilledButton(
-            onPressed: () => exit(0),
-            child: Text(l10n.exit),
-          ),
-        ],
-      ),
+      title: l10n.restartRequired,
+      content: Text(l10n.restartMessage),
+      actions: [
+        AppButton(
+          label: l10n.exit,
+          onPressed: () => exit(0),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/settings/widgets/data_section.dart
+++ b/lib/screens/settings/widgets/data_section.dart
@@ -10,6 +10,8 @@ import '../../../core/file_utils.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/database_service.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import '../../../widgets/app_section.dart';
 import '../../wizard/setup_wizard.dart';
 
@@ -188,36 +190,36 @@ class DataSection extends StatelessWidget {
     bool p = true;
     bool u = false;
 
-    return await showDialog<bool>(
-      context: context,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) => AlertDialog(
-          title: Text(l10n.exportOptions),
-          content: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 450),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _buildExportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, (v) => setState(() => d = v)),
-                const SizedBox(height: 12),
-                _buildExportOption(l10n.includePrompts, l10n.includePromptsDesc, p, (v) => setState(() => p = v)),
-                const SizedBox(height: 12),
-                _buildExportOption(l10n.includeUsage, l10n.includeUsageDesc, u, (v) => setState(() => u = v)),
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
-            FilledButton(
-              onPressed: () {
-                onUpdate(d, p, u);
-                Navigator.pop(context, true);
-              },
-              child: Text(l10n.exportNow),
-            ),
+    return await AppDialog.show<bool>(
+      context,
+      title: l10n.exportOptions,
+      maxWidth: 450,
+      content: StatefulBuilder(
+        builder: (context, setState) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildExportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, (v) => setState(() => d = v)),
+            const SizedBox(height: 12),
+            _buildExportOption(l10n.includePrompts, l10n.includePromptsDesc, p, (v) => setState(() => p = v)),
+            const SizedBox(height: 12),
+            _buildExportOption(l10n.includeUsage, l10n.includeUsageDesc, u, (v) => setState(() => u = v)),
           ],
         ),
       ),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        AppButton(
+          label: l10n.exportNow,
+          onPressed: () {
+            onUpdate(d, p, u);
+            Navigator.pop(context, true);
+          },
+        ),
+      ],
     );
   }
 
@@ -360,39 +362,39 @@ class DataSection extends StatelessWidget {
     bool p = hasPrompts;
     bool u = hasUsage;
 
-    return await showDialog<bool>(
-      context: context,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) => AlertDialog(
-          title: Text(l10n.importOptions),
-          content: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 450),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
-                const SizedBox(height: 20),
-                _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
-                const SizedBox(height: 12),
-                _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
-                const SizedBox(height: 12),
-                _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
-            FilledButton(
-              onPressed: () {
-                onUpdate(d, p, u);
-                Navigator.pop(context, true);
-              },
-              style: FilledButton.styleFrom(backgroundColor: Colors.red, foregroundColor: Colors.white),
-              child: Text(l10n.importNow),
-            ),
+    return await AppDialog.show<bool>(
+      context,
+      title: l10n.importOptions,
+      maxWidth: 450,
+      content: StatefulBuilder(
+        builder: (context, setState) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+            const SizedBox(height: 20),
+            _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
+            const SizedBox(height: 12),
+            _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
+            const SizedBox(height: 12),
+            _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
           ],
         ),
       ),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        AppButton(
+          label: l10n.importNow,
+          variant: AppButtonVariant.destructive,
+          onPressed: () {
+            onUpdate(d, p, u);
+            Navigator.pop(context, true);
+          },
+        ),
+      ],
     );
   }
 
@@ -414,29 +416,31 @@ class DataSection extends StatelessWidget {
   }
 
   void _resetSettings(BuildContext context, AppLocalizations l10n) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.confirmReset),
-        content: Text(l10n.resetWarning),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
-            onPressed: () async {
-              final appState = Provider.of<AppState>(context, listen: false);
-              await DatabaseService().resetAllSettings();
-              if (!context.mounted) return;
-              Navigator.pop(context);
-              appState.addLog('All settings reset to default.');
-              await appState.loadSettings();
-              await appState.galleryState.reloadSettings();
-              await appState.fileBrowserState.reloadSettings();
-            },
-            child: Text(l10n.resetEverything, style: const TextStyle(color: Colors.white)),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.confirmReset,
+      content: Text(l10n.resetWarning),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.resetEverything,
+          variant: AppButtonVariant.destructive,
+          onPressed: () async {
+            final appState = Provider.of<AppState>(context, listen: false);
+            await DatabaseService().resetAllSettings();
+            if (!context.mounted) return;
+            Navigator.pop(context);
+            appState.addLog('All settings reset to default.');
+            await appState.loadSettings();
+            await appState.galleryState.reloadSettings();
+            await appState.fileBrowserState.reloadSettings();
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/wizard/setup_wizard.dart
+++ b/lib/screens/wizard/setup_wizard.dart
@@ -12,6 +12,8 @@ import '../../services/llm/llm_types.dart';
 import '../../services/llm/model_discovery_service.dart';
 import '../../state/app_state.dart';
 import '../../widgets/api_key_field.dart';
+import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 import '../../widgets/settings_widgets.dart';
 import 'wizard_import.dart';
 
@@ -456,24 +458,21 @@ class _SetupWizardState extends State<SetupWizard> {
       
       if (!mounted) return;
       
-      final selected = await showDialog<DiscoveredModel>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text(l10n.selectModelsToAdd),
-          content: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400, maxHeight: 400),
-            child: ListView.builder(
-              itemCount: models.length,
-              itemBuilder: (context, index) {
-                final m = models[index];
-                return ListTile(
-                  title: Text(m.displayName),
-                  subtitle: Text(m.modelId),
-                  onTap: () => Navigator.pop(context, m),
-                );
-              },
-            ),
-          ),
+      final selected = await AppDialog.show<DiscoveredModel>(
+        context,
+        title: l10n.selectModelsToAdd,
+        maxWidth: 400,
+        maxHeight: 400,
+        content: ListView.builder(
+          itemCount: models.length,
+          itemBuilder: (context, index) {
+            final m = models[index];
+            return ListTile(
+              title: Text(m.displayName),
+              subtitle: Text(m.modelId),
+              onTap: () => Navigator.pop(context, m),
+            );
+          },
         ),
       );
 
@@ -502,19 +501,17 @@ class _SetupWizardState extends State<SetupWizard> {
   }
 
   void _showRestartDialog(AppLocalizations l10n) {
-    showDialog(
-      context: context,
+    AppDialog.show<void>(
+      context,
       barrierDismissible: false,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.restartRequired),
-        content: Text(l10n.restartMessage),
-        actions: [
-          FilledButton(
-            onPressed: () => exit(0),
-            child: Text(l10n.exit),
-          ),
-        ],
-      ),
+      title: l10n.restartRequired,
+      content: Text(l10n.restartMessage),
+      actions: [
+        AppButton(
+          label: l10n.exit,
+          onPressed: () => exit(0),
+        ),
+      ],
     );
   }
 

--- a/lib/screens/wizard/wizard_import.dart
+++ b/lib/screens/wizard/wizard_import.dart
@@ -9,6 +9,8 @@ import '../../core/backup_error_text.dart';
 import '../../l10n/app_localizations.dart';
 import '../../services/database_service.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 
 /// Backup-import flow for the setup wizard.
 ///
@@ -138,39 +140,39 @@ Future<bool?> _showDesktopImportOptions(
   bool p = hasPrompts;
   bool u = hasUsage;
 
-  return await showDialog<bool>(
-    context: context,
-    builder: (context) => StatefulBuilder(
-      builder: (context, setState) => AlertDialog(
-        title: Text(l10n.importOptions),
-        content: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 450),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
-              const SizedBox(height: 20),
-              _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
-              const SizedBox(height: 12),
-              _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
-              const SizedBox(height: 12),
-              _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
-          FilledButton(
-            onPressed: () {
-              onUpdate(d, p, u);
-              Navigator.pop(context, true);
-            },
-            style: FilledButton.styleFrom(backgroundColor: Colors.red, foregroundColor: Colors.white),
-            child: Text(l10n.importNow),
-          ),
+  return await AppDialog.show<bool>(
+    context,
+    title: l10n.importOptions,
+    maxWidth: 450,
+    content: StatefulBuilder(
+      builder: (context, setState) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+          const SizedBox(height: 20),
+          _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
+          const SizedBox(height: 12),
+          _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
+          const SizedBox(height: 12),
+          _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
         ],
       ),
     ),
+    actions: [
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context, false),
+      ),
+      AppButton(
+        label: l10n.importNow,
+        variant: AppButtonVariant.destructive,
+        onPressed: () {
+          onUpdate(d, p, u);
+          Navigator.pop(context, true);
+        },
+      ),
+    ],
   );
 }
 

--- a/lib/screens/workbench/folder_list.dart
+++ b/lib/screens/workbench/folder_list.dart
@@ -8,6 +8,7 @@ import '../../l10n/app_localizations.dart';
 import '../../state/app_state.dart';
 import '../../state/gallery_state.dart';
 import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 import '../../widgets/app_icon_button.dart';
 import '../../widgets/panel_resizer.dart';
 import 'directory_tree_item.dart';
@@ -311,29 +312,29 @@ class FolderList extends StatelessWidget {
 
   void _confirmRemove(BuildContext context, AppState appState, String path, String folderName) {
     final l10n = AppLocalizations.of(context)!;
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.removeFolderConfirmTitle),
-        content: Text(l10n.removeFolderConfirmMessage(folderName)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(l10n.cancel),
-          ),
-          TextButton(
-            onPressed: () {
-              if (useFileBrowserState) {
-                appState.fileBrowserState.removeBaseDirectory(path);
-              } else {
-                appState.removeBaseDirectory(path);
-              }
-              Navigator.pop(context);
-            },
-            child: Text(l10n.remove, style: const TextStyle(color: Colors.red)),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.removeFolderConfirmTitle,
+      content: Text(l10n.removeFolderConfirmMessage(folderName)),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.remove,
+          variant: AppButtonVariant.destructive,
+          onPressed: () {
+            if (useFileBrowserState) {
+              appState.fileBrowserState.removeBaseDirectory(path);
+            } else {
+              appState.removeBaseDirectory(path);
+            }
+            Navigator.pop(context);
+          },
+        ),
+      ],
     );
   }
 

--- a/lib/screens/workbench/widgets/crop_resize_toolbar.dart
+++ b/lib/screens/workbench/widgets/crop_resize_toolbar.dart
@@ -12,6 +12,8 @@ import '../../../models/app_image.dart';
 import '../../../services/image_processing_service.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 
 class CropResizeToolbar extends StatefulWidget {
   const CropResizeToolbar({super.key});
@@ -126,20 +128,22 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
       final cancelLabel = l10n.cancel;
       final overwriteLabel = l10n.overwriteSource;
 
-      final confirmed = await showDialog<bool>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text(confirmTitle),
-          content: Text(confirmMessage),
-          actions: [
-            TextButton(onPressed: () => Navigator.pop(context, false), child: Text(cancelLabel)),
-            FilledButton(
-              onPressed: () => Navigator.pop(context, true),
-              style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
-              child: Text(overwriteLabel),
-            ),
-          ],
-        ),
+      final confirmed = await AppDialog.show<bool>(
+        context,
+        title: confirmTitle,
+        content: Text(confirmMessage),
+        actions: [
+          AppButton(
+            label: cancelLabel,
+            variant: AppButtonVariant.text,
+            onPressed: () => Navigator.pop(context, false),
+          ),
+          AppButton(
+            label: overwriteLabel,
+            variant: AppButtonVariant.destructive,
+            onPressed: () => Navigator.pop(context, true),
+          ),
+        ],
       );
       if (confirmed != true) return;
     }
@@ -595,39 +599,41 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
   }
 
   void _showMobileResizeDialog(BuildContext context, AppLocalizations l10n, WorkbenchUIState uiState) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.resize),
-        content: StatefulBuilder(
-          builder: (context, setDialogState) => Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Row(
-                children: [
-                  Expanded(child: _buildDimensionField(_widthController, l10n.width)),
-                  const Padding(padding: EdgeInsets.symmetric(horizontal: 8), child: Text("×")),
-                  Expanded(child: _buildDimensionField(_heightController, l10n.height)),
-                ],
-              ),
-              const SizedBox(height: 12),
-              SwitchListTile(
-                title: Text(l10n.maintainAspectRatio, style: const TextStyle(fontSize: 13)),
-                value: uiState.maintainAspectRatio,
-                onChanged: (v) {
-                  uiState.setMaintainAspectRatio(v);
-                  setDialogState(() {});
-                },
-                contentPadding: EdgeInsets.zero,
-                dense: true,
-              ),
-            ],
-          ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.resize,
+      content: StatefulBuilder(
+        builder: (context, setDialogState) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Expanded(child: _buildDimensionField(_widthController, l10n.width)),
+                const Padding(padding: EdgeInsets.symmetric(horizontal: 8), child: Text("×")),
+                Expanded(child: _buildDimensionField(_heightController, l10n.height)),
+              ],
+            ),
+            const SizedBox(height: 12),
+            SwitchListTile(
+              title: Text(l10n.maintainAspectRatio, style: const TextStyle(fontSize: 13)),
+              value: uiState.maintainAspectRatio,
+              onChanged: (v) {
+                uiState.setMaintainAspectRatio(v);
+                setDialogState(() {});
+              },
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+            ),
+          ],
         ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.close)),
-        ],
       ),
+      actions: [
+        AppButton(
+          label: l10n.close,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
     );
   }
 

--- a/lib/screens/workbench/widgets/gallery_file_actions.dart
+++ b/lib/screens/workbench/widgets/gallery_file_actions.dart
@@ -10,6 +10,8 @@ import '../../../core/constants.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/app_image.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 
 /// File-system side effects for gallery items (save / share / delete).
 ///
@@ -100,23 +102,22 @@ Future<void> confirmAndDeleteImageFile(
   final filename = imageFile.name;
   final isWindows = Platform.isWindows;
 
-  final confirmed = await showDialog<bool>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Text(l10n.deleteFileConfirmTitle),
-      content: Text(l10n.deleteFileConfirmMessage(filename)),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context, false),
-          child: Text(l10n.cancel),
-        ),
-        FilledButton(
-          style: FilledButton.styleFrom(backgroundColor: Colors.red),
-          onPressed: () => Navigator.pop(context, true),
-          child: Text(isWindows ? l10n.moveToTrash : l10n.permanentlyDelete),
-        ),
-      ],
-    ),
+  final confirmed = await AppDialog.show<bool>(
+    context,
+    title: l10n.deleteFileConfirmTitle,
+    content: Text(l10n.deleteFileConfirmMessage(filename)),
+    actions: [
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context, false),
+      ),
+      AppButton(
+        label: isWindows ? l10n.moveToTrash : l10n.permanentlyDelete,
+        variant: AppButtonVariant.destructive,
+        onPressed: () => Navigator.pop(context, true),
+      ),
+    ],
   );
 
   if (confirmed == true && context.mounted) {

--- a/lib/screens/workbench/widgets/gallery_toolbar.dart
+++ b/lib/screens/workbench/widgets/gallery_toolbar.dart
@@ -10,6 +10,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../models/app_image.dart';
 import '../../../state/app_state.dart';
 import '../../../state/gallery_state.dart';
+import '../../../widgets/dialogs/thumbnail_size_dialog.dart';
 
 class GalleryToolbar extends StatelessWidget {
   const GalleryToolbar({
@@ -490,34 +491,10 @@ class GalleryToolbar extends StatelessWidget {
   }
 
   void _showThumbnailSizeDialog(BuildContext context, GalleryState state, double current, AppLocalizations l10n) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.thumbnailSize),
-        content: StatefulBuilder(
-          builder: (context, setState) {
-            double val = current;
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Slider(
-                  value: val,
-                  min: 80,
-                  max: 400,
-                  onChanged: (v) {
-                    state.setThumbnailSize(v);
-                    setState(() => val = v);
-                  },
-                ),
-                Text("${val.toInt()}px"),
-              ],
-            );
-          },
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text("OK")),
-        ],
-      ),
+    showThumbnailSizeDialog(
+      context,
+      initialSize: current,
+      onChanged: state.setThumbnailSize,
     );
   }
 }

--- a/lib/screens/workbench/widgets/mask_editor_toolbar.dart
+++ b/lib/screens/workbench/widgets/mask_editor_toolbar.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 
 class MaskEditorToolbar extends StatelessWidget {
   final VoidCallback onUndo;
@@ -227,35 +229,39 @@ class MaskEditorToolbar extends StatelessWidget {
     Function(double) onChanged,
     String Function(double) displayConverter
   ) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(title),
-        content: StatefulBuilder(
-          builder: (context, setState) {
-            // Find current value in the slider range
-            double val = currentValue;
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Slider(
-                  value: val,
-                  min: min,
-                  max: max,
-                  onChanged: (newVal) {
-                    onChanged(newVal);
-                    setState(() => val = newVal);
-                  },
-                ),
-                Text(displayConverter(val)),
-              ],
-            );
-          },
+    // Outside the builder, so it survives the rebuilds the drag causes.
+    var val = currentValue;
+
+    AppDialog.show<void>(
+      context,
+      title: title,
+      content: StatefulBuilder(
+        builder: (context, setState) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Slider(
+              value: val,
+              min: min,
+              max: max,
+              onChanged: (newVal) {
+                onChanged(newVal);
+                setState(() => val = newVal);
+              },
+            ),
+            Text(displayConverter(val)),
+          ],
         ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text("OK")),
-        ],
       ),
+      actions: [
+        // Same wording the thumbnail-size dialog dismisses with: both are
+        // live-preview sliders where the change has already happened, so the
+        // button only closes.
+        AppButton(
+          label: AppLocalizations.of(context)!.confirm,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
     );
   }
 

--- a/lib/screens/workbench/widgets/queue_settings_dialog.dart
+++ b/lib/screens/workbench/widgets/queue_settings_dialog.dart
@@ -3,84 +3,85 @@ import 'package:provider/provider.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import 'safety_settings_section.dart';
 
 /// Queue/output settings dialog shared by the image and video workbenches:
 /// concurrency, retry count, filename prefix and Gemini safety thresholds.
 Future<void> showQueueSettingsDialog(BuildContext context) {
+  final l10n = AppLocalizations.of(context)!;
   final prefixController = TextEditingController(
     text: Provider.of<AppState>(context, listen: false).imagePrefix,
   );
 
-  return showDialog<void>(
-    context: context,
-    builder: (context) => StatefulBuilder(
+  return AppDialog.show<void>(
+    context,
+    title: l10n.queueSettings,
+    maxWidth: 340,
+    content: StatefulBuilder(
       builder: (context, setDialogState) {
         final appState = Provider.of<AppState>(context);
-        final l10n = AppLocalizations.of(context)!;
-        return AlertDialog(
-          title: Text(l10n.queueSettings),
-          content: SizedBox(
-            width: 340,
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(l10n.concurrencyLimit(appState.concurrencyLimit)),
-                  Slider(
-                    value: appState.concurrencyLimit.toDouble(),
-                    min: 1,
-                    max: 8,
-                    divisions: 7,
-                    onChanged: (v) {
-                      appState.setConcurrency(v.toInt());
-                      setDialogState(() {});
-                    },
-                  ),
-                  const SizedBox(height: 16),
-                  Text(l10n.retryCount(appState.retryCount)),
-                  Slider(
-                    value: appState.retryCount.toDouble(),
-                    min: 0,
-                    max: 5,
-                    divisions: 5,
-                    onChanged: (v) {
-                      appState.setRetryCount(v.toInt());
-                      setDialogState(() {});
-                    },
-                  ),
-                  const Divider(),
-                  const SizedBox(height: 8),
-                  Text(l10n.filenamePrefix,
-                      style: const TextStyle(
-                          fontWeight: FontWeight.bold, fontSize: 13)),
-                  const SizedBox(height: 8),
-                  TextField(
-                    controller: prefixController,
-                    decoration: InputDecoration(
-                      isDense: true,
-                      border: const OutlineInputBorder(),
-                      hintText: l10n.prefixHint,
-                    ),
-                    onChanged: (v) => appState.setImagePrefix(v),
-                  ),
-                  const SizedBox(height: 8),
-                  const Divider(),
-                  const SizedBox(height: 8),
-                  const SafetySettingsSection(),
-                ],
+        // The body keeps its own scroll view: the safety section makes it
+        // arbitrarily tall and there is no height worth naming as its ceiling.
+        return SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(l10n.concurrencyLimit(appState.concurrencyLimit)),
+              Slider(
+                value: appState.concurrencyLimit.toDouble(),
+                min: 1,
+                max: 8,
+                divisions: 7,
+                onChanged: (v) {
+                  appState.setConcurrency(v.toInt());
+                  setDialogState(() {});
+                },
               ),
-            ),
+              const SizedBox(height: 16),
+              Text(l10n.retryCount(appState.retryCount)),
+              Slider(
+                value: appState.retryCount.toDouble(),
+                min: 0,
+                max: 5,
+                divisions: 5,
+                onChanged: (v) {
+                  appState.setRetryCount(v.toInt());
+                  setDialogState(() {});
+                },
+              ),
+              const Divider(),
+              const SizedBox(height: 8),
+              Text(l10n.filenamePrefix,
+                  style: const TextStyle(
+                      fontWeight: FontWeight.bold, fontSize: 13)),
+              const SizedBox(height: 8),
+              TextField(
+                controller: prefixController,
+                decoration: InputDecoration(
+                  isDense: true,
+                  border: const OutlineInputBorder(),
+                  hintText: l10n.prefixHint,
+                ),
+                onChanged: (v) => appState.setImagePrefix(v),
+              ),
+              const SizedBox(height: 8),
+              const Divider(),
+              const SizedBox(height: 8),
+              const SafetySettingsSection(),
+            ],
           ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(l10n.close),
-            ),
-          ],
         );
       },
     ),
+    actions: [
+      AppButton(
+        label: l10n.close,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context),
+      ),
+    ],
   ).then((_) => prefixController.dispose());
 }

--- a/lib/screens/workbench/widgets/workbench_top_bar.dart
+++ b/lib/screens/workbench/widgets/workbench_top_bar.dart
@@ -7,6 +7,8 @@ import '../../../l10n/app_localizations.dart';
 import '../../../models/llm_channel.dart';
 import '../../../models/llm_model.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_dialog.dart';
 import '../../../widgets/app_tool_button.dart';
 import '../workbench_layout.dart';
 
@@ -217,13 +219,16 @@ class WorkbenchTopBar extends StatelessWidget {
   }
 
   void _showConcurrencyDialog(BuildContext context, AppLocalizations l10n) {
+    // AppDialog is built directly rather than via AppDialog.show: the heading
+    // carries the live value, so the whole dialog has to sit inside the
+    // StatefulBuilder.
     showDialog(
       context: context,
       builder: (dialogContext) => StatefulBuilder(
         builder: (dialogContext, setDialogState) {
           final appState = Provider.of<AppState>(dialogContext);
-          return AlertDialog(
-            title: Text(l10n.concurrencyLimit(appState.concurrencyLimit)),
+          return AppDialog(
+            title: l10n.concurrencyLimit(appState.concurrencyLimit),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -241,9 +246,10 @@ class WorkbenchTopBar extends StatelessWidget {
               ],
             ),
             actions: [
-              TextButton(
+              AppButton(
+                label: l10n.close,
+                variant: AppButtonVariant.text,
                 onPressed: () => Navigator.pop(dialogContext),
-                child: Text(l10n.close),
               ),
             ],
           );

--- a/lib/screens/workbench/workbench_screen.dart
+++ b/lib/screens/workbench/workbench_screen.dart
@@ -25,6 +25,8 @@ import '../../services/task_queue_service.dart';
 import '../../state/app_state.dart';
 import '../../state/gallery_state.dart';
 import '../../state/workbench_ui_state.dart';
+import '../../widgets/app_button.dart';
+import '../../widgets/app_dialog.dart';
 import '../../widgets/drawing_canvas.dart';
 import '../../widgets/unified_sidebar.dart';
 import 'gallery.dart';
@@ -355,19 +357,21 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
                       tooltip: l10n.rename,
                       onPressed: () async {
                         final ctrl = TextEditingController(text: meta.title ?? '');
-                        final newTitle = await showDialog<String>(
-                          context: sheetContext,
-                          builder: (dialogContext) => AlertDialog(
-                            title: Text(l10n.rename),
-                            content: TextField(controller: ctrl, autofocus: true),
-                            actions: [
-                              TextButton(onPressed: () => Navigator.pop(dialogContext), child: Text(l10n.cancel)),
-                              FilledButton(
-                                onPressed: () => Navigator.pop(dialogContext, ctrl.text.trim()),
-                                child: Text(l10n.confirm),
-                              ),
-                            ],
-                          ),
+                        final newTitle = await AppDialog.show<String>(
+                          sheetContext,
+                          title: l10n.rename,
+                          content: TextField(controller: ctrl, autofocus: true),
+                          actions: [
+                            AppButton(
+                              label: l10n.cancel,
+                              variant: AppButtonVariant.text,
+                              onPressed: () => Navigator.pop(sheetContext),
+                            ),
+                            AppButton(
+                              label: l10n.confirm,
+                              onPressed: () => Navigator.pop(sheetContext, ctrl.text.trim()),
+                            ),
+                          ],
                         );
                         if (newTitle != null && newTitle.isNotEmpty) {
                           await workbenchUIState.renameAssistantSession(meta.id, newTitle);
@@ -381,18 +385,20 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
                       icon: Icon(Icons.delete_outline, size: 18, color: colorScheme.error),
                       tooltip: l10n.delete,
                       onPressed: () async {
-                        final confirmed = await showDialog<bool>(
-                          context: sheetContext,
-                          builder: (dialogContext) => AlertDialog(
-                            content: Text(l10n.optDeleteSessionConfirm),
-                            actions: [
-                              TextButton(onPressed: () => Navigator.pop(dialogContext, false), child: Text(l10n.cancel)),
-                              FilledButton(
-                                onPressed: () => Navigator.pop(dialogContext, true),
-                                child: Text(l10n.delete),
-                              ),
-                            ],
-                          ),
+                        final confirmed = await AppDialog.show<bool>(
+                          sheetContext,
+                          content: Text(l10n.optDeleteSessionConfirm),
+                          actions: [
+                            AppButton(
+                              label: l10n.cancel,
+                              variant: AppButtonVariant.text,
+                              onPressed: () => Navigator.pop(sheetContext, false),
+                            ),
+                            AppButton(
+                              label: l10n.delete,
+                              onPressed: () => Navigator.pop(sheetContext, true),
+                            ),
+                          ],
                         );
                         if (confirmed == true) {
                           await workbenchUIState.deleteAssistantSession(meta.id);
@@ -423,15 +429,17 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     if (session.mode == next) return;
     if (session.transcript.isNotEmpty) {
       final l10n = AppLocalizations.of(context)!;
-      final confirmed = await showDialog<bool>(
-        context: context,
-        builder: (context) => AlertDialog(
-          content: Text(l10n.optModeSwitchConfirm),
-          actions: [
-            TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
-            FilledButton(onPressed: () => Navigator.pop(context, true), child: Text(l10n.confirm)),
-          ],
-        ),
+      final confirmed = await AppDialog.show<bool>(
+        context,
+        content: Text(l10n.optModeSwitchConfirm),
+        actions: [
+          AppButton(
+            label: l10n.cancel,
+            variant: AppButtonVariant.text,
+            onPressed: () => Navigator.pop(context, false),
+          ),
+          AppButton(label: l10n.confirm, onPressed: () => Navigator.pop(context, true)),
+        ],
       );
       if (confirmed != true) return;
     }
@@ -470,15 +478,17 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     }
 
     if (!mounted) return;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        content: Text(l10n.kbScaffoldConfirm(root)),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
-          FilledButton(onPressed: () => Navigator.pop(context, true), child: Text(l10n.confirm)),
-        ],
-      ),
+    final confirmed = await AppDialog.show<bool>(
+      context,
+      content: Text(l10n.kbScaffoldConfirm(root)),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        AppButton(label: l10n.confirm, onPressed: () => Navigator.pop(context, true)),
+      ],
     );
     if (confirmed != true) return;
 

--- a/lib/widgets/app_dialog.dart
+++ b/lib/widgets/app_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../core/responsive.dart';
+
 /// Corner radius shared by every dialog.
 ///
 /// The same 12 the inset panels use ([PanelCard], [AppCard],
@@ -18,6 +20,13 @@ const double appDialogRadius = 12;
 /// dialog whose body owns its own layout, construct [AppDialog] directly
 /// inside your own `showDialog`/`showGeneralDialog` call: the chrome still
 /// applies and nothing about the shape is assumed.
+///
+/// Note on popping: [actions] are built with the *caller's* context, not a
+/// builder-scoped one, so `Navigator.pop(context, value)` inside an action
+/// resolves to the nearest enclosing [Navigator] and pops its topmost route —
+/// this dialog. That holds because the app has a single navigator; introduce a
+/// nested one and an action inside a bottom sheet would start closing the
+/// sheet instead of the dialog.
 ///
 /// Two things callers reach for that this deliberately does not provide:
 ///
@@ -171,6 +180,14 @@ class AppDialog extends StatelessWidget {
       // Material's own stock white/near-black sheet.
       backgroundColor: colorScheme.surfaceContainer,
       clipBehavior: clipBehavior,
+      // Material's 40px side inset costs a phone a fifth of its width; on a
+      // 390pt screen a form dialog ends up 310pt wide with its fields
+      // squeezed. Handled here rather than per call site, because every
+      // dialog in the app has the same problem.
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: Responsive.isMobile(context) ? 12 : 40,
+        vertical: 24,
+      ),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(appDialogRadius)),
       child: ConstrainedBox(
         constraints: BoxConstraints(

--- a/lib/widgets/app_dialog.dart
+++ b/lib/widgets/app_dialog.dart
@@ -1,92 +1,251 @@
 import 'package:flutter/material.dart';
 
-/// The app's dialog chrome: rounded [Dialog] surface, title in
-/// [TextTheme.titleLarge], right-aligned action row.
+/// Corner radius shared by every dialog.
 ///
-/// Every dialog in `lib/widgets/dialogs/` and `lib/widgets/models/` currently
-/// hand-builds this — its own padding, its own corner radius, its own title
-/// [TextStyle] — so no two dialogs in the app match exactly. This is the
-/// shared shell they should build on instead.
+/// The same 12 the inset panels use ([PanelCard], [AppCard],
+/// [AppSegmentedControl]). Dialogs used to be hand-rolled at 24 and Material's
+/// own default is 28, but one radius across the app was the call: a dialog is
+/// another surface in the same system, not a visitor from another one.
+const double appDialogRadius = 12;
+
+/// The app's dialog chrome: rounded surface, title in [TextTheme.titleLarge],
+/// right-aligned action row.
+///
+/// Every dialog used to hand-build this — its own padding, corner radius and
+/// title style — so no two matched. This is the shared shell they build on.
 ///
 /// Use [AppDialog.show] for the common title/content/actions shape. For a
-/// dialog that needs full control over its body (a full-screen editor
-/// pop-out, for instance) construct [AppDialog] directly inside your own
-/// `showDialog`/`showGeneralDialog` call and pass whatever `content` you
-/// need — the chrome still applies, but nothing about the shape is assumed.
+/// dialog whose body owns its own layout, construct [AppDialog] directly
+/// inside your own `showDialog`/`showGeneralDialog` call: the chrome still
+/// applies and nothing about the shape is assumed.
+///
+/// Two things callers reach for that this deliberately does not provide:
+///
+/// * **A `builder`.** Dialogs with live internal state wrap their own
+///   [StatefulBuilder] around [content]; it passes through untouched.
+/// * **An `IntrinsicWidth` body.** [AlertDialog] sizes itself to its content,
+///   which is why a scrollable inside one fails to lay out and why call sites
+///   grew `SizedBox(width: …)` workarounds. The width here comes from
+///   [maxWidth] instead, so a scrollable body is safe and those wrappers can
+///   go.
 class AppDialog extends StatelessWidget {
+  /// Plain-text heading. Mutually exclusive with [titleWidget].
   final String? title;
+
+  /// A second, quieter line under [title] — a count, a step, a file name.
+  final String? subtitle;
+
+  /// Leading glyph beside [title], tinted [iconColor] or the accent.
+  final IconData? icon;
+  final Color? iconColor;
+
+  /// Escape hatch for a heading this shell cannot express. Mutually exclusive
+  /// with [title]; prefer [title] + [subtitle] + [icon], which covers all but
+  /// a couple of cases.
+  final Widget? titleWidget;
+
   final Widget content;
+
+  /// Trailing buttons, right-aligned with 8px between them.
   final List<Widget>? actions;
 
-  /// Caps how wide the dialog grows on desktop; it still shrinks to fit
-  /// smaller viewports.
+  /// Replaces the whole action row, for a footer that is not a right-aligned
+  /// run of buttons — a wizard pairing step dots on the left with Back/Next on
+  /// the right. Wins over [actions].
+  final Widget? actionsOverride;
+
+  /// Caps how wide the dialog grows; it still shrinks to fit smaller
+  /// viewports.
   final double maxWidth;
+
+  /// Caps how tall the dialog grows.
+  ///
+  /// Without this a tall body has nothing to push back against — a dialog
+  /// shrink-wraps its content, so a long list grows until it runs off the
+  /// screen, and an [Expanded] child inside it throws outright. Set this
+  /// whenever the body can be arbitrarily long.
+  final double? maxHeight;
+
+  /// Wraps [content] in a scroll view. Pair with [maxHeight]: on its own a
+  /// scrollable still has unbounded height and so never scrolls.
+  final bool scrollable;
+
+  /// Padding around [content] only, leaving the title and actions inset as
+  /// usual. Set to [EdgeInsets.zero] for a body that reaches the dialog's
+  /// edges — a full-bleed list, or content that carries its own padding.
+  final EdgeInsetsGeometry? contentPadding;
+
+  /// Clips the body to the rounded corners. Needed when a scrolling or
+  /// ink-splashing child would otherwise paint over them.
+  final Clip clipBehavior;
 
   const AppDialog({
     super.key,
     this.title,
+    this.subtitle,
+    this.icon,
+    this.iconColor,
+    this.titleWidget,
     required this.content,
     this.actions,
-    this.maxWidth = 480,
-  });
+    this.actionsOverride,
+    this.maxWidth = 560,
+    this.maxHeight,
+    this.scrollable = false,
+    this.contentPadding,
+    this.clipBehavior = Clip.none,
+  }) : assert(title == null || titleWidget == null,
+            'Give AppDialog a title or a titleWidget, not both');
 
   /// Shows an [AppDialog] and returns whatever the caller pops with
   /// `Navigator.pop(context, result)`.
   static Future<T?> show<T>(
     BuildContext context, {
     String? title,
+    String? subtitle,
+    IconData? icon,
+    Color? iconColor,
+    Widget? titleWidget,
     required Widget content,
     List<Widget>? actions,
-    double maxWidth = 480,
+    Widget? actionsOverride,
+    double maxWidth = 560,
+    double? maxHeight,
+    bool scrollable = false,
+    EdgeInsetsGeometry? contentPadding,
+    Clip clipBehavior = Clip.none,
     bool barrierDismissible = true,
   }) {
     return showDialog<T>(
       context: context,
       barrierDismissible: barrierDismissible,
-      builder: (_) => AppDialog(title: title, content: content, actions: actions, maxWidth: maxWidth),
+      builder: (_) => AppDialog(
+        title: title,
+        subtitle: subtitle,
+        icon: icon,
+        iconColor: iconColor,
+        titleWidget: titleWidget,
+        content: content,
+        actions: actions,
+        actionsOverride: actionsOverride,
+        maxWidth: maxWidth,
+        maxHeight: maxHeight,
+        scrollable: scrollable,
+        contentPadding: contentPadding,
+        clipBehavior: clipBehavior,
+      ),
     );
   }
+
+  /// Inset from the dialog's edge to its content.
+  static const double _pad = 20;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
+
+    final heading = _buildHeading(context, colorScheme);
+    final footer = _buildFooter();
+
+    Widget body = scrollable ? SingleChildScrollView(child: content) : content;
+
+    // Padding is applied per slot rather than once around the column, so a
+    // body asking for EdgeInsets.zero can reach the dialog's edges — a
+    // full-bleed list — while the title and actions above and below it stay
+    // inset. The default absorbs the outer inset on whichever sides have no
+    // neighbour to provide it.
+    body = Padding(
+      padding: contentPadding ??
+          EdgeInsets.only(
+            left: _pad,
+            right: _pad,
+            top: heading == null ? _pad : 0,
+            bottom: footer == null ? _pad : 0,
+          ),
+      child: body,
+    );
 
     return Dialog(
       // A tone above the canvas, same family PanelCard draws its surface
       // from, so a dialog reads as one more surface in the app rather than
       // Material's own stock white/near-black sheet.
       backgroundColor: colorScheme.surfaceContainer,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      clipBehavior: clipBehavior,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(appDialogRadius)),
       child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: maxWidth),
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (title != null) ...[
-                Text(title!, style: textTheme.titleLarge),
-                const SizedBox(height: 16),
-              ],
-              Flexible(child: content),
-              if (actions != null && actions!.isNotEmpty) ...[
-                const SizedBox(height: 20),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    for (var i = 0; i < actions!.length; i++) ...[
-                      if (i > 0) const SizedBox(width: 8),
-                      actions![i],
-                    ],
-                  ],
-                ),
-              ],
-            ],
-          ),
+        constraints: BoxConstraints(
+          maxWidth: maxWidth,
+          maxHeight: maxHeight ?? double.infinity,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (heading != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(_pad, _pad, _pad, 16),
+                child: heading,
+              ),
+            // The only slot allowed to take the height left over, so a
+            // maxHeight bounds the scrolling body rather than cutting the
+            // action row off the bottom of the dialog.
+            Flexible(child: body),
+            if (footer != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(_pad, _pad, _pad, _pad),
+                child: footer,
+              ),
+          ],
         ),
       ),
+    );
+  }
+
+  Widget? _buildHeading(BuildContext context, ColorScheme colorScheme) {
+    if (titleWidget != null) return titleWidget;
+    if (title == null) return null;
+
+    final textTheme = Theme.of(context).textTheme;
+
+    final text = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title!, style: textTheme.titleLarge),
+        if (subtitle != null) ...[
+          const SizedBox(height: 2),
+          Text(
+            subtitle!,
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+          ),
+        ],
+      ],
+    );
+
+    if (icon == null) return text;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 22, color: iconColor ?? colorScheme.primary),
+        const SizedBox(width: 10),
+        Expanded(child: text),
+      ],
+    );
+  }
+
+  Widget? _buildFooter() {
+    if (actionsOverride != null) return actionsOverride;
+    if (actions == null || actions!.isEmpty) return null;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        for (var i = 0; i < actions!.length; i++) ...[
+          if (i > 0) const SizedBox(width: 8),
+          actions![i],
+        ],
+      ],
     );
   }
 }

--- a/lib/widgets/dialogs/file_rename_dialog.dart
+++ b/lib/widgets/dialogs/file_rename_dialog.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
 
 import '../../l10n/app_localizations.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
 
 Future<void> showFileRenameDialog({
   required BuildContext context,
@@ -18,37 +20,36 @@ Future<void> showFileRenameDialog({
 
   final controller = TextEditingController(text: nameStem);
 
-  final bool? confirmed = await showDialog<bool>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: Text(l10n.renameFile),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          TextField(
-            controller: controller,
-            decoration: InputDecoration(
-              labelText: l10n.newFilename,
-              suffixText: extension,
-              border: const OutlineInputBorder(),
-            ),
-            autofocus: true,
-            onSubmitted: (val) => Navigator.pop(context, true),
+  final bool? confirmed = await AppDialog.show<bool>(
+    context,
+    title: l10n.renameFile,
+    content: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextField(
+          controller: controller,
+          decoration: InputDecoration(
+            labelText: l10n.newFilename,
+            suffixText: extension,
+            border: const OutlineInputBorder(),
           ),
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context, false),
-          child: Text(l10n.cancel),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.pop(context, true),
-          child: Text(l10n.rename),
+          autofocus: true,
+          onSubmitted: (val) => Navigator.pop(context, true),
         ),
       ],
     ),
+    actions: [
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context, false),
+      ),
+      AppButton(
+        label: l10n.rename,
+        onPressed: () => Navigator.pop(context, true),
+      ),
+    ],
   );
 
   if (confirmed == true) {

--- a/lib/widgets/dialogs/image_size_picker_dialog.dart
+++ b/lib/widgets/dialogs/image_size_picker_dialog.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../services/llm/model_capabilities.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
 
 /// Picker for image-size parameters whose values aren't exhaustively
 /// enumerable (currently used by gpt-image-2). Renders the spec's preset
@@ -119,115 +121,114 @@ class _ImageSizePickerDialogState extends State<_ImageSizePickerDialog> {
         ? checkOpenAIImage2SizeRules(_width!, _height!)
         : const <SizeRuleResult>[];
 
-    return AlertDialog(
-      title: Text(l10n.imageSizePickerTitle),
-      content: SizedBox(
-        width: 460,
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (hasAuto) ...[
-                _SectionHeader(label: l10n.imageSizeAuto),
-                const SizedBox(height: 6),
-                _AutoCard(
-                  selected: widget.currentValue == 'auto' &&
-                      _width.toString() == '1024' && _height.toString() == '1024',
-                  onTap: () => Navigator.of(context).pop('auto'),
-                  label: l10n.imageSizeAutoDesc,
-                ),
-                const SizedBox(height: 16),
-              ],
-              _SectionHeader(label: l10n.imageSizePresets),
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: presets.map((opt) {
-                  final isSelected = widget.currentValue == opt.value;
-                  return ChoiceChip(
-                    label: Text(opt.value.replaceAll('x', '×')),
-                    selected: isSelected,
-                    onSelected: (_) {
-                      final parsed = _parseSize(opt.value);
-                      if (parsed != null) _setSize(parsed.$1, parsed.$2);
-                    },
-                  );
-                }).toList(),
-              ),
-              const SizedBox(height: 20),
-              _SectionHeader(label: l10n.imageSizeCustom),
-              const SizedBox(height: 8),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _widthCtrl,
-                      decoration: InputDecoration(
-                        labelText: l10n.imageSizeWidth,
-                        isDense: true,
-                        border: const OutlineInputBorder(),
-                        suffixText: 'px',
-                      ),
-                      keyboardType: TextInputType.number,
-                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                      onChanged: _onWidthChanged,
-                      onEditingComplete: _commitSnap,
-                    ),
-                  ),
-                  const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 10),
-                    child: Icon(Icons.close, size: 16),
-                  ),
-                  Expanded(
-                    child: TextField(
-                      controller: _heightCtrl,
-                      decoration: InputDecoration(
-                        labelText: l10n.imageSizeHeight,
-                        isDense: true,
-                        border: const OutlineInputBorder(),
-                        suffixText: 'px',
-                      ),
-                      keyboardType: TextInputType.number,
-                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                      onChanged: _onHeightChanged,
-                      onEditingComplete: _commitSnap,
-                    ),
-                  ),
-                ],
-              ),
+    return AppDialog(
+      title: l10n.imageSizePickerTitle,
+      maxWidth: 460,
+      content: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (hasAuto) ...[
+              _SectionHeader(label: l10n.imageSizeAuto),
               const SizedBox(height: 6),
-              Text(
-                l10n.imageSizeSnapHint,
-                style: TextStyle(fontSize: 11, color: colorScheme.outline),
+              _AutoCard(
+                selected: widget.currentValue == 'auto' &&
+                    _width.toString() == '1024' && _height.toString() == '1024',
+                onTap: () => Navigator.of(context).pop('auto'),
+                label: l10n.imageSizeAutoDesc,
               ),
-              if (rules.isNotEmpty) ...[
-                const SizedBox(height: 14),
-                _AspectPreview(
-                  width: _width!,
-                  height: _height!,
-                  valid: _customValid,
-                ),
-                const SizedBox(height: 14),
-                ...rules.map((r) => _RuleRow(
-                      label: _ruleLabel(l10n, r.labelKey, _width!, _height!),
-                      passes: r.passes,
-                    )),
-              ],
+              const SizedBox(height: 16),
             ],
-          ),
+            _SectionHeader(label: l10n.imageSizePresets),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: presets.map((opt) {
+                final isSelected = widget.currentValue == opt.value;
+                return ChoiceChip(
+                  label: Text(opt.value.replaceAll('x', '×')),
+                  selected: isSelected,
+                  onSelected: (_) {
+                    final parsed = _parseSize(opt.value);
+                    if (parsed != null) _setSize(parsed.$1, parsed.$2);
+                  },
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 20),
+            _SectionHeader(label: l10n.imageSizeCustom),
+            const SizedBox(height: 8),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _widthCtrl,
+                    decoration: InputDecoration(
+                      labelText: l10n.imageSizeWidth,
+                      isDense: true,
+                      border: const OutlineInputBorder(),
+                      suffixText: 'px',
+                    ),
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    onChanged: _onWidthChanged,
+                    onEditingComplete: _commitSnap,
+                  ),
+                ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 10),
+                  child: Icon(Icons.close, size: 16),
+                ),
+                Expanded(
+                  child: TextField(
+                    controller: _heightCtrl,
+                    decoration: InputDecoration(
+                      labelText: l10n.imageSizeHeight,
+                      isDense: true,
+                      border: const OutlineInputBorder(),
+                      suffixText: 'px',
+                    ),
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    onChanged: _onHeightChanged,
+                    onEditingComplete: _commitSnap,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            Text(
+              l10n.imageSizeSnapHint,
+              style: TextStyle(fontSize: 11, color: colorScheme.outline),
+            ),
+            if (rules.isNotEmpty) ...[
+              const SizedBox(height: 14),
+              _AspectPreview(
+                width: _width!,
+                height: _height!,
+                valid: _customValid,
+              ),
+              const SizedBox(height: 14),
+              ...rules.map((r) => _RuleRow(
+                    label: _ruleLabel(l10n, r.labelKey, _width!, _height!),
+                    passes: r.passes,
+                  )),
+            ],
+          ],
         ),
       ),
       actions: [
-        TextButton(
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(l10n.cancel),
         ),
-        FilledButton(
+        AppButton(
+          label: l10n.apply,
           onPressed: _customValid ? () => Navigator.of(context).pop('${_width}x$_height') : null,
-          child: Text(l10n.apply),
         ),
       ],
     );

--- a/lib/widgets/dialogs/prompt_history_dialog.dart
+++ b/lib/widgets/dialogs/prompt_history_dialog.dart
@@ -5,6 +5,8 @@ import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/prompt_history_entry.dart';
 import '../../state/app_state.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
 
 /// Prompt-header action that opens the recent-prompt picker for [type].
 ///
@@ -237,22 +239,21 @@ class _PromptHistorySheetState extends State<PromptHistorySheet> {
 
   Future<void> _confirmClear() async {
     final l10n = AppLocalizations.of(context)!;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.clearPromptHistory),
-        content: Text(l10n.clearPromptHistoryConfirm),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(l10n.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(l10n.clear),
-          ),
-        ],
-      ),
+    final confirmed = await AppDialog.show<bool>(
+      context,
+      title: l10n.clearPromptHistory,
+      content: Text(l10n.clearPromptHistoryConfirm),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        AppButton(
+          label: l10n.clear,
+          onPressed: () => Navigator.pop(context, true),
+        ),
+      ],
     );
     if (confirmed != true || !mounted) return;
 
@@ -324,53 +325,54 @@ class _PromptPreviewDialog extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
 
-    return AlertDialog(
-      title: Text(l10n.preview),
-      content: SizedBox(
-        width: 500,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              formatRelativeTime(l10n, entry.usedAt),
-              style: TextStyle(fontSize: 11, color: colorScheme.outline),
-            ),
-            const SizedBox(height: 12),
-            Flexible(
-              child: Container(
-                width: double.infinity,
-                constraints: const BoxConstraints(maxHeight: 320),
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: colorScheme.surfaceContainerHighest.withAlpha(80),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: SingleChildScrollView(
-                  child: SelectableText(
-                    entry.content,
-                    style: const TextStyle(fontSize: 13),
-                  ),
+    return AppDialog(
+      title: l10n.preview,
+      maxWidth: 500,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            formatRelativeTime(l10n, entry.usedAt),
+            style: TextStyle(fontSize: 11, color: colorScheme.outline),
+          ),
+          const SizedBox(height: 12),
+          // Caps the prompt body only — the warning line below it has to stay
+          // visible however long the prompt runs.
+          Flexible(
+            child: Container(
+              width: double.infinity,
+              constraints: const BoxConstraints(maxHeight: 320),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest.withAlpha(80),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: SingleChildScrollView(
+                child: SelectableText(
+                  entry.content,
+                  style: const TextStyle(fontSize: 13),
                 ),
               ),
             ),
-            const SizedBox(height: 10),
-            Text(
-              l10n.applyPromptWarning,
-              style: TextStyle(fontSize: 11, color: colorScheme.outline),
-            ),
-          ],
-        ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            l10n.applyPromptWarning,
+            style: TextStyle(fontSize: 11, color: colorScheme.outline),
+          ),
+        ],
       ),
       actions: [
-        TextButton(
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
           onPressed: () => Navigator.pop(context, false),
-          child: Text(l10n.cancel),
         ),
-        FilledButton.icon(
+        AppButton(
+          label: l10n.usePrompt,
+          icon: Icons.check,
           onPressed: () => Navigator.pop(context, true),
-          icon: const Icon(Icons.check, size: 16),
-          label: Text(l10n.usePrompt),
         ),
       ],
     );

--- a/lib/widgets/dialogs/task_log_dialog.dart
+++ b/lib/widgets/dialogs/task_log_dialog.dart
@@ -7,6 +7,9 @@ import 'package:provider/provider.dart';
 import '../../l10n/app_localizations.dart';
 import '../../services/task_queue_service.dart';
 import '../../state/app_state.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
+import '../app_snackbar.dart';
 
 /// The full log of a single task, in a console the user can read, select and
 /// copy from.
@@ -86,54 +89,42 @@ class _TaskLogDialogState extends State<TaskLogDialog> {
     final logs = widget.task.logs;
     final media = MediaQuery.of(context).size;
 
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxWidth: 720,
-          maxHeight: media.height * 0.8,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 18, 20, 14),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildHeader(colorScheme, l10n),
-              const SizedBox(height: 14),
-              Flexible(
-                child: logs.isEmpty
-                    ? _buildEmpty(colorScheme, l10n)
-                    : _buildConsole(logs, colorScheme),
-              ),
-              const SizedBox(height: 12),
-              _buildActions(logs, colorScheme, l10n),
-            ],
-          ),
-        ),
-      ),
+    return AppDialog(
+      maxWidth: 720,
+      // The console is a ListView, so it needs a ceiling to lay out against
+      // rather than growing with the log.
+      maxHeight: media.height * 0.8,
+      // titleWidget rather than title/subtitle/icon: the live indicator sits
+      // on the trailing edge of the heading, which the shell's leading-icon
+      // layout has nowhere to put.
+      titleWidget: _buildHeader(context, colorScheme, l10n),
+      content: logs.isEmpty ? _buildEmpty(colorScheme, l10n) : _buildConsole(logs, colorScheme),
+      // The line count is part of the footer, pinned opposite the buttons.
+      actionsOverride: _buildActions(logs, colorScheme, l10n),
     );
   }
 
-  Widget _buildHeader(ColorScheme colorScheme, AppLocalizations l10n) {
+  Widget _buildHeader(BuildContext context, ColorScheme colorScheme, AppLocalizations l10n) {
     final task = widget.task;
+    final textTheme = Theme.of(context).textTheme;
+
     return Row(
       children: [
-        Icon(Icons.terminal, size: 20, color: colorScheme.onSurfaceVariant),
+        Icon(Icons.terminal, size: 22, color: colorScheme.onSurfaceVariant),
         const SizedBox(width: 10),
         Expanded(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                l10n.taskLogTitle,
-                style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
-              ),
+              // Matches the type AppDialog gives a plain title, so this
+              // hand-built heading is not a different size from every other
+              // dialog's.
+              Text(l10n.taskLogTitle, style: textTheme.titleLarge),
               const SizedBox(height: 2),
               Text(
                 l10n.taskId(task.id.length > 8 ? task.id.substring(0, 8) : task.id),
-                style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+                style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
               ),
             ],
           ),
@@ -147,7 +138,7 @@ class _TaskLogDialogState extends State<TaskLogDialog> {
           const SizedBox(width: 8),
           Text(
             l10n.taskLogLive,
-            style: TextStyle(fontSize: 11, color: colorScheme.primary),
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.primary),
           ),
         ],
       ],
@@ -235,25 +226,24 @@ class _TaskLogDialogState extends State<TaskLogDialog> {
       children: [
         Text(
           l10n.taskLogLineCount(logs.length),
-          style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
         ),
         const Spacer(),
-        TextButton.icon(
+        AppButton(
+          label: l10n.copyLogs,
+          icon: Icons.copy_outlined,
+          variant: AppButtonVariant.text,
           onPressed: logs.isEmpty
               ? null
               : () {
                   Clipboard.setData(ClipboardData(text: logs.join('\n')));
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text(l10n.taskLogCopied)),
-                  );
+                  AppSnackBar.success(context, l10n.taskLogCopied);
                 },
-          icon: const Icon(Icons.copy_outlined, size: 16),
-          label: Text(l10n.copyLogs),
         ),
         const SizedBox(width: 8),
-        FilledButton(
+        AppButton(
+          label: l10n.close,
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(l10n.close),
         ),
       ],
     );

--- a/lib/widgets/dialogs/thumbnail_size_dialog.dart
+++ b/lib/widgets/dialogs/thumbnail_size_dialog.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
+
+/// Smallest and largest tile the gallery grids will draw, in logical pixels.
+const double kMinThumbnailSize = 80;
+const double kMaxThumbnailSize = 400;
+
+/// Adjusts the grid's tile size, live.
+///
+/// Shared by the workbench gallery and the file browser, which had a copy
+/// each. Both copies were raw [AlertDialog]s, so neither picked up the app's
+/// surface or corner radius, and the workbench one had its value declared
+/// inside the [StatefulBuilder] — reinitialised on every rebuild, so the
+/// handle sprang back to where the dialog opened while the grid behind it
+/// kept resizing.
+///
+/// [onChanged] fires on every frame of the drag rather than on release: the
+/// grid resizing underneath *is* the preview, so there is nothing to confirm
+/// and the button only dismisses.
+Future<void> showThumbnailSizeDialog(
+  BuildContext context, {
+  required double initialSize,
+  required ValueChanged<double> onChanged,
+}) {
+  final l10n = AppLocalizations.of(context)!;
+  // Outside the builder, so it survives the rebuilds the drag causes.
+  var size = initialSize.clamp(kMinThumbnailSize, kMaxThumbnailSize);
+
+  return AppDialog.show<void>(
+    context,
+    title: l10n.thumbnailSize,
+    maxWidth: 360,
+    content: StatefulBuilder(
+      builder: (context, setState) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Slider(
+            value: size,
+            min: kMinThumbnailSize,
+            max: kMaxThumbnailSize,
+            onChanged: (v) {
+              setState(() => size = v);
+              onChanged(v);
+            },
+          ),
+          Text('${size.toInt()}px', style: Theme.of(context).textTheme.bodyMedium),
+        ],
+      ),
+    ),
+    actions: [
+      AppButton(
+        label: l10n.confirm,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context),
+      ),
+    ],
+  );
+}

--- a/lib/widgets/markdown_editor.dart
+++ b/lib/widgets/markdown_editor.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
 import '../../l10n/app_localizations.dart';
+import 'app_dialog.dart';
 import 'app_segmented_control.dart';
 
 /// A specialized controller that provides basic syntax highlighting for Markdown.
@@ -354,19 +355,23 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
           },
         );
 
+        // Left as Dialog.fullscreen: on a phone the pop-out *is* the screen,
+        // and a rounded card inset from the edges would waste the width the
+        // user opened it to get.
         if (isCompact) {
           return Dialog.fullscreen(child: body);
         }
+
         final screen = MediaQuery.of(dialogContext).size;
-        return Dialog(
+        return AppDialog(
           clipBehavior: Clip.antiAlias,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-          insetPadding: const EdgeInsets.symmetric(horizontal: 40, vertical: 24),
-          child: SizedBox(
-            width: (screen.width * 0.8).clamp(0.0, 1000.0),
-            height: screen.height * 0.85,
-            child: body,
-          ),
+          maxWidth: (screen.width * 0.8).clamp(0.0, 1000.0),
+          // A deliberate height, not a ceiling: the editor should not resize
+          // as the text grows under the cursor.
+          maxHeight: screen.height * 0.85,
+          // The body carries its own toolbar and padding, and fills the card.
+          contentPadding: EdgeInsets.zero,
+          content: SizedBox(height: screen.height * 0.85, child: body),
         );
       },
     );

--- a/lib/widgets/models/channel_edit_dialog.dart
+++ b/lib/widgets/models/channel_edit_dialog.dart
@@ -6,6 +6,8 @@ import '../../l10n/app_localizations.dart';
 import '../../models/llm_channel.dart';
 import '../../state/app_state.dart';
 import '../api_key_field.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
 import 'channel_form_sections.dart';
 
 /// Edit-channel dialog. Desktop: a fixed-width two-column layout —
@@ -127,30 +129,18 @@ class _ChannelEditDialogState extends State<ChannelEditDialog> {
     }
 
     final colorScheme = Theme.of(context).colorScheme;
-    return AlertDialog(
-      titlePadding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
-      title: Row(
-        children: [
-          Icon(Icons.edit_note, color: colorScheme.primary),
-          const SizedBox(width: 12),
-          Text(l10n.editChannel),
-          const Spacer(),
-          if (widget.channel != null)
-            Flexible(
-              child: Text(
-                widget.channel!.displayName,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(fontSize: 13, color: colorScheme.outline),
-              ),
-            ),
-        ],
-      ),
-      contentPadding: EdgeInsets.zero,
+    return AppDialog(
+      icon: Icons.edit_note,
+      title: l10n.editChannel,
+      // Which channel is being edited belongs under the heading, not trailing
+      // it: as a Spacer'd tail it collided with a long title at narrow widths.
+      subtitle: widget.channel?.displayName,
+      maxWidth: 680,
       clipBehavior: Clip.antiAlias,
-      content: SizedBox(
-        width: 680,
-        child: SingleChildScrollView(
+      // The body brings its own padding so its two columns can carry the
+      // divider between them right to the edges.
+      contentPadding: EdgeInsets.zero,
+      content: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(24, 4, 24, 8),
           // No IntrinsicHeight here: the appearance column contains a Wrap,
           // whose intrinsic height is computed as a single run — under a
@@ -198,17 +188,16 @@ class _ChannelEditDialogState extends State<ChannelEditDialog> {
             ],
           ),
         ),
-      ),
-      actionsPadding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
       actions: [
-        TextButton(
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
           onPressed: () => Navigator.pop(context),
-          child: Text(l10n.cancel),
         ),
-        FilledButton.icon(
+        AppButton(
+          label: l10n.save,
+          icon: Icons.save,
           onPressed: _save,
-          icon: const Icon(Icons.save, size: 18),
-          label: Text(l10n.save),
         ),
       ],
     );

--- a/lib/widgets/models/channel_wizard_dialog.dart
+++ b/lib/widgets/models/channel_wizard_dialog.dart
@@ -6,6 +6,8 @@ import '../../l10n/app_localizations.dart';
 import '../../services/llm/channel_dialect.dart';
 import '../../state/app_state.dart';
 import '../api_key_field.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
 import '../app_segmented_control.dart';
 import 'channel_form_sections.dart';
 
@@ -297,7 +299,14 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
               padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
               child: Align(
                 alignment: Alignment.centerLeft,
-                child: _buildStepCaption(l10n),
+                // Same treatment AppDialog gives the desktop dialog's
+                // subtitle, so the step caption reads the same on both.
+                child: Text(
+                  _stepCaption(l10n),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
               ),
             ),
             Expanded(child: content),
@@ -327,57 +336,47 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
       );
     }
 
-    return AlertDialog(
-      titlePadding: const EdgeInsets.fromLTRB(24, 20, 24, 12),
-      title: Row(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Text(l10n.addChannel),
-          const Spacer(),
-          _buildStepCaption(l10n),
-        ],
-      ),
-      contentPadding: EdgeInsets.zero,
+    return AppDialog(
+      title: l10n.addChannel,
+      subtitle: _stepCaption(l10n),
+      maxWidth: 560,
       clipBehavior: Clip.antiAlias,
-      // Fixed size so the dialog doesn't resize between steps; shorter steps
+      // The steps carry their own padding, and step content reaches the edges.
+      contentPadding: EdgeInsets.zero,
+      // Fixed height so the dialog doesn't resize between steps; shorter steps
       // simply leave whitespace below (content is top-aligned and scrolls
       // when it exceeds the height).
-      content: SizedBox(width: 560, height: 520, child: content),
-      actionsPadding: const EdgeInsets.fromLTRB(24, 8, 24, 16),
-      actions: [
-        Row(
-          children: [
-            _buildStepDots(),
-            const Spacer(),
-            if (_currentStep > 0)
-              TextButton(onPressed: _back, child: Text(l10n.back))
-            else
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: Text(l10n.cancel),
-              ),
-            const SizedBox(width: 8),
-            FilledButton(
-              onPressed: _isNextEnabled() ? _next : null,
-              child: Text(
-                  _currentStep == _totalSteps - 1 ? l10n.finish : l10n.next),
+      content: SizedBox(height: 520, child: content),
+      // Not `actions`: the step dots are pinned opposite the buttons, and the
+      // shell's right-aligned row would shove the whole thing to one side.
+      actionsOverride: Row(
+        children: [
+          _buildStepDots(),
+          const Spacer(),
+          if (_currentStep > 0)
+            AppButton(
+              label: l10n.back,
+              variant: AppButtonVariant.text,
+              onPressed: _back,
+            )
+          else
+            AppButton(
+              label: l10n.cancel,
+              variant: AppButtonVariant.text,
+              onPressed: () => Navigator.pop(context),
             ),
-          ],
-        ),
-      ],
+          const SizedBox(width: 8),
+          AppButton(
+            label: _currentStep == _totalSteps - 1 ? l10n.finish : l10n.next,
+            onPressed: _isNextEnabled() ? _next : null,
+          ),
+        ],
+      ),
     );
   }
 
-  Widget _buildStepCaption(AppLocalizations l10n) {
-    return Text(
-      '${_currentStep + 1}/$_totalSteps · ${_stepSubtitle(l10n)}',
-      style: TextStyle(
-        fontSize: 13,
-        fontWeight: FontWeight.normal,
-        color: Theme.of(context).colorScheme.outline,
-      ),
-    );
-  }
+  String _stepCaption(AppLocalizations l10n) =>
+      '${_currentStep + 1}/$_totalSteps · ${_stepSubtitle(l10n)}';
 
   Widget _buildStepDots() {
     final colorScheme = Theme.of(context).colorScheme;

--- a/lib/widgets/models/discovery_dialog.dart
+++ b/lib/widgets/models/discovery_dialog.dart
@@ -7,6 +7,8 @@ import '../../services/llm/llm_types.dart';
 import '../../services/llm/model_discovery_service.dart';
 import '../../services/llm/model_family.dart';
 import '../../state/app_state.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
 
 class DiscoveryDialog extends StatefulWidget {
   final LLMChannel channel;
@@ -123,35 +125,39 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
       );
     }
 
-    return AlertDialog(
-      title: Row(
+    final media = MediaQuery.of(context).size;
+
+    return AppDialog(
+      icon: Icons.auto_awesome_outlined,
+      title: l10n.selectModelsToAdd,
+      maxWidth: media.width.clamp(280.0, 600.0),
+      // A fixed height, not just a ceiling: the body swaps between a spinner,
+      // an error and a list, and without one the dialog would resize under
+      // the pointer each time discovery moves on.
+      maxHeight: media.height.clamp(280.0, 600.0),
+      // The list reaches the dialog's edges; the search field above it brings
+      // its own inset.
+      contentPadding: EdgeInsets.zero,
+      content: Column(
         children: [
-          Icon(Icons.auto_awesome_outlined, color: Theme.of(context).colorScheme.primary),
-          const SizedBox(width: 12),
-          Text(l10n.selectModelsToAdd),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
+            child: _buildSearchBar(l10n),
+          ),
+          Expanded(child: _buildMainContent(l10n)),
         ],
       ),
-      contentPadding: EdgeInsets.zero,
-      content: SizedBox(
-        width: MediaQuery.of(context).size.width.clamp(280.0, 600.0).clamp(0.0, MediaQuery.of(context).size.width - 32),
-        height: MediaQuery.of(context).size.height.clamp(280.0, 600.0).clamp(0.0, MediaQuery.of(context).size.height - 96),
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
-              child: _buildSearchBar(l10n),
-            ),
-            Expanded(child: _buildMainContent(l10n)),
-          ],
-        ),
-      ),
       actions: [
-        TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
         if (!_isLoading && _error == null && _discovered.isNotEmpty)
-          FilledButton.icon(
+          AppButton(
+            label: l10n.addSelected(_selectedIds.length),
+            icon: Icons.add,
             onPressed: _selectedIds.isEmpty ? null : _handleAddSelected,
-            icon: const Icon(Icons.add, size: 18),
-            label: Text(l10n.addSelected(_selectedIds.length)),
           ),
       ],
     );

--- a/lib/widgets/models/model_edit_dialog.dart
+++ b/lib/widgets/models/model_edit_dialog.dart
@@ -6,6 +6,8 @@ import '../../models/llm_model.dart';
 import '../../services/llm/channel_dialect.dart';
 import '../../services/llm/context_budget.dart';
 import '../../state/app_state.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
 import '../app_segmented_control.dart';
 
 class ModelEditDialog extends StatefulWidget {
@@ -111,83 +113,86 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
     final colorScheme = Theme.of(context).colorScheme;
     final isMobile = Responsive.isMobile(context);
 
-    return Dialog(
+    return AppDialog(
       clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-      insetPadding: EdgeInsets.symmetric(horizontal: isMobile ? 12 : 40, vertical: 24),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 620, maxHeight: 760),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildHeader(colorScheme),
-            Flexible(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.fromLTRB(24, 20, 24, 12),
-                child: _buildForm(colorScheme, twoColumn: !isMobile),
-              ),
-            ),
-            _buildFooter(colorScheme),
-          ],
+      maxWidth: 620,
+      maxHeight: 760,
+      // titleWidget rather than icon/title/subtitle: this heading keeps its
+      // tinted icon tile and its own close button, neither of which the
+      // shell's leading-icon layout has a place for.
+      titleWidget: _buildHeader(context, colorScheme),
+      scrollable: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 24),
+      content: _buildForm(colorScheme, twoColumn: !isMobile),
+      actions: [
+        AppButton(
+          label: widget.l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
         ),
-      ),
+        AppButton(
+          label: widget.model == null ? widget.l10n.add : widget.l10n.save,
+          icon: Icons.save,
+          onPressed: _canSave ? _save : null,
+        ),
+      ],
     );
   }
 
   // --- Header -------------------------------------------------------------
 
-  Widget _buildHeader(ColorScheme colorScheme) {
+  /// The heading: tinted icon tile, name, model id, close.
+  ///
+  /// No bottom rule any more — the app's panels gave up hard divider lines
+  /// for spacing, and [AppDialog]'s own gap already separates this from the
+  /// form. Type comes from the scale so it matches every other dialog title.
+  Widget _buildHeader(BuildContext context, ColorScheme colorScheme) {
     final l10n = widget.l10n;
     final isEdit = widget.model != null;
-    return Container(
-      padding: const EdgeInsets.fromLTRB(20, 14, 10, 14),
-      decoration: BoxDecoration(
-        border: Border(bottom: BorderSide(color: colorScheme.outlineVariant.withAlpha(90))),
-      ),
-      child: Row(
-        children: [
-          Container(
-            width: 40,
-            height: 40,
-            decoration: BoxDecoration(
-              color: colorScheme.primaryContainer,
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: Icon(
-              isEdit ? Icons.edit_outlined : Icons.add_box_outlined,
-              size: 22,
-              color: colorScheme.onPrimaryContainer,
-            ),
+    final textTheme = Theme.of(context).textTheme;
+
+    return Row(
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: colorScheme.primaryContainer,
+            borderRadius: BorderRadius.circular(12),
           ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
+          child: Icon(
+            isEdit ? Icons.edit_outlined : Icons.add_box_outlined,
+            size: 22,
+            color: colorScheme.onPrimaryContainer,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                isEdit ? l10n.editLlmModel : l10n.addLlmModel,
+                style: textTheme.titleLarge,
+                overflow: TextOverflow.ellipsis,
+              ),
+              if (isEdit)
                 Text(
-                  isEdit ? l10n.editLlmModel : l10n.addLlmModel,
-                  style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+                  widget.model!.modelId,
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                    fontFamily: 'monospace',
+                  ),
                   overflow: TextOverflow.ellipsis,
                 ),
-                if (isEdit)
-                  Text(
-                    widget.model!.modelId,
-                    style: TextStyle(
-                      fontSize: 11,
-                      color: colorScheme.onSurfaceVariant,
-                      fontFamily: 'monospace',
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-              ],
-            ),
+            ],
           ),
-          IconButton(
-            icon: const Icon(Icons.close, size: 20),
-            onPressed: () => Navigator.pop(context),
-          ),
-        ],
-      ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.close, size: 20),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
     );
   }
 
@@ -395,32 +400,6 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
     );
   }
 
-  // --- Footer -------------------------------------------------------------
-
-  Widget _buildFooter(ColorScheme colorScheme) {
-    final l10n = widget.l10n;
-    return Container(
-      padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
-      decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: colorScheme.outlineVariant.withAlpha(90))),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(l10n.cancel),
-          ),
-          const SizedBox(width: 8),
-          FilledButton.icon(
-            onPressed: _canSave ? _save : null,
-            icon: const Icon(Icons.save, size: 18),
-            label: Text(widget.model == null ? l10n.add : l10n.save),
-          ),
-        ],
-      ),
-    );
-  }
 
   Future<void> _save() async {
     final channel = widget.appState.allChannels.firstWhere((c) => c.id == channelId);

--- a/lib/widgets/pricing_group_manager.dart
+++ b/lib/widgets/pricing_group_manager.dart
@@ -6,6 +6,8 @@ import '../core/responsive.dart';
 import '../l10n/app_localizations.dart';
 import '../models/pricing_group.dart';
 import '../state/app_state.dart';
+import 'app_button.dart';
+import 'app_dialog.dart';
 import 'app_icon_button.dart';
 import 'app_segmented_control.dart';
 
@@ -228,23 +230,25 @@ class PricingGroupManager extends StatelessWidget {
   }
 
   void _confirmDelete(BuildContext context, AppState appState, AppLocalizations l10n, PricingGroup group) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.delete),
-        content: Text(l10n.deleteFeeGroupConfirm(group.name)),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-          FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
-            onPressed: () async {
-              await appState.deletePricingGroup(group.id!);
-              if (context.mounted) Navigator.pop(context);
-            },
-            child: Text(l10n.delete),
-          ),
-        ],
-      ),
+    AppDialog.show<void>(
+      context,
+      title: l10n.delete,
+      content: Text(l10n.deleteFeeGroupConfirm(group.name)),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
+        ),
+        AppButton(
+          label: l10n.delete,
+          variant: AppButtonVariant.destructive,
+          onPressed: () async {
+            await appState.deletePricingGroup(group.id!);
+            if (context.mounted) Navigator.pop(context);
+          },
+        ),
+      ],
     );
   }
 
@@ -678,21 +682,24 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
       );
     }
 
-    return Dialog(
+    final saveLabel = widget.group == null ? widget.l10n.add : widget.l10n.save;
+
+    return AppDialog(
       clipBehavior: Clip.antiAlias,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-      insetPadding: const EdgeInsets.symmetric(horizontal: 40, vertical: 24),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 520, maxHeight: 640),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildHeader(colorScheme),
-            body,
-            _buildFooter(colorScheme),
-          ],
+      maxWidth: 520,
+      maxHeight: 640,
+      titleWidget: _buildHeader(colorScheme, chromeless: true),
+      scrollable: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 24),
+      content: _buildForm(colorScheme),
+      actions: [
+        AppButton(
+          label: widget.l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context),
         ),
-      ),
+        AppButton(label: saveLabel, icon: Icons.save, onPressed: _save),
+      ],
     );
   }
 
@@ -710,16 +717,25 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
 
   // --- Header -------------------------------------------------------------
 
-  Widget _buildHeader(ColorScheme colorScheme) {
+  /// The heading, shared by the desktop dialog and the mobile sheet.
+  ///
+  /// [chromeless] drops the padding and the bottom rule for the dialog, where
+  /// [AppDialog] supplies both the inset and the separation. The sheet keeps
+  /// them: there the rule is what divides the header from the drag grabber
+  /// above it.
+  Widget _buildHeader(ColorScheme colorScheme, {bool chromeless = false}) {
     final l10n = widget.l10n;
     final accent = _accent(colorScheme);
     final isAdd = widget.group == null;
+    final textTheme = Theme.of(context).textTheme;
 
     return Container(
-      padding: const EdgeInsets.fromLTRB(20, 16, 14, 16),
-      decoration: BoxDecoration(
-        border: Border(bottom: BorderSide(color: colorScheme.outlineVariant.withAlpha(90))),
-      ),
+      padding: chromeless ? EdgeInsets.zero : const EdgeInsets.fromLTRB(20, 16, 14, 16),
+      decoration: chromeless
+          ? null
+          : BoxDecoration(
+              border: Border(bottom: BorderSide(color: colorScheme.outlineVariant.withAlpha(90))),
+            ),
       child: Row(
         children: [
           Container(
@@ -739,7 +755,7 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
               children: [
                 Text(
                   isAdd ? l10n.addFeeGroup : l10n.editFeeGroup,
-                  style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 18),
+                  style: textTheme.titleLarge,
                   overflow: TextOverflow.ellipsis,
                 ),
                 const SizedBox(height: 2),
@@ -748,7 +764,7 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
                 // nothing the user cannot already see and change.
                 Text(
                   l10n.feeGroupEditorSubtitle,
-                  style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
+                  style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
                   overflow: TextOverflow.ellipsis,
                 ),
               ],

--- a/lib/widgets/settings_widgets.dart
+++ b/lib/widgets/settings_widgets.dart
@@ -4,6 +4,8 @@ import '../core/constants.dart';
 import '../l10n/app_localizations.dart';
 import '../services/font_service.dart';
 import '../state/app_state.dart';
+import 'app_button.dart';
+import 'app_dialog.dart';
 import 'app_segmented_control.dart';
 
 class ThemeSelector extends StatelessWidget {
@@ -257,22 +259,21 @@ class FontSelector extends StatelessWidget {
     if (!context.mounted) return;
     final font = FontService.meta(key)!;
     final sizeMB = (font.totalBytes / 1048576).toStringAsFixed(1);
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(l10n.fontDownloadTitle),
-        content: Text('${font.displayName}  ·  ~$sizeMB MB\n\n${l10n.fontDownloadPrompt}'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text(l10n.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: Text(l10n.fontDownloadAction),
-          ),
-        ],
-      ),
+    final confirmed = await AppDialog.show<bool>(
+      context,
+      title: l10n.fontDownloadTitle,
+      content: Text('${font.displayName}  ·  ~$sizeMB MB\n\n${l10n.fontDownloadPrompt}'),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        AppButton(
+          label: l10n.fontDownloadAction,
+          onPressed: () => Navigator.pop(context, true),
+        ),
+      ],
     );
     if (confirmed != true || !context.mounted) return;
 
@@ -329,7 +330,8 @@ class _FontDownloadDialogState extends State<_FontDownloadDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
+    return AppDialog(
+      maxWidth: 360,
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/test/app_dialog_capabilities_test.dart
+++ b/test/app_dialog_capabilities_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_dialog.dart';
+
+/// Covers the capabilities [AppDialog] grew so the app's ~50 hand-rolled
+/// dialogs could move onto it.
+///
+/// Each one here unblocked a specific group of call sites; the comments name
+/// the failure the capability exists to prevent, because "it renders" is not
+/// what these are checking.
+/// Identifies the test's own body widget. Dialog's internals paint boxes of
+/// their own, so finding by type picks up more than the content.
+const bodyKey = ValueKey('dialog-body');
+
+void main() {
+  const seed = Colors.indigo;
+  final theme = buildAppTheme(seedColor: seed, brightness: Brightness.light);
+
+  Widget host(Widget dialog) => MaterialApp(
+        theme: theme,
+        home: Scaffold(body: Center(child: dialog)),
+      );
+
+  /// The painted card, not the [Dialog] widget.
+  ///
+  /// `Dialog` expands to the whole route and holds its inset padding, so its
+  /// own rect is the screen — measuring it would make every size assertion
+  /// here pass for the wrong reason. The `Material` it wraps its child in is
+  /// the surface the user actually sees.
+  Finder surface() =>
+      find.descendant(of: find.byType(AppDialog), matching: find.byType(Material)).first;
+
+  Size dialogSize(WidgetTester tester) => tester.getSize(surface());
+
+  group('maxHeight', () {
+    testWidgets('bounds a body that would otherwise grow past the screen', (tester) async {
+      // The blocker for every list dialog. A dialog shrink-wraps, so without
+      // a ceiling a long list just keeps growing.
+      await tester.pumpWidget(host(AppDialog(
+        title: 'Pick one',
+        maxHeight: 300,
+        content: ListView(
+          shrinkWrap: true,
+          children: [for (var i = 0; i < 200; i++) ListTile(title: Text('Row $i'))],
+        ),
+      )));
+
+      expect(dialogSize(tester).height, lessThanOrEqualTo(300));
+    });
+
+    testWidgets('lets an Expanded child inside the body lay out', (tester) async {
+      // An Expanded under an unbounded height throws outright. Several
+      // pickers put a list in one, so this has to hold rather than merely
+      // clip.
+      await tester.pumpWidget(host(AppDialog(
+        title: 'Discovered',
+        maxHeight: 320,
+        content: Column(
+          children: [
+            const Text('Header'),
+            Expanded(
+              child: ListView(children: const [Text('a'), Text('b')]),
+            ),
+          ],
+        ),
+      )));
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('keeps the action row on screen instead of clipping it off', (tester) async {
+      // The subtle half of the bug: bound the whole column instead of just
+      // the body and the buttons are the part that falls off the bottom.
+      await tester.pumpWidget(host(AppDialog(
+        title: 'Pick one',
+        maxHeight: 300,
+        content: ListView(
+          shrinkWrap: true,
+          children: [for (var i = 0; i < 200; i++) ListTile(title: Text('Row $i'))],
+        ),
+        actions: [TextButton(onPressed: () {}, child: const Text('Close'))],
+      )));
+
+      final card = tester.getRect(surface());
+      final button = tester.getRect(find.text('Close'));
+
+      expect(button.bottom, lessThanOrEqualTo(card.bottom));
+      expect(card.height, lessThanOrEqualTo(300));
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  testWidgets('scrollable wraps the body so a bounded dialog can scroll', (tester) async {
+    await tester.pumpWidget(host(AppDialog(
+      title: 'Long',
+      maxHeight: 240,
+      scrollable: true,
+      content: Column(
+        children: [for (var i = 0; i < 60; i++) Text('Line $i')],
+      ),
+    )));
+
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  group('contentPadding', () {
+    testWidgets('zero bleeds the body to the edges but not the title', (tester) async {
+      // Full-bleed lists need the body at the edge; the heading must stay
+      // inset or the dialog looks broken rather than deliberate.
+      await tester.pumpWidget(host(const AppDialog(
+        title: 'Channels',
+        maxWidth: 400,
+        contentPadding: EdgeInsets.zero,
+        content: SizedBox(key: bodyKey, height: 40, width: double.infinity),
+      )));
+
+      final card = tester.getRect(surface());
+      final body = tester.getRect(find.byKey(bodyKey));
+      final title = tester.getRect(find.text('Channels'));
+
+      expect(body.left, card.left);
+      expect(body.right, card.right);
+      expect(title.left, greaterThan(card.left));
+    });
+
+    testWidgets('the default insets the body on every free side', (tester) async {
+      await tester.pumpWidget(host(const AppDialog(
+        maxWidth: 400,
+        content: SizedBox(key: bodyKey, height: 40, width: double.infinity),
+      )));
+
+      final card = tester.getRect(surface());
+      final body = tester.getRect(find.byKey(bodyKey));
+
+      // No title and no actions, so the body owns all four insets.
+      expect(body.left, greaterThan(card.left));
+      expect(body.top, greaterThan(card.top));
+      expect(body.bottom, lessThan(card.bottom));
+    });
+  });
+
+  group('heading', () {
+    testWidgets('subtitle renders under the title, quieter', (tester) async {
+      await tester.pumpWidget(host(const AppDialog(
+        title: 'Rename files',
+        subtitle: '12 images selected',
+        content: SizedBox.shrink(),
+      )));
+
+      final title = tester.widget<Text>(find.text('Rename files'));
+      final subtitle = tester.widget<Text>(find.text('12 images selected'));
+
+      expect(subtitle.style!.fontSize, lessThan(title.style!.fontSize!));
+      expect(subtitle.style!.color, theme.colorScheme.onSurfaceVariant);
+    });
+
+    testWidgets('icon takes the accent unless told otherwise', (tester) async {
+      await tester.pumpWidget(host(const AppDialog(
+        title: 'Delete',
+        icon: Icons.warning_amber,
+        content: SizedBox.shrink(),
+      )));
+
+      expect(tester.widget<Icon>(find.byIcon(Icons.warning_amber)).color, theme.colorScheme.primary);
+    });
+
+    testWidgets('iconColor overrides it, for destructive headings', (tester) async {
+      await tester.pumpWidget(host(AppDialog(
+        title: 'Delete',
+        icon: Icons.warning_amber,
+        iconColor: theme.colorScheme.error,
+        content: const SizedBox.shrink(),
+      )));
+
+      expect(tester.widget<Icon>(find.byIcon(Icons.warning_amber)).color, theme.colorScheme.error);
+    });
+
+    testWidgets('a title and a titleWidget together is a mistake, not a silent win', (tester) async {
+      expect(
+        () => AppDialog(
+          title: 'A',
+          titleWidget: const Text('B'),
+          content: const SizedBox.shrink(),
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  testWidgets('actionsOverride replaces the right-aligned row wholesale', (tester) async {
+    // The wizard footer: step dots pinned left, buttons right. Feeding that
+    // through `actions` would wrap a full-width Row inside a
+    // MainAxisAlignment.end Row and shove it off to one side.
+    await tester.pumpWidget(host(AppDialog(
+      title: 'Step 2',
+      maxWidth: 400,
+      content: const SizedBox(height: 40),
+      actions: [TextButton(onPressed: () {}, child: const Text('Ignored'))],
+      actionsOverride: Row(
+        children: [
+          const Text('dots'),
+          const Spacer(),
+          TextButton(onPressed: () {}, child: const Text('Next')),
+        ],
+      ),
+    )));
+
+    expect(find.text('Ignored'), findsNothing);
+
+    final dots = tester.getRect(find.text('dots'));
+    final next = tester.getRect(find.text('Next'));
+    expect(dots.left, lessThan(next.left), reason: 'The override lost its own alignment');
+  });
+
+  testWidgets('the radius matches the panels, not Material stock', (tester) async {
+    // Settled deliberately: one radius across the app, so a dialog reads as
+    // another surface in the same system.
+    await tester.pumpWidget(host(const AppDialog(content: SizedBox.shrink())));
+
+    final dialog = tester.widget<Dialog>(
+        find.descendant(of: find.byType(AppDialog), matching: find.byType(Dialog)));
+    final shape = dialog.shape! as RoundedRectangleBorder;
+
+    expect(shape.borderRadius, BorderRadius.circular(appDialogRadius));
+    expect(appDialogRadius, 12);
+  });
+}

--- a/test/gallery_toolbar_overflow_test.dart
+++ b/test/gallery_toolbar_overflow_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/l10n/app_localizations.dart';
 import 'package:joycai_image_ai_toolkits/screens/workbench/widgets/gallery_toolbar.dart';
 import 'package:joycai_image_ai_toolkits/state/app_state.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_dialog.dart';
 import 'package:provider/provider.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
@@ -132,6 +133,45 @@ void main() {
       expect(toggle.right, lessThanOrEqualTo(bar.right + 0.01),
           reason: 'View toggle clipped at ${width}px');
     }
+  });
+
+  testWidgets('the thumbnail dialog slider follows the drag it caused', (tester) async {
+    // The handle used to spring back to where the dialog opened while the
+    // grid behind it kept resizing: the local holding the value was declared
+    // inside the StatefulBuilder, so every rebuild reinitialised it. The grid
+    // moved because the state was written through directly, which is what
+    // made this read as lag rather than as a broken control.
+    await pumpAtWidth(tester, 420);
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Thumbnail Size'));
+    await tester.pumpAndSettle();
+
+    final before = tester.widget<Slider>(find.byType(Slider)).value;
+
+    await tester.drag(find.byType(Slider), const Offset(60, 0));
+    await tester.pumpAndSettle();
+
+    final after = tester.widget<Slider>(find.byType(Slider)).value;
+    expect(after, greaterThan(before), reason: 'The slider did not keep the value it was dragged to');
+
+    // The readout beside it has to agree, and so does the grid it drives.
+    expect(find.text('${after.toInt()}px'), findsOneWidget);
+  });
+
+  testWidgets('the thumbnail dialog is built from the themed dialog shell', (tester) async {
+    // Raw AlertDialog ignores the app's surface and corner radius, which is
+    // how this one ended up looking like a different application.
+    await pumpAtWidth(tester, 420);
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Thumbnail Size'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppDialog), findsOneWidget);
+    expect(find.byType(AlertDialog), findsNothing);
   });
 
   testWidgets('the collapsed menu still reaches every control it swallowed', (tester) async {

--- a/test/prompt_history_sheet_test.dart
+++ b/test/prompt_history_sheet_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/l10n/app_localizations.dart';
 import 'package:joycai_image_ai_toolkits/models/prompt_history_entry.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_dialog.dart';
 import 'package:joycai_image_ai_toolkits/widgets/dialogs/prompt_history_dialog.dart';
 
 /// Drives the recent-prompt picker the way a user does: open, tap an entry,
@@ -40,7 +41,7 @@ void main() {
     await tester.tap(find.text('a watercolour cat'));
     await tester.pumpAndSettle();
 
-    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.byType(AppDialog), findsOneWidget);
     // Nothing is replaced until the user confirms.
     expect(applied, isEmpty);
   });
@@ -65,7 +66,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(applied, isEmpty);
-    expect(find.byType(AlertDialog), findsNothing);
+    expect(find.byType(AppDialog), findsNothing);
   });
 
   testWidgets('preview shows the whole prompt, not the truncated card text', (tester) async {


### PR DESCRIPTION
## Summary

Follow-up to #63. Every dialog in the app now builds on the shared `AppDialog` — 45 raw `AlertDialog`s and 4 hand-rolled `Dialog`s across 32 files.

Three commits, reviewable in order:

1. **`44b058c`** — fixes the two bugs that started this: the thumbnail-size dialog wasn't themed, and its slider sprang back on every drag frame while the grid kept resizing. Also merges the file browser's duplicate copy of it.
2. **`bb229d7`** — extends `AppDialog` with what an audit of all ~50 call sites showed it was missing. No call sites change here, so the shell is reviewable on its own.
3. **`9fb9def`** — the migration itself.

## Why

None of these dialogs picked up the app's surface colour, corner radius or type scale, so each looked like it came from a different application. Beyond the chrome, the migration collapses variation that had accumulated:

- Destructive confirms were red in **five different spellings** across 14 sites (`Colors.red`, `colorScheme.error`, an `ElevatedButton` with a hand-written white label, a `TextButton` with red text). All now `AppButtonVariant.destructive`.
- Nine dialogs used a `SizedBox` purely to work around `AlertDialog`'s intrinsic-width layout. Those wrappers are gone; width is a `maxWidth` on the shell.
- Six composite "icon + text" headings became the shell's `icon`/`title`/`subtitle`. Only three still need `titleWidget`, each for a real reason (a live indicator, a close button, a tinted icon tile).

## Decisions worth a look

- **Dialog radius is 12**, matching `PanelCard`/`AppCard`, rather than the 24 the hand-rolled dialogs had drifted to. Settled deliberately before 30 files baked in the other answer.
- **`AppDialog` insets itself 12px on phones** instead of Material's 40. That default cost a 390pt screen a fifth of its width — on every dialog at once, so the shell owns it rather than each call site.
- **Not migrated, on purpose**: `media_preview_dialog` and the markdown editor's phone pop-out stay `Dialog.fullscreen` (an immersive black viewer shouldn't inherit dialog chrome; a full-screen editor shouldn't be inset). The two `showGeneralDialog` slide-in side panels are duplicated chrome of a *different* shape and want their own shell — worth a follow-up `AppSidePanel`.

## Fixed in passing

`mask_editor_toolbar`'s slider dialog had the same defect as the thumbnail one — the value declared *inside* the `StatefulBuilder`, so each rebuild reinitialised it and the handle sprang back while the brush kept changing. The pattern had been copy-pasted; the other three slider dialogs read from state and were already fine.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 348 pass, including 16 new `AppDialog` capability tests (bounded height, scrollable, full-bleed content, `actionsOverride`, heading slots)
- [x] `grep` confirms zero `AlertDialog(` left in `lib/`
- [ ] **Needs a real run**: dialogs are hard to assert on visually. Worth opening a few by hand — the channel wizard (fixed height across steps), model discovery (list under a bounded height), and any delete confirm (destructive button) are the ones most likely to show a layout problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)