### PR TITLE
refactor(ui): rebuild the Prompt Assistant to the new design

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1213,5 +1213,89 @@
   "optAskUserOtherHint": "Other / add details...",
   "optAskUserConfirm": "Send answers",
   "optAskUserAnswered": "Answered",
-  "optAskUserDismissed": "Continued in chat"
+  "optAskUserDismissed": "Continued in chat",
+  "optAgentSteps": "Agent process · {count} steps",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "viewed {count} reference images",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "read {count} documents",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "Show all {count} steps",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "Collapse steps",
+  "optPromptExpand": "Show full text",
+  "optPromptCollapse": "Collapse",
+  "optKbReady": "Ready",
+  "optKbTreeStats": "{files} documents · {dirs} folders",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "Content updated {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "Rescan",
+  "optKbCitedThisRound": "Cited this round",
+  "optKbCitedAll": "All {count}",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "Nothing cited yet",
+  "optAttachedImages": "{count} reference images sent with the message",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter to send · Shift+Enter for a new line",
+  "optModeBadgeAgent": "{mode} · Agent",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "Numbers match the filenames cited in the prompt; the agent can view these images."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1297,5 +1297,6 @@
       }
     }
   },
-  "optRefNumberingHint": "Numbers match the filenames cited in the prompt; the agent can view these images."
+  "optRefNumberingHint": "Numbers match the filenames cited in the prompt; the agent can view these images.",
+  "optModeKnowledgeEditShort": "Edit KB"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -806,6 +806,9 @@
   "sendToComparator": "比較ツールに送信",
   "sendToComparatorRaw": "Before (RAW) として設定",
   "sendToComparatorAfter": "After (結果) として設定",
+  "sendToFirstFrame": "動画の最初のフレームに設定",
+  "sendToLastFrame": "動画の最後のフレームに設定",
+  "sendToVideoReferences": "動画の参照画像に追加",
   "sendToSelection": "選択に追加",
   "sendToOptimizer": "プロンプトアシスタントに送信",
   "optimizePromptWithImage": "画像からプロンプトを最適化",
@@ -1070,5 +1073,89 @@
   "optAskUserOtherHint": "その他 / 補足...",
   "optAskUserConfirm": "回答を送信",
   "optAskUserAnswered": "回答済み",
-  "optAskUserDismissed": "チャットで継続"
+  "optAskUserDismissed": "チャットで継続",
+  "optAgentSteps": "エージェント処理 · {count} ステップ",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "参照画像 {count} 枚を確認",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "ドキュメント {count} 件を読了",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "全 {count} ステップを表示",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "ステップを折りたたむ",
+  "optPromptExpand": "全文を表示",
+  "optPromptCollapse": "折りたたむ",
+  "optKbReady": "初期化済み",
+  "optKbTreeStats": "ドキュメント {files} 件 · フォルダ {dirs} 個",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "内容更新 {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "再スキャン",
+  "optKbCitedThisRound": "今回の参照",
+  "optKbCitedAll": "全 {count} 件",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "参照はまだありません",
+  "optAttachedImages": "参照画像 {count} 枚をメッセージと共に送信",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter で送信 · Shift+Enter で改行",
+  "optModeBadgeAgent": "{mode} · エージェント",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1157,5 +1157,6 @@
       }
     }
   },
-  "optRefNumberingHint": "番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。"
+  "optRefNumberingHint": "番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。",
+  "optModeKnowledgeEditShort": "ナレッジ編集"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4414,6 +4414,114 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Continued in chat'**
   String get optAskUserDismissed;
+
+  /// No description provided for @optAgentSteps.
+  ///
+  /// In en, this message translates to:
+  /// **'Agent process · {count} steps'**
+  String optAgentSteps(int count);
+
+  /// No description provided for @optAgentStepsImages.
+  ///
+  /// In en, this message translates to:
+  /// **'viewed {count} reference images'**
+  String optAgentStepsImages(int count);
+
+  /// No description provided for @optAgentStepsDocs.
+  ///
+  /// In en, this message translates to:
+  /// **'read {count} documents'**
+  String optAgentStepsDocs(int count);
+
+  /// No description provided for @optAgentStepsExpand.
+  ///
+  /// In en, this message translates to:
+  /// **'Show all {count} steps'**
+  String optAgentStepsExpand(int count);
+
+  /// No description provided for @optAgentStepsCollapse.
+  ///
+  /// In en, this message translates to:
+  /// **'Collapse steps'**
+  String get optAgentStepsCollapse;
+
+  /// No description provided for @optPromptExpand.
+  ///
+  /// In en, this message translates to:
+  /// **'Show full text'**
+  String get optPromptExpand;
+
+  /// No description provided for @optPromptCollapse.
+  ///
+  /// In en, this message translates to:
+  /// **'Collapse'**
+  String get optPromptCollapse;
+
+  /// No description provided for @optKbReady.
+  ///
+  /// In en, this message translates to:
+  /// **'Ready'**
+  String get optKbReady;
+
+  /// No description provided for @optKbTreeStats.
+  ///
+  /// In en, this message translates to:
+  /// **'{files} documents · {dirs} folders'**
+  String optKbTreeStats(int files, int dirs);
+
+  /// No description provided for @optKbContentUpdated.
+  ///
+  /// In en, this message translates to:
+  /// **'Content updated {time}'**
+  String optKbContentUpdated(String time);
+
+  /// No description provided for @optKbRescan.
+  ///
+  /// In en, this message translates to:
+  /// **'Rescan'**
+  String get optKbRescan;
+
+  /// No description provided for @optKbCitedThisRound.
+  ///
+  /// In en, this message translates to:
+  /// **'Cited this round'**
+  String get optKbCitedThisRound;
+
+  /// No description provided for @optKbCitedAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All {count}'**
+  String optKbCitedAll(int count);
+
+  /// No description provided for @optKbCitedNone.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing cited yet'**
+  String get optKbCitedNone;
+
+  /// No description provided for @optAttachedImages.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} reference images sent with the message'**
+  String optAttachedImages(int count);
+
+  /// No description provided for @optSendHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter to send · Shift+Enter for a new line'**
+  String get optSendHint;
+
+  /// No description provided for @optModeBadgeAgent.
+  ///
+  /// In en, this message translates to:
+  /// **'{mode} · Agent'**
+  String optModeBadgeAgent(String mode);
+
+  /// No description provided for @optRefNumberingHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Numbers match the filenames cited in the prompt; the agent can view these images.'**
+  String get optRefNumberingHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4522,6 +4522,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Numbers match the filenames cited in the prompt; the agent can view these images.'**
   String get optRefNumberingHint;
+
+  /// No description provided for @optModeKnowledgeEditShort.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit KB'**
+  String get optModeKnowledgeEditShort;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2382,4 +2382,77 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get optAskUserDismissed => 'Continued in chat';
+
+  @override
+  String optAgentSteps(int count) {
+    return 'Agent process · $count steps';
+  }
+
+  @override
+  String optAgentStepsImages(int count) {
+    return 'viewed $count reference images';
+  }
+
+  @override
+  String optAgentStepsDocs(int count) {
+    return 'read $count documents';
+  }
+
+  @override
+  String optAgentStepsExpand(int count) {
+    return 'Show all $count steps';
+  }
+
+  @override
+  String get optAgentStepsCollapse => 'Collapse steps';
+
+  @override
+  String get optPromptExpand => 'Show full text';
+
+  @override
+  String get optPromptCollapse => 'Collapse';
+
+  @override
+  String get optKbReady => 'Ready';
+
+  @override
+  String optKbTreeStats(int files, int dirs) {
+    return '$files documents · $dirs folders';
+  }
+
+  @override
+  String optKbContentUpdated(String time) {
+    return 'Content updated $time';
+  }
+
+  @override
+  String get optKbRescan => 'Rescan';
+
+  @override
+  String get optKbCitedThisRound => 'Cited this round';
+
+  @override
+  String optKbCitedAll(int count) {
+    return 'All $count';
+  }
+
+  @override
+  String get optKbCitedNone => 'Nothing cited yet';
+
+  @override
+  String optAttachedImages(int count) {
+    return '$count reference images sent with the message';
+  }
+
+  @override
+  String get optSendHint => 'Enter to send · Shift+Enter for a new line';
+
+  @override
+  String optModeBadgeAgent(String mode) {
+    return '$mode · Agent';
+  }
+
+  @override
+  String get optRefNumberingHint =>
+      'Numbers match the filenames cited in the prompt; the agent can view these images.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2455,4 +2455,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get optRefNumberingHint =>
       'Numbers match the filenames cited in the prompt; the agent can view these images.';
+
+  @override
+  String get optModeKnowledgeEditShort => 'Edit KB';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2403,4 +2403,7 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get optRefNumberingHint =>
       '番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。';
+
+  @override
+  String get optModeKnowledgeEditShort => 'ナレッジ編集';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1854,13 +1854,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sendToComparatorAfter => 'After (結果) として設定';
 
   @override
-  String get sendToFirstFrame => 'Set as First Frame (Video)';
+  String get sendToFirstFrame => '動画の最初のフレームに設定';
 
   @override
-  String get sendToLastFrame => 'Set as Last Frame (Video)';
+  String get sendToLastFrame => '動画の最後のフレームに設定';
 
   @override
-  String get sendToVideoReferences => 'Add to Video References';
+  String get sendToVideoReferences => '動画の参照画像に追加';
 
   @override
   String get sendToSelection => '選択に追加';
@@ -2330,4 +2330,77 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get optAskUserDismissed => 'チャットで継続';
+
+  @override
+  String optAgentSteps(int count) {
+    return 'エージェント処理 · $count ステップ';
+  }
+
+  @override
+  String optAgentStepsImages(int count) {
+    return '参照画像 $count 枚を確認';
+  }
+
+  @override
+  String optAgentStepsDocs(int count) {
+    return 'ドキュメント $count 件を読了';
+  }
+
+  @override
+  String optAgentStepsExpand(int count) {
+    return '全 $count ステップを表示';
+  }
+
+  @override
+  String get optAgentStepsCollapse => 'ステップを折りたたむ';
+
+  @override
+  String get optPromptExpand => '全文を表示';
+
+  @override
+  String get optPromptCollapse => '折りたたむ';
+
+  @override
+  String get optKbReady => '初期化済み';
+
+  @override
+  String optKbTreeStats(int files, int dirs) {
+    return 'ドキュメント $files 件 · フォルダ $dirs 個';
+  }
+
+  @override
+  String optKbContentUpdated(String time) {
+    return '内容更新 $time';
+  }
+
+  @override
+  String get optKbRescan => '再スキャン';
+
+  @override
+  String get optKbCitedThisRound => '今回の参照';
+
+  @override
+  String optKbCitedAll(int count) {
+    return '全 $count 件';
+  }
+
+  @override
+  String get optKbCitedNone => '参照はまだありません';
+
+  @override
+  String optAttachedImages(int count) {
+    return '参照画像 $count 枚をメッセージと共に送信';
+  }
+
+  @override
+  String get optSendHint => 'Enter で送信 · Shift+Enter で改行';
+
+  @override
+  String optModeBadgeAgent(String mode) {
+    return '$mode · エージェント';
+  }
+
+  @override
+  String get optRefNumberingHint =>
+      '番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2385,6 +2385,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get optRefNumberingHint => '序号与提示词中引用的文件名对应，agent 可查看这些图片。';
+
+  @override
+  String get optModeKnowledgeEditShort => '库编辑';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -4765,4 +4768,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get optRefNumberingHint => '序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。';
+
+  @override
+  String get optModeKnowledgeEditShort => '庫編輯';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2313,6 +2313,78 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get optAskUserDismissed => '已在对话中继续';
+
+  @override
+  String optAgentSteps(int count) {
+    return 'Agent 过程 · $count 步';
+  }
+
+  @override
+  String optAgentStepsImages(int count) {
+    return '查看 $count 张参考图';
+  }
+
+  @override
+  String optAgentStepsDocs(int count) {
+    return '阅读 $count 篇文档';
+  }
+
+  @override
+  String optAgentStepsExpand(int count) {
+    return '展开全部 $count 步';
+  }
+
+  @override
+  String get optAgentStepsCollapse => '收起步骤';
+
+  @override
+  String get optPromptExpand => '展开全文';
+
+  @override
+  String get optPromptCollapse => '收起';
+
+  @override
+  String get optKbReady => '已初始化';
+
+  @override
+  String optKbTreeStats(int files, int dirs) {
+    return '$files 篇文档 · $dirs 个目录';
+  }
+
+  @override
+  String optKbContentUpdated(String time) {
+    return '内容更新于 $time';
+  }
+
+  @override
+  String get optKbRescan => '重新扫描';
+
+  @override
+  String get optKbCitedThisRound => '本轮引用';
+
+  @override
+  String optKbCitedAll(int count) {
+    return '全部 $count 篇';
+  }
+
+  @override
+  String get optKbCitedNone => '尚无引用';
+
+  @override
+  String optAttachedImages(int count) {
+    return '$count 张参考图随消息发送';
+  }
+
+  @override
+  String get optSendHint => 'Enter 发送 · Shift+Enter 换行';
+
+  @override
+  String optModeBadgeAgent(String mode) {
+    return '$mode · Agent';
+  }
+
+  @override
+  String get optRefNumberingHint => '序号与提示词中引用的文件名对应，agent 可查看这些图片。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -4148,6 +4220,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get sendToComparatorAfter => '設為處理後 (Result)';
 
   @override
+  String get sendToFirstFrame => '設為影片首格';
+
+  @override
+  String get sendToLastFrame => '設為影片末格';
+
+  @override
+  String get sendToVideoReferences => '加入影片參考圖';
+
+  @override
   String get sendToSelection => '新增至選取項目';
 
   @override
@@ -4612,4 +4693,76 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get optAskUserDismissed => '已在對話中繼續';
+
+  @override
+  String optAgentSteps(int count) {
+    return 'Agent 過程 · $count 步';
+  }
+
+  @override
+  String optAgentStepsImages(int count) {
+    return '檢視 $count 張參考圖';
+  }
+
+  @override
+  String optAgentStepsDocs(int count) {
+    return '閱讀 $count 篇文件';
+  }
+
+  @override
+  String optAgentStepsExpand(int count) {
+    return '展開全部 $count 步';
+  }
+
+  @override
+  String get optAgentStepsCollapse => '收合步驟';
+
+  @override
+  String get optPromptExpand => '展開全文';
+
+  @override
+  String get optPromptCollapse => '收合';
+
+  @override
+  String get optKbReady => '已初始化';
+
+  @override
+  String optKbTreeStats(int files, int dirs) {
+    return '$files 篇文件 · $dirs 個目錄';
+  }
+
+  @override
+  String optKbContentUpdated(String time) {
+    return '內容更新於 $time';
+  }
+
+  @override
+  String get optKbRescan => '重新掃描';
+
+  @override
+  String get optKbCitedThisRound => '本輪引用';
+
+  @override
+  String optKbCitedAll(int count) {
+    return '全部 $count 篇';
+  }
+
+  @override
+  String get optKbCitedNone => '尚無引用';
+
+  @override
+  String optAttachedImages(int count) {
+    return '$count 張參考圖隨訊息傳送';
+  }
+
+  @override
+  String get optSendHint => 'Enter 傳送 · Shift+Enter 換行';
+
+  @override
+  String optModeBadgeAgent(String mode) {
+    return '$mode · Agent';
+  }
+
+  @override
+  String get optRefNumberingHint => '序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1199,5 +1199,89 @@
   "optAskUserOtherHint": "其他 / 补充说明...",
   "optAskUserConfirm": "发送回答",
   "optAskUserAnswered": "已回答",
-  "optAskUserDismissed": "已在对话中继续"
+  "optAskUserDismissed": "已在对话中继续",
+  "optAgentSteps": "Agent 过程 · {count} 步",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "查看 {count} 张参考图",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "阅读 {count} 篇文档",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "展开全部 {count} 步",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "收起步骤",
+  "optPromptExpand": "展开全文",
+  "optPromptCollapse": "收起",
+  "optKbReady": "已初始化",
+  "optKbTreeStats": "{files} 篇文档 · {dirs} 个目录",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "内容更新于 {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "重新扫描",
+  "optKbCitedThisRound": "本轮引用",
+  "optKbCitedAll": "全部 {count} 篇",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "尚无引用",
+  "optAttachedImages": "{count} 张参考图随消息发送",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter 发送 · Shift+Enter 换行",
+  "optModeBadgeAgent": "{mode} · Agent",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "序号与提示词中引用的文件名对应，agent 可查看这些图片。"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1283,5 +1283,6 @@
       }
     }
   },
-  "optRefNumberingHint": "序号与提示词中引用的文件名对应，agent 可查看这些图片。"
+  "optRefNumberingHint": "序号与提示词中引用的文件名对应，agent 可查看这些图片。",
+  "optModeKnowledgeEditShort": "库编辑"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -806,6 +806,9 @@
   "sendToComparator": "發送到比較器",
   "sendToComparatorRaw": "設為原始圖 (RAW)",
   "sendToComparatorAfter": "設為處理後 (Result)",
+  "sendToFirstFrame": "設為影片首格",
+  "sendToLastFrame": "設為影片末格",
+  "sendToVideoReferences": "加入影片參考圖",
   "sendToSelection": "新增至選取項目",
   "sendToOptimizer": "發送到提示詞助手",
   "optimizePromptWithImage": "使用圖片優化提示詞",
@@ -1070,5 +1073,89 @@
   "optAskUserOtherHint": "其他 / 補充說明...",
   "optAskUserConfirm": "送出回答",
   "optAskUserAnswered": "已回答",
-  "optAskUserDismissed": "已在對話中繼續"
+  "optAskUserDismissed": "已在對話中繼續",
+  "optAgentSteps": "Agent 過程 · {count} 步",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "檢視 {count} 張參考圖",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "閱讀 {count} 篇文件",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "展開全部 {count} 步",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "收合步驟",
+  "optPromptExpand": "展開全文",
+  "optPromptCollapse": "收合",
+  "optKbReady": "已初始化",
+  "optKbTreeStats": "{files} 篇文件 · {dirs} 個目錄",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "內容更新於 {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "重新掃描",
+  "optKbCitedThisRound": "本輪引用",
+  "optKbCitedAll": "全部 {count} 篇",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "尚無引用",
+  "optAttachedImages": "{count} 張參考圖隨訊息傳送",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter 傳送 · Shift+Enter 換行",
+  "optModeBadgeAgent": "{mode} · Agent",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1157,5 +1157,6 @@
       }
     }
   },
-  "optRefNumberingHint": "序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。"
+  "optRefNumberingHint": "序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。",
+  "optModeKnowledgeEditShort": "庫編輯"
 }

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -404,5 +404,89 @@
   "optAskUserOtherHint": "Other / add details...",
   "optAskUserConfirm": "Send answers",
   "optAskUserAnswered": "Answered",
-  "optAskUserDismissed": "Continued in chat"
+  "optAskUserDismissed": "Continued in chat",
+  "optAgentSteps": "Agent process · {count} steps",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "viewed {count} reference images",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "read {count} documents",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "Show all {count} steps",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "Collapse steps",
+  "optPromptExpand": "Show full text",
+  "optPromptCollapse": "Collapse",
+  "optKbReady": "Ready",
+  "optKbTreeStats": "{files} documents · {dirs} folders",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "Content updated {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "Rescan",
+  "optKbCitedThisRound": "Cited this round",
+  "optKbCitedAll": "All {count}",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "Nothing cited yet",
+  "optAttachedImages": "{count} reference images sent with the message",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter to send · Shift+Enter for a new line",
+  "optModeBadgeAgent": "{mode} · Agent",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "Numbers match the filenames cited in the prompt; the agent can view these images."
 }

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -488,5 +488,6 @@
       }
     }
   },
-  "optRefNumberingHint": "Numbers match the filenames cited in the prompt; the agent can view these images."
+  "optRefNumberingHint": "Numbers match the filenames cited in the prompt; the agent can view these images.",
+  "optModeKnowledgeEditShort": "Edit KB"
 }

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -488,5 +488,6 @@
       }
     }
   },
-  "optRefNumberingHint": "番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。"
+  "optRefNumberingHint": "番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。",
+  "optModeKnowledgeEditShort": "ナレッジ編集"
 }

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -137,6 +137,9 @@
   "sendToComparator": "比較ツールに送信",
   "sendToComparatorRaw": "Before (RAW) として設定",
   "sendToComparatorAfter": "After (結果) として設定",
+  "sendToFirstFrame": "動画の最初のフレームに設定",
+  "sendToLastFrame": "動画の最後のフレームに設定",
+  "sendToVideoReferences": "動画の参照画像に追加",
   "sendToSelection": "選択に追加",
   "sendToOptimizer": "プロンプトアシスタントに送信",
   "optimizePromptWithImage": "画像からプロンプトを最適化",
@@ -401,5 +404,89 @@
   "optAskUserOtherHint": "その他 / 補足...",
   "optAskUserConfirm": "回答を送信",
   "optAskUserAnswered": "回答済み",
-  "optAskUserDismissed": "チャットで継続"
+  "optAskUserDismissed": "チャットで継続",
+  "optAgentSteps": "エージェント処理 · {count} ステップ",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "参照画像 {count} 枚を確認",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "ドキュメント {count} 件を読了",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "全 {count} ステップを表示",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "ステップを折りたたむ",
+  "optPromptExpand": "全文を表示",
+  "optPromptCollapse": "折りたたむ",
+  "optKbReady": "初期化済み",
+  "optKbTreeStats": "ドキュメント {files} 件 · フォルダ {dirs} 個",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "内容更新 {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "再スキャン",
+  "optKbCitedThisRound": "今回の参照",
+  "optKbCitedAll": "全 {count} 件",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "参照はまだありません",
+  "optAttachedImages": "参照画像 {count} 枚をメッセージと共に送信",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter で送信 · Shift+Enter で改行",
+  "optModeBadgeAgent": "{mode} · エージェント",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "番号はプロンプトで引用されるファイル名に対応します。エージェントはこれらの画像を参照できます。"
 }

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -488,5 +488,6 @@
       }
     }
   },
-  "optRefNumberingHint": "序号与提示词中引用的文件名对应，agent 可查看这些图片。"
+  "optRefNumberingHint": "序号与提示词中引用的文件名对应，agent 可查看这些图片。",
+  "optModeKnowledgeEditShort": "库编辑"
 }

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -404,5 +404,89 @@
   "optAskUserOtherHint": "其他 / 补充说明...",
   "optAskUserConfirm": "发送回答",
   "optAskUserAnswered": "已回答",
-  "optAskUserDismissed": "已在对话中继续"
+  "optAskUserDismissed": "已在对话中继续",
+  "optAgentSteps": "Agent 过程 · {count} 步",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "查看 {count} 张参考图",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "阅读 {count} 篇文档",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "展开全部 {count} 步",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "收起步骤",
+  "optPromptExpand": "展开全文",
+  "optPromptCollapse": "收起",
+  "optKbReady": "已初始化",
+  "optKbTreeStats": "{files} 篇文档 · {dirs} 个目录",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "内容更新于 {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "重新扫描",
+  "optKbCitedThisRound": "本轮引用",
+  "optKbCitedAll": "全部 {count} 篇",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "尚无引用",
+  "optAttachedImages": "{count} 张参考图随消息发送",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter 发送 · Shift+Enter 换行",
+  "optModeBadgeAgent": "{mode} · Agent",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "序号与提示词中引用的文件名对应，agent 可查看这些图片。"
 }

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -488,5 +488,6 @@
       }
     }
   },
-  "optRefNumberingHint": "序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。"
+  "optRefNumberingHint": "序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。",
+  "optModeKnowledgeEditShort": "庫編輯"
 }

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -137,6 +137,9 @@
   "sendToComparator": "發送到比較器",
   "sendToComparatorRaw": "設為原始圖 (RAW)",
   "sendToComparatorAfter": "設為處理後 (Result)",
+  "sendToFirstFrame": "設為影片首格",
+  "sendToLastFrame": "設為影片末格",
+  "sendToVideoReferences": "加入影片參考圖",
   "sendToSelection": "新增至選取項目",
   "sendToOptimizer": "發送到提示詞助手",
   "optimizePromptWithImage": "使用圖片優化提示詞",
@@ -401,5 +404,89 @@
   "optAskUserOtherHint": "其他 / 補充說明...",
   "optAskUserConfirm": "送出回答",
   "optAskUserAnswered": "已回答",
-  "optAskUserDismissed": "已在對話中繼續"
+  "optAskUserDismissed": "已在對話中繼續",
+  "optAgentSteps": "Agent 過程 · {count} 步",
+  "@optAgentSteps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsImages": "檢視 {count} 張參考圖",
+  "@optAgentStepsImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsDocs": "閱讀 {count} 篇文件",
+  "@optAgentStepsDocs": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsExpand": "展開全部 {count} 步",
+  "@optAgentStepsExpand": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optAgentStepsCollapse": "收合步驟",
+  "optPromptExpand": "展開全文",
+  "optPromptCollapse": "收合",
+  "optKbReady": "已初始化",
+  "optKbTreeStats": "{files} 篇文件 · {dirs} 個目錄",
+  "@optKbTreeStats": {
+    "placeholders": {
+      "files": {
+        "type": "int"
+      },
+      "dirs": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbContentUpdated": "內容更新於 {time}",
+  "@optKbContentUpdated": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "optKbRescan": "重新掃描",
+  "optKbCitedThisRound": "本輪引用",
+  "optKbCitedAll": "全部 {count} 篇",
+  "@optKbCitedAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optKbCitedNone": "尚無引用",
+  "optAttachedImages": "{count} 張參考圖隨訊息傳送",
+  "@optAttachedImages": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "optSendHint": "Enter 傳送 · Shift+Enter 換行",
+  "optModeBadgeAgent": "{mode} · Agent",
+  "@optModeBadgeAgent": {
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      }
+    }
+  },
+  "optRefNumberingHint": "序號與提示詞中引用的檔名對應，agent 可檢視這些圖片。"
 }

--- a/lib/screens/workbench/widgets/optimizer_config_panel.dart
+++ b/lib/screens/workbench/widgets/optimizer_config_panel.dart
@@ -4,9 +4,13 @@ import 'package:provider/provider.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/prompt.dart';
 import '../../../models/tag.dart';
+import '../../../core/file_utils.dart';
 import '../../../services/knowledge_base_service.dart';
 import '../../../services/prompt_optimizer_agent.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_card.dart';
+import '../../../widgets/app_icon_button.dart';
 import '../../../widgets/app_segmented_control.dart';
 import '../../../widgets/chat_model_selector.dart';
 import 'config_section_header.dart';
@@ -21,6 +25,11 @@ class OptimizerConfigPanel extends StatefulWidget {
   final String? kbPath;
   final List<PromptTag> tags;
   final List<SystemPrompt> filteredSysPrompts;
+
+  /// Knowledge files the current answer rests on, newest turn first. Passed in
+  /// rather than read from the session here, so this panel stays
+  /// presentational and testable without the workbench's providers.
+  final List<String> citedKnowledgeFiles;
   final Function(int?) onModelChanged;
   final Function(int?) onTagChanged;
   final Function(String?) onSysPromptChanged;
@@ -44,6 +53,7 @@ class OptimizerConfigPanel extends StatefulWidget {
     this.kbPath,
     required this.tags,
     required this.filteredSysPrompts,
+    this.citedKnowledgeFiles = const [],
     required this.onModelChanged,
     required this.onTagChanged,
     required this.onSysPromptChanged,
@@ -61,12 +71,21 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
   late final TextEditingController _customCtrl;
   bool _scaffolding = false;
 
+  /// What the knowledge base holds, as of the last scan. Null while scanning
+  /// for the first time.
+  KbTreeStats? _kbStats;
+  bool _scanning = false;
+
+  /// Cited files listed before the "all N" link takes over.
+  static const int _citedPreviewCount = 3;
+
   @override
   void initState() {
     super.initState();
     _customCtrl = TextEditingController(
       text: widget.useCustomSysPrompt ? widget.selectedSysPrompt ?? '' : '',
     );
+    _loadKbStats();
   }
 
   @override
@@ -75,6 +94,36 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
     // When switching into custom mode, pre-populate with the current sys prompt.
     if (widget.useCustomSysPrompt && !old.useCustomSysPrompt) {
       _customCtrl.text = widget.selectedSysPrompt ?? '';
+    }
+    // A newly configured or repaired base has different contents to count.
+    if (widget.kbPath != old.kbPath || widget.kbStatus != old.kbStatus) {
+      _loadKbStats();
+    }
+  }
+
+  /// Counts the tree off the build path.
+  ///
+  /// [KnowledgeBaseService.scanTree] is synchronous file IO; a large base
+  /// walked during build would drop frames. There is nothing to invalidate
+  /// here — the count is only ever as fresh as its last run, which is exactly
+  /// what the card claims.
+  Future<void> _loadKbStats() async {
+    final root = widget.kbPath;
+    if (root == null || widget.kbStatus != KbStatus.ok) {
+      if (mounted) setState(() => _kbStats = null);
+      return;
+    }
+
+    setState(() => _scanning = true);
+    try {
+      final stats = await Future(() => KnowledgeBaseService().scanTree(root));
+      if (mounted) setState(() => _kbStats = stats);
+    } catch (_) {
+      // A folder that vanished mid-scan is already reported by kbStatus; the
+      // card simply shows no counts rather than an error of its own.
+      if (mounted) setState(() => _kbStats = null);
+    } finally {
+      if (mounted) setState(() => _scanning = false);
     }
   }
 
@@ -110,10 +159,21 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
       ],
     );
 
-    return SingleChildScrollView(
-      controller: widget.scrollController,
-      padding: const EdgeInsets.all(16),
-      child: content,
+    // Expanded inside a Column, not a bare SingleChildScrollView: on its own
+    // the scroll view shrink-wraps to its content, and the panel card then
+    // shrinks with it and floats in the middle of the canvas. The column
+    // claims the full height the card offers and lets the body scroll inside
+    // it.
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            controller: widget.scrollController,
+            padding: const EdgeInsets.all(16),
+            child: content,
+          ),
+        ),
+      ],
     );
   }
 
@@ -148,88 +208,238 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
 
   Widget _buildKnowledgeStatus(AppLocalizations l10n, ColorScheme colorScheme) {
     final ok = widget.kbStatus == KbStatus.ok;
-    final String text;
+    final textTheme = Theme.of(context).textTheme;
+
+    final String problem;
     switch (widget.kbStatus) {
       case KbStatus.ok:
-        text = widget.kbPath ?? '';
+        problem = '';
       case KbStatus.notSet:
-        text = l10n.optKbNotConfigured;
+        problem = l10n.optKbNotConfigured;
       case KbStatus.missingDir:
-        text = l10n.kbInvalidDir;
+        problem = l10n.kbInvalidDir;
       case KbStatus.missingEntry:
-        text = l10n.kbMissingEntry;
+        problem = l10n.kbMissingEntry;
     }
+
     return Padding(
       padding: const EdgeInsets.only(top: 16),
-      child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: ok
-              ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.5)
-              : colorScheme.errorContainer.withValues(alpha: 0.4),
-          borderRadius: BorderRadius.circular(8),
-        ),
+      child: AppCard(
+        outlined: true,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
             Row(
               children: [
                 Icon(
                   ok ? Icons.menu_book_outlined : Icons.warning_amber_outlined,
                   size: 16,
-                  color: ok ? colorScheme.primary : colorScheme.error,
+                  color: ok ? colorScheme.onSurfaceVariant : colorScheme.error,
                 ),
                 const SizedBox(width: 8),
-                Text(
-                  l10n.knowledgeBase,
-                  style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold, color: colorScheme.onSurfaceVariant),
-                ),
+                Expanded(child: Text(l10n.knowledgeBase, style: textTheme.titleSmall)),
+                if (ok) _buildReadyPill(l10n, colorScheme, textTheme),
               ],
             ),
-            const SizedBox(height: 6),
-            Text(
-              text,
-              style: TextStyle(
-                fontSize: 11,
-                color: ok ? colorScheme.onSurfaceVariant : colorScheme.error,
+            const SizedBox(height: 10),
+            if (!ok)
+              Text(problem, style: textTheme.bodySmall?.copyWith(color: colorScheme.error))
+            else ...[
+              // The folder, in a code-ish chip: it is a path, and paths read
+              // badly as prose at the end of a wrapped sentence.
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  widget.kbPath ?? '',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                    fontFamily: 'monospace',
+                  ),
+                ),
               ),
-            ),
-            const SizedBox(height: 8),
-            // Disabled once the base has an entry file: initializing is a
-            // one-time act, and KbStatus.ok means one is already there. Shown
-            // disabled rather than hidden so the action stays discoverable and
-            // its unavailability is explained. KnowledgeBaseStarter.scaffold
-            // refuses independently — this is only the first gate.
-            Align(
-              alignment: Alignment.centerLeft,
-              child: _scaffolding
-                  ? const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 6),
-                      child: SizedBox(
-                        width: 14,
-                        height: 14,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                    )
-                  : Tooltip(
-                      message: ok
-                          ? l10n.kbScaffoldAlreadyInit(KnowledgeBaseService.entryFileName)
-                          : '',
-                      child: FilledButton.tonalIcon(
-                        onPressed: ok ? null : _handleScaffold,
-                        icon: const Icon(Icons.auto_awesome_outlined, size: 15),
-                        label: Text(l10n.kbScaffoldCreate, style: const TextStyle(fontSize: 11)),
-                        style: FilledButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(horizontal: 12),
-                          minimumSize: const Size(0, 32),
-                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        ),
-                      ),
-                    ),
-            ),
+              const SizedBox(height: 8),
+              _buildTreeStatsLine(l10n, colorScheme, textTheme),
+            ],
+            const SizedBox(height: 10),
+            _buildKbActions(l10n, ok),
+            if (ok) _buildCitedThisRound(l10n, colorScheme, textTheme),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildReadyPill(AppLocalizations l10n, ColorScheme colorScheme, TextTheme textTheme) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 7,
+          height: 7,
+          decoration: BoxDecoration(color: colorScheme.primary, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 6),
+        Text(
+          l10n.optKbReady,
+          style: textTheme.labelMedium?.copyWith(color: colorScheme.primary),
+        ),
+      ],
+    );
+  }
+
+  /// How much the assistant can see, and how fresh it is.
+  ///
+  /// Deliberately "content updated", not "last indexed": there is no index.
+  /// The service reads the folder on every call, so the only thing that can
+  /// be stale is this card — and the question the user is actually asking is
+  /// whether the edit they just made will be picked up, which the newest file
+  /// timestamp answers directly.
+  Widget _buildTreeStatsLine(
+    AppLocalizations l10n,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    final stats = _kbStats;
+    // Nothing rather than a spinner while there are no counts. A scan that
+    // fails — an unreadable folder, a path that moved — would otherwise leave
+    // an indeterminate spinner turning forever, which reads as a hung app
+    // when the truth is simply that there is nothing to report. The rescan
+    // button carries the progress instead, where it resolves.
+    if (stats == null) return const SizedBox.shrink();
+
+    final updated = stats.newestModified;
+    final parts = [
+      l10n.optKbTreeStats(stats.files, stats.directories),
+      if (updated != null) l10n.optKbContentUpdated(_formatStamp(updated)),
+    ];
+
+    return Text(
+      parts.join(' · '),
+      style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+    );
+  }
+
+  /// `HH:mm` while it is today's date, `MM-DD HH:mm` once it is not — a bare
+  /// clock time on a three-day-old file reads as "just now".
+  String _formatStamp(DateTime when) {
+    String two(int v) => v.toString().padLeft(2, '0');
+    final now = DateTime.now();
+    final clock = '${two(when.hour)}:${two(when.minute)}';
+    final sameDay = when.year == now.year && when.month == now.month && when.day == now.day;
+    return sameDay ? clock : '${two(when.month)}-${two(when.day)} $clock';
+  }
+
+  Widget _buildKbActions(AppLocalizations l10n, bool ok) {
+    if (_scaffolding) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 6),
+        child: SizedBox(width: 14, height: 14, child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+
+    // Wrap, not Row: the panel narrows to 250px and these are three controls
+    // with labels.
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        // Kept visible and disabled once the base has an entry file, rather
+        // than hidden: initializing is a one-time act, and an action that
+        // silently disappears leaves the user wondering where it went. The
+        // tooltip says why it is off. KnowledgeBaseStarter.scaffold refuses
+        // independently — this is only the first gate.
+        Tooltip(
+          message: ok ? l10n.kbScaffoldAlreadyInit(KnowledgeBaseService.entryFileName) : '',
+          child: AppButton(
+            label: l10n.kbScaffoldCreate,
+            icon: Icons.auto_awesome_outlined,
+            variant: AppButtonVariant.secondary,
+            onPressed: ok ? null : _handleScaffold,
+          ),
+        ),
+        if (ok) ...[
+          AppButton(
+            label: l10n.optKbRescan,
+            icon: Icons.refresh,
+            variant: AppButtonVariant.text,
+            loading: _scanning,
+            onPressed: _loadKbStats,
+          ),
+          AppIconButton(
+            icon: Icons.folder_open_outlined,
+            tooltip: l10n.openInFolder,
+            size: 34,
+            onPressed: widget.kbPath == null ? null : () => FileUtils.openPath(widget.kbPath!),
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// The documents holding up the answer on screen.
+  ///
+  /// Derived from the session's own history rather than tracked, so it cannot
+  /// drift from what was actually sent — see
+  /// [PromptOptimizerAgent.citedKnowledgeFiles].
+  Widget _buildCitedThisRound(
+    AppLocalizations l10n,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    final cited = widget.citedKnowledgeFiles;
+    final shown = cited.take(_citedPreviewCount).toList();
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(l10n.optKbCitedThisRound, style: textTheme.titleSmall),
+          const SizedBox(height: 6),
+          if (cited.isEmpty)
+            Text(
+              l10n.optKbCitedNone,
+              style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+            )
+          else ...[
+            for (final path in shown)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                child: Row(
+                  children: [
+                    Icon(Icons.description_outlined, size: 14, color: colorScheme.onSurfaceVariant),
+                    const SizedBox(width: 6),
+                    Flexible(
+                      child: Text(
+                        path,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            if (cited.length > shown.length)
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Text(
+                  l10n.optKbCitedAll(cited.length),
+                  style: textTheme.labelMedium?.copyWith(color: colorScheme.primary),
+                ),
+              ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/screens/workbench/widgets/optimizer_config_panel.dart
+++ b/lib/screens/workbench/widgets/optimizer_config_panel.dart
@@ -151,11 +151,19 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
           label: l10n.refinerModel,
           onChanged: widget.onModelChanged,
           models: appState.multimodalModels,
+          prefixIcon: Icons.tune,
+          style: ChatModelSelectorStyle.card,
         ),
         if (widget.mode == AssistantMode.systemPrompt)
           _buildSysPromptSection(l10n, colorScheme)
-        else
+        else ...[
           _buildKnowledgeStatus(l10n, colorScheme),
+          // Its own card, not a tail on the status card: the base's
+          // configuration is fixed for the session while this changes with
+          // every answer, and reading them as one block invites the two to be
+          // confused for each other.
+          _buildCitedThisRound(l10n, colorScheme, Theme.of(context).textTheme),
+        ],
       ],
     );
 
@@ -177,6 +185,13 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
     );
   }
 
+  /// The three assistant modes, as the panel's top-level navigation.
+  ///
+  /// No icons and the short edit label on purpose: three segments share the
+  /// width of a panel that narrows to 250px, and a glyph plus five characters
+  /// each leaves every one of them ellipsized. The raised style keeps the
+  /// accent free for the state *inside* the tab — the ready badge, the cited
+  /// files — rather than spending it on the tab strip.
   Widget _buildModeSelector(AppLocalizations l10n, ColorScheme colorScheme) {
     final kbSelectable = widget.kbStatus == KbStatus.ok;
     return AppSegmentedControl<AssistantMode>(
@@ -184,18 +199,15 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
         AppSegment(
           value: AssistantMode.systemPrompt,
           label: l10n.optModeSystemPrompt,
-          icon: Icons.tune,
         ),
         AppSegment(
           value: AssistantMode.knowledgeBase,
           label: l10n.optModeKnowledge,
-          icon: Icons.menu_book_outlined,
           enabled: kbSelectable || widget.mode == AssistantMode.knowledgeBase,
         ),
         AppSegment(
           value: AssistantMode.knowledgeEdit,
-          label: l10n.optModeKnowledgeEdit,
-          icon: Icons.edit_note_outlined,
+          label: l10n.optModeKnowledgeEditShort,
           enabled: kbSelectable || widget.mode == AssistantMode.knowledgeEdit,
         ),
       ],
@@ -203,6 +215,7 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
       onChanged: widget.onModeChanged,
       expand: true,
       compact: true,
+      style: AppSegmentStyle.raised,
     );
   }
 
@@ -270,7 +283,6 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
             ],
             const SizedBox(height: 10),
             _buildKbActions(l10n, ok),
-            if (ok) _buildCitedThisRound(l10n, colorScheme, textTheme),
           ],
         ),
       ),
@@ -345,42 +357,46 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
       );
     }
 
-    // Wrap, not Row: the panel narrows to 250px and these are three controls
-    // with labels.
+    // Kept visible and disabled once the base has an entry file, rather than
+    // hidden: initializing is a one-time act, and an action that silently
+    // disappears leaves the user wondering where it went. The tooltip says
+    // why it is off. KnowledgeBaseStarter.scaffold refuses independently —
+    // this is only the first gate.
+    final initialize = Tooltip(
+      message: ok ? l10n.kbScaffoldAlreadyInit(KnowledgeBaseService.entryFileName) : '',
+      child: AppButton(
+        label: l10n.kbScaffoldCreate,
+        icon: Icons.auto_awesome_outlined,
+        variant: AppButtonVariant.secondary,
+        onPressed: ok ? null : _handleScaffold,
+      ),
+    );
+
+    if (!ok) return Align(alignment: Alignment.centerLeft, child: initialize);
+
+    // Wrap, not Row: the panel narrows to 250px, and three labelled controls
+    // on one line there would each be a few ellipsized characters.
     return Wrap(
       spacing: 8,
       runSpacing: 8,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        // Kept visible and disabled once the base has an entry file, rather
-        // than hidden: initializing is a one-time act, and an action that
-        // silently disappears leaves the user wondering where it went. The
-        // tooltip says why it is off. KnowledgeBaseStarter.scaffold refuses
-        // independently — this is only the first gate.
-        Tooltip(
-          message: ok ? l10n.kbScaffoldAlreadyInit(KnowledgeBaseService.entryFileName) : '',
-          child: AppButton(
-            label: l10n.kbScaffoldCreate,
-            icon: Icons.auto_awesome_outlined,
-            variant: AppButtonVariant.secondary,
-            onPressed: ok ? null : _handleScaffold,
-          ),
+        initialize,
+        // Rescan is the live action once the base exists, so it takes the
+        // tonal weight while initialize sits spent beside it.
+        AppButton(
+          label: l10n.optKbRescan,
+          icon: Icons.refresh,
+          variant: AppButtonVariant.secondary,
+          loading: _scanning,
+          onPressed: _loadKbStats,
         ),
-        if (ok) ...[
-          AppButton(
-            label: l10n.optKbRescan,
-            icon: Icons.refresh,
-            variant: AppButtonVariant.text,
-            loading: _scanning,
-            onPressed: _loadKbStats,
-          ),
-          AppIconButton(
-            icon: Icons.folder_open_outlined,
-            tooltip: l10n.openInFolder,
-            size: 34,
-            onPressed: widget.kbPath == null ? null : () => FileUtils.openPath(widget.kbPath!),
-          ),
-        ],
+        AppIconButton(
+          icon: Icons.folder_open_outlined,
+          tooltip: l10n.openInFolder,
+          size: 34,
+          onPressed: widget.kbPath == null ? null : () => FileUtils.openPath(widget.kbPath!),
+        ),
       ],
     );
   }
@@ -399,47 +415,50 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
     final shown = cited.take(_citedPreviewCount).toList();
 
     return Padding(
-      padding: const EdgeInsets.only(top: 14),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(l10n.optKbCitedThisRound, style: textTheme.titleSmall),
-          const SizedBox(height: 6),
-          if (cited.isEmpty)
-            Text(
-              l10n.optKbCitedNone,
-              style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
-            )
-          else ...[
-            for (final path in shown)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 2),
-                child: Row(
-                  children: [
-                    Icon(Icons.description_outlined, size: 14, color: colorScheme.onSurfaceVariant),
-                    const SizedBox(width: 6),
-                    Flexible(
-                      child: Text(
-                        path,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+      padding: const EdgeInsets.only(top: 12),
+      child: AppCard(
+        outlined: true,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(l10n.optKbCitedThisRound, style: textTheme.titleSmall),
+            const SizedBox(height: 6),
+            if (cited.isEmpty)
+              Text(
+                l10n.optKbCitedNone,
+                style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+              )
+            else ...[
+              for (final path in shown)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 2),
+                  child: Row(
+                    children: [
+                      Icon(Icons.description_outlined, size: 14, color: colorScheme.onSurfaceVariant),
+                      const SizedBox(width: 6),
+                      Flexible(
+                        child: Text(
+                          path,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-            if (cited.length > shown.length)
-              Padding(
-                padding: const EdgeInsets.only(top: 2),
-                child: Text(
-                  l10n.optKbCitedAll(cited.length),
-                  style: textTheme.labelMedium?.copyWith(color: colorScheme.primary),
+              if (cited.length > shown.length)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    l10n.optKbCitedAll(cited.length),
+                    style: textTheme.labelMedium?.copyWith(color: colorScheme.primary),
+                  ),
                 ),
-              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/screens/workbench/widgets/optimizer_reference_panel.dart
+++ b/lib/screens/workbench/widgets/optimizer_reference_panel.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_card.dart';
 import 'config_section_header.dart';
 
 class OptimizerReferencePanel extends StatelessWidget {
@@ -63,52 +64,86 @@ class OptimizerReferencePanel extends StatelessWidget {
                   final viewed = session.viewedImagePaths.contains(image.path);
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 12.0),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Stack(
+                    child: AppCard(
+                      outlined: true,
+                      padding: EdgeInsets.zero,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        mainAxisSize: MainAxisSize.min,
                         children: [
-                          Image(
-                            image: image.imageProvider,
-                            fit: BoxFit.cover,
-                            width: double.infinity,
-                          ),
-                          // The agent addresses images by this 1-based id.
-                          Positioned(
-                            top: 6,
-                            left: 6,
-                            child: _Badge(
-                              text: '#${index + 1}',
-                              background: colorScheme.surface.withValues(alpha: 0.85),
-                              foreground: colorScheme.onSurface,
+                          // A fixed 4:3 window rather than the image's own
+                          // height: unconstrained, one tall portrait shot
+                          // filled the panel and pushed the rest out of sight,
+                          // so the numbering the prompt refers to was no
+                          // longer scannable.
+                          AspectRatio(
+                            aspectRatio: 4 / 3,
+                            child: Stack(
+                              fit: StackFit.expand,
+                              children: [
+                                ColoredBox(
+                                  color: colorScheme.surfaceContainerHighest,
+                                  child: Image(image: image.imageProvider, fit: BoxFit.cover),
+                                ),
+                                // The agent addresses images by this 1-based
+                                // id, and the optimized prompt cites the same
+                                // number.
+                                Positioned(
+                                  top: 6,
+                                  left: 6,
+                                  child: _Badge(
+                                    text: '${index + 1}',
+                                    background: colorScheme.primary,
+                                    foreground: colorScheme.onPrimary,
+                                  ),
+                                ),
+                                Positioned(
+                                  top: 6,
+                                  right: 6,
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      if (viewed) ...[
+                                        Tooltip(
+                                          message: l10n.optViewed,
+                                          child: _Badge(
+                                            icon: Icons.visibility_outlined,
+                                            background: colorScheme.surface.withValues(alpha: 0.85),
+                                            foreground: colorScheme.onSurfaceVariant,
+                                          ),
+                                        ),
+                                        const SizedBox(width: 4),
+                                      ],
+                                      Tooltip(
+                                        message: l10n.optRemoveImage,
+                                        child: InkWell(
+                                          borderRadius: BorderRadius.circular(6),
+                                          onTap: () => workbenchUIState.removeAssistantImage(image),
+                                          child: _Badge(
+                                            icon: Icons.close,
+                                            background: colorScheme.surface.withValues(alpha: 0.85),
+                                            foreground: colorScheme.error,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
-                          if (viewed)
-                            Positioned(
-                              top: 6,
-                              right: 6,
-                              child: Tooltip(
-                                message: l10n.optViewed,
-                                child: _Badge(
-                                  icon: Icons.visibility_outlined,
-                                  background: colorScheme.tertiaryContainer.withValues(alpha: 0.9),
-                                  foreground: colorScheme.onTertiaryContainer,
-                                ),
-                              ),
-                            ),
-                          Positioned(
-                            bottom: 6,
-                            right: 6,
-                            child: Tooltip(
-                              message: l10n.optRemoveImage,
-                              child: InkWell(
-                                borderRadius: BorderRadius.circular(6),
-                                onTap: () => workbenchUIState.removeAssistantImage(image),
-                                child: _Badge(
-                                  icon: Icons.close,
-                                  background: colorScheme.surface.withValues(alpha: 0.85),
-                                  foreground: colorScheme.error,
-                                ),
-                              ),
+                          // The name the prompt will cite, off the picture so
+                          // it never covers the thing being referred to.
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
+                            child: Text(
+                              image.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                    fontFamily: 'monospace',
+                                  ),
                             ),
                           ),
                         ],
@@ -117,6 +152,20 @@ class OptimizerReferencePanel extends StatelessWidget {
                   );
                 },
               ),
+            ),
+          ),
+        // Why the numbers matter, said once at the bottom rather than as a
+        // tooltip on each card: the ordering is what the prompt cites, and
+        // that is not guessable from a numbered badge alone.
+        if (images.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+            child: Text(
+              l10n.optRefNumberingHint,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                    height: 1.4,
+                  ),
             ),
           ),
       ],

--- a/lib/screens/workbench/widgets/prompt_optimizer_toolbar.dart
+++ b/lib/screens/workbench/widgets/prompt_optimizer_toolbar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../widgets/panel_resizer.dart';
 
 class PromptOptimizerToolbar extends StatelessWidget {
   final VoidCallback onNewSession;
@@ -10,6 +11,10 @@ class PromptOptimizerToolbar extends StatelessWidget {
   final bool isRefining;
   final bool canApply;
 
+  /// Localised name of the session's mode, shown as a badge beside the title.
+  /// Null hides the badge.
+  final String? modeLabel;
+
   const PromptOptimizerToolbar({
     super.key,
     required this.onNewSession,
@@ -17,6 +22,7 @@ class PromptOptimizerToolbar extends StatelessWidget {
     required this.onApply,
     required this.isRefining,
     required this.canApply,
+    this.modeLabel,
   });
 
   @override
@@ -25,8 +31,10 @@ class PromptOptimizerToolbar extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final isMobile = Responsive.isMobile(context);
 
+    final textTheme = Theme.of(context).textTheme;
+
     return Container(
-      height: 52,
+      height: kPanelHeaderHeight,
       padding: const EdgeInsets.symmetric(horizontal: 12),
       decoration: BoxDecoration(
         color: colorScheme.surface,
@@ -38,10 +46,47 @@ class PromptOptimizerToolbar extends StatelessWidget {
           Expanded(
             child: isMobile
                 ? const SizedBox.shrink()
-                : Text(
-                    l10n.promptOptimizer,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                    overflow: TextOverflow.ellipsis,
+                : Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          l10n.promptOptimizer,
+                          style: textTheme.titleMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      if (modeLabel != null) ...[
+                        const SizedBox(width: 10),
+                        // Which brain is answering. The three modes behave
+                        // very differently and the setting that picks them
+                        // lives in a panel that can be closed, so the header
+                        // has to say it.
+                        Flexible(
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                            decoration: BoxDecoration(
+                              color: colorScheme.surfaceContainerHighest,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.smart_toy_outlined, size: 13, color: colorScheme.onSurfaceVariant),
+                                const SizedBox(width: 5),
+                                Flexible(
+                                  child: Text(
+                                    l10n.optModeBadgeAgent(modeLabel!),
+                                    overflow: TextOverflow.ellipsis,
+                                    style: textTheme.labelMedium
+                                        ?.copyWith(color: colorScheme.onSurfaceVariant),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
           ),
 
@@ -67,15 +112,29 @@ class PromptOptimizerToolbar extends StatelessWidget {
             const VerticalDivider(width: 16, indent: 12, endIndent: 12),
           ],
 
+          // Solid in the app's own accent, not the tertiary hue: this is the
+          // one action the whole screen builds towards, and it should read as
+          // the same "commit" colour every other primary button uses.
+          //
+          // Disabled is an outline, not a grey slab. There is nothing to apply
+          // until the agent has produced a prompt, and a filled grey button
+          // looks broken where an empty one reads as "not yet".
           FilledButton.icon(
             onPressed: canApply ? onApply : null,
             icon: const Icon(Icons.check, size: 18),
-            label: Text(isMobile ? l10n.apply : l10n.applyToWorkbench, style: const TextStyle(fontSize: 12)),
+            label: Text(
+              isMobile ? l10n.apply : l10n.applyToWorkbench,
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
             style: FilledButton.styleFrom(
-              backgroundColor: colorScheme.tertiary,
-              foregroundColor: colorScheme.onTertiary,
+              disabledBackgroundColor: Colors.transparent,
+              disabledForegroundColor: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
               visualDensity: VisualDensity.compact,
-              padding: const EdgeInsets.symmetric(horizontal: 12),
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              side: canApply
+                  ? null
+                  : BorderSide(color: colorScheme.outlineVariant),
+              elevation: canApply ? null : 0,
             ),
           ),
 

--- a/lib/screens/workbench/widgets/prompt_optimizer_view.dart
+++ b/lib/screens/workbench/widgets/prompt_optimizer_view.dart
@@ -7,6 +7,22 @@ import '../../../core/app_theme.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/prompt_optimizer_agent.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_button.dart';
+import '../../../widgets/app_card.dart';
+import '../../../widgets/app_snackbar.dart';
+
+/// One row of the transcript as drawn, which is not one-to-one with
+/// [OptimizerChatEntry]: a run of consecutive tool calls collapses into a
+/// single timeline card.
+class _TranscriptRow {
+  /// Transcript index of the first entry, used as a stable expand-state key.
+  final int startIndex;
+  final List<OptimizerChatEntry> entries;
+
+  _TranscriptRow({required this.startIndex, required this.entries});
+
+  bool get isToolGroup => entries.first.kind == OptimizerEntryKind.tool;
+}
 
 /// Multi-turn chat view for the prompt-optimizer agent.
 ///
@@ -54,6 +70,21 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
   /// Edit ids whose full proposed content is expanded. Purely presentational.
   final Set<String> _expandedKbEdits = {};
 
+  /// Transcript indices of tool groups the user has opened, and prompt cards
+  /// whose full text is showing. Both keyed by transcript index, which is
+  /// stable because the transcript is append-only.
+  final Set<int> _expandedToolGroups = {};
+  final Set<int> _expandedPrompts = {};
+
+  /// Steps shown before a timeline card needs opening. Three is enough to see
+  /// what kind of work the agent did without the card becoming the page.
+  static const int _collapsedStepCount = 3;
+
+  /// A prompt longer than this folds. Roughly the point where the card starts
+  /// pushing the reply that explains it off the screen.
+  static const int _promptFoldChars = 600;
+  static const double _promptFoldHeight = 260;
+
   @override
   void dispose() {
     _session?.removeListener(_onSessionChanged);
@@ -88,12 +119,17 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
     );
   }
 
-  bool _isCtrlEnter(KeyEvent event) {
-    return event is KeyDownEvent &&
-        (event.logicalKey == LogicalKeyboardKey.enter ||
-            event.logicalKey == LogicalKeyboardKey.numpadEnter) &&
-        (HardwareKeyboard.instance.isControlPressed ||
-            HardwareKeyboard.instance.isMetaPressed);
+  /// Enter sends; Shift+Enter inserts a newline.
+  ///
+  /// This is a chat box, and every chat box works this way — the old
+  /// Ctrl+Enter meant the most common action needed two hands and was
+  /// undiscoverable without the tooltip. Shift+Enter keeps multi-line prompts
+  /// possible, and the hint under the field now says so.
+  bool _isSendKey(KeyEvent event) {
+    if (event is! KeyDownEvent) return false;
+    final isEnter = event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter;
+    return isEnter && !HardwareKeyboard.instance.isShiftPressed;
   }
 
   @override
@@ -103,16 +139,30 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Column(
-      children: [
-        Expanded(
-          child: session.transcript.isEmpty
-              ? _buildEmptyState(l10n, colorScheme)
-              : _buildTranscript(session, l10n, colorScheme),
-        ),
-        if (session.isRunning || widget.isBusy) _buildWorkingIndicator(l10n, colorScheme),
-        _buildInputBar(l10n, colorScheme),
-      ],
+    // The bottom console can be dragged up until this pane is only a couple
+    // of hundred pixels tall. A composer that always reserves six lines then
+    // leaves nothing for the conversation and overflows outright, so it is
+    // capped against the height actually on offer.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final composerLines = switch (constraints.maxHeight) {
+          < 240 => 1,
+          < 340 => 3,
+          _ => 6,
+        };
+
+        return Column(
+          children: [
+            Expanded(
+              child: session.transcript.isEmpty
+                  ? _buildEmptyState(l10n, colorScheme)
+                  : _buildTranscript(session, l10n, colorScheme),
+            ),
+            if (session.isRunning || widget.isBusy) _buildWorkingIndicator(l10n, colorScheme),
+            _buildInputBar(l10n, colorScheme, composerLines),
+          ],
+        );
+      },
     );
   }
 
@@ -143,29 +193,182 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
     );
   }
 
+  /// Collapses each run of consecutive tool calls into one row.
+  ///
+  /// A ten-step agent turn used to render as ten grey lines of the same weight
+  /// as everything else, so the answer it produced was buried under the
+  /// working-out. Grouping is done here rather than in the agent because it is
+  /// purely presentational — the transcript itself stays one entry per call.
+  ///
+  /// Rows are keyed by the transcript index of their first entry, which is
+  /// stable: the transcript is append-only, so an index never refers to a
+  /// different entry later.
+  static List<_TranscriptRow> _groupRows(List<OptimizerChatEntry> transcript) {
+    final rows = <_TranscriptRow>[];
+    for (var i = 0; i < transcript.length; i++) {
+      final entry = transcript[i];
+      final continuesGroup = entry.kind == OptimizerEntryKind.tool &&
+          rows.isNotEmpty &&
+          rows.last.isToolGroup;
+      if (continuesGroup) {
+        rows.last.entries.add(entry);
+      } else {
+        rows.add(_TranscriptRow(startIndex: i, entries: [entry]));
+      }
+    }
+    return rows;
+  }
+
   Widget _buildTranscript(
     PromptOptimizerSession session,
     AppLocalizations l10n,
     ColorScheme colorScheme,
   ) {
+    final rows = _groupRows(session.transcript);
+
     return ListView.builder(
       controller: _scrollCtrl,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-      itemCount: session.transcript.length,
+      itemCount: rows.length,
       itemBuilder: (context, index) {
-        final entry = session.transcript[index];
-        final isLast = index == session.transcript.length - 1;
+        final row = rows[index];
+        final isLast = index == rows.length - 1;
         return Align(
           alignment: Alignment.topCenter,
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 780),
             child: Padding(
               padding: const EdgeInsets.only(bottom: 12),
-              child: _buildEntry(entry, isLast, l10n, colorScheme),
+              child: row.isToolGroup
+                  ? _buildAgentTimeline(row, l10n, colorScheme)
+                  : _buildEntry(row.entries.first, isLast, l10n, colorScheme),
             ),
           ),
         );
       },
+    );
+  }
+
+  /// The agent's working-out for one stretch of a turn, as a single card.
+  ///
+  /// Collapsed by default to a summary plus the first few steps: the interesting
+  /// thing is usually *that* it consulted the knowledge base and how much, not
+  /// each individual filename.
+  Widget _buildAgentTimeline(
+    _TranscriptRow row,
+    AppLocalizations l10n,
+    ColorScheme colorScheme,
+  ) {
+    final textTheme = Theme.of(context).textTheme;
+    final steps = row.entries;
+    final expanded = _expandedToolGroups.contains(row.startIndex);
+    final shown = expanded ? steps : steps.take(_collapsedStepCount).toList();
+
+    final images = steps.where((e) => e.toolName == 'view_image').length;
+    final docs = steps.where((e) => e.toolName == 'read_knowledge_file').length;
+    final detail = [
+      if (images > 0) l10n.optAgentStepsImages(images),
+      if (docs > 0) l10n.optAgentStepsDocs(docs),
+    ].join(' · ');
+
+    return AppCard(
+      outlined: true,
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
+      onTap: () => setState(() {
+        if (!_expandedToolGroups.remove(row.startIndex)) {
+          _expandedToolGroups.add(row.startIndex);
+        }
+      }),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.check_circle_outline, size: 16, color: colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(l10n.optAgentSteps(steps.length), style: textTheme.titleSmall),
+              if (detail.isNotEmpty) ...[
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    detail,
+                    overflow: TextOverflow.ellipsis,
+                    style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+                  ),
+                ),
+              ] else
+                const Spacer(),
+              Icon(
+                expanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+                size: 18,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (final step in shown) _buildToolStep(step, l10n, colorScheme),
+          if (steps.length > _collapsedStepCount) ...[
+            const SizedBox(height: 2),
+            AppButton(
+              label: expanded
+                  ? l10n.optAgentStepsCollapse
+                  : l10n.optAgentStepsExpand(steps.length),
+              variant: AppButtonVariant.text,
+              onPressed: () => setState(() {
+                if (!_expandedToolGroups.remove(row.startIndex)) {
+                  _expandedToolGroups.add(row.startIndex);
+                }
+              }),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Label and glyph for one tool call, shared by the timeline card and the
+  /// lone-call fallback so the two cannot describe the same call differently.
+  (String, IconData) _describeTool(OptimizerChatEntry entry, AppLocalizations l10n) {
+    switch (entry.toolName) {
+      case 'view_image':
+        return (l10n.optToolViewImage(entry.text), Icons.visibility_outlined);
+      case 'read_knowledge_file':
+        return (l10n.optToolReadKnowledge(entry.text), Icons.menu_book_outlined);
+      case 'list_knowledge_files':
+        return (l10n.optToolListKnowledge, Icons.folder_outlined);
+      case 'write_knowledge_file':
+        // Only reached for restored sessions — a live staged edit renders as
+        // an actionable kbEdit card instead.
+        return (l10n.optToolWriteKnowledge(entry.text), Icons.edit_note_outlined);
+      default:
+        return (l10n.optToolListImages, Icons.checklist_rtl);
+    }
+  }
+
+  Widget _buildToolStep(
+    OptimizerChatEntry entry,
+    AppLocalizations l10n,
+    ColorScheme colorScheme,
+  ) {
+    final (label, icon) = _describeTool(entry, l10n);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Icon(icon, size: 14, color: colorScheme.outline),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -209,46 +412,11 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
         );
 
       case OptimizerEntryKind.tool:
-        final String label;
-        final IconData icon;
-        switch (entry.toolName) {
-          case 'view_image':
-            label = l10n.optToolViewImage(entry.text);
-            icon = Icons.visibility_outlined;
-          case 'read_knowledge_file':
-            label = l10n.optToolReadKnowledge(entry.text);
-            icon = Icons.menu_book_outlined;
-          case 'list_knowledge_files':
-            label = l10n.optToolListKnowledge;
-            icon = Icons.folder_outlined;
-          case 'write_knowledge_file':
-            // Only reached for restored sessions — a live staged edit renders
-            // as an actionable kbEdit card instead.
-            label = l10n.optToolWriteKnowledge(entry.text);
-            icon = Icons.edit_note_outlined;
-          default:
-            label = l10n.optToolListImages;
-            icon = Icons.checklist_rtl;
-        }
+        // Reached only for a lone tool call with no neighbours; a run of them
+        // is grouped into the timeline card by _groupRows before this.
         return Align(
           alignment: Alignment.centerLeft,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 2),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(icon, size: 14, color: colorScheme.outline),
-                const SizedBox(width: 6),
-                Flexible(
-                  child: Text(
-                    label,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(fontSize: 11, color: colorScheme.outline),
-                  ),
-                ),
-              ],
-            ),
-          ),
+          child: _buildToolStep(entry, l10n, colorScheme),
         );
 
       case OptimizerEntryKind.prompt:
@@ -531,6 +699,13 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
   }
 
   Widget _buildPromptCard(OptimizerChatEntry entry, AppLocalizations l10n, ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
+    // Keyed by version rather than transcript index: a prompt card is the one
+    // row a user scrolls back to, and the version is what identifies it.
+    final key = entry.version ?? 1;
+    final expanded = _expandedPrompts.contains(key);
+    final isLong = entry.text.length > _promptFoldChars;
+
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
@@ -550,11 +725,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                 Expanded(
                   child: Text(
                     l10n.optPromptVersion(entry.version ?? 1),
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.bold,
-                      color: colorScheme.tertiary,
-                    ),
+                    style: textTheme.titleSmall?.copyWith(color: colorScheme.tertiary),
                   ),
                 ),
                 IconButton(
@@ -563,15 +734,13 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                   visualDensity: VisualDensity.compact,
                   onPressed: () {
                     Clipboard.setData(ClipboardData(text: entry.text));
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text(l10n.optPromptCopied)),
-                    );
+                    AppSnackBar.success(context, l10n.optPromptCopied);
                   },
                 ),
                 FilledButton.tonalIcon(
                   onPressed: () => widget.onApplyPrompt(entry.text),
                   icon: const Icon(Icons.check, size: 15),
-                  label: Text(l10n.apply, style: const TextStyle(fontSize: 12)),
+                  label: Text(l10n.apply, style: textTheme.labelMedium),
                   style: tonalButtonStyle(Theme.of(context).colorScheme)
                       .copyWith(visualDensity: VisualDensity.compact),
                 ),
@@ -580,14 +749,35 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(14, 6, 14, 12),
-            child: MarkdownBody(
-              data: entry.text,
-              selectable: true,
-              styleSheet: MarkdownStyleSheet(
-                p: TextStyle(color: colorScheme.onSurface, fontSize: 13, height: 1.45),
+            // Folded to a readable opening rather than scrolled inside its own
+            // box: a long prompt otherwise pushes the reply that explains it,
+            // and the input bar, off the bottom of the conversation.
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: isLong && !expanded ? _promptFoldHeight : double.infinity,
+              ),
+              child: ClipRect(
+                child: MarkdownBody(
+                  data: entry.text,
+                  selectable: true,
+                  styleSheet: MarkdownStyleSheet(
+                    p: TextStyle(color: colorScheme.onSurface, fontSize: 13, height: 1.45),
+                  ),
+                ),
               ),
             ),
           ),
+          if (isLong)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 0, 8, 4),
+              child: AppButton(
+                label: expanded ? l10n.optPromptCollapse : l10n.optPromptExpand,
+                variant: AppButtonVariant.text,
+                onPressed: () => setState(() {
+                  if (!_expandedPrompts.remove(key)) _expandedPrompts.add(key);
+                }),
+              ),
+            ),
           if (entry.note != null)
             Padding(
               padding: const EdgeInsets.fromLTRB(14, 0, 14, 10),
@@ -622,48 +812,121 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
     );
   }
 
-  Widget _buildInputBar(AppLocalizations l10n, ColorScheme colorScheme) {
+  /// The composer: what will be sent, the text, and how to send it.
+  ///
+  /// The send control moved out of `suffixIcon` and onto its own footer row.
+  /// As a suffix it was vertically centred, so it drifted down the field as
+  /// the text grew to six lines, and there was nowhere to say that the
+  /// reference images go with the message — which is the one thing about this
+  /// box that is not obvious.
+  Widget _buildInputBar(AppLocalizations l10n, ColorScheme colorScheme, int maxLines) {
     final canSend = !widget.isBusy;
+    final textTheme = Theme.of(context).textTheme;
+    final attachedCount = context.watch<WorkbenchUIState>().optimizerReferenceImages.length;
+
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
       child: Align(
         alignment: Alignment.topCenter,
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 780),
-          child: Focus(
-            onKeyEvent: (node, event) {
-              if (canSend && _isCtrlEnter(event)) {
-                widget.onSend();
-                return KeyEventResult.handled;
-              }
-              return KeyEventResult.ignored;
-            },
-            child: TextField(
-              controller: widget.inputCtrl,
-              minLines: 1,
-              maxLines: 6,
-              enabled: true,
-              style: const TextStyle(fontSize: 13, height: 1.4),
-              decoration: InputDecoration(
-                hintText: l10n.optChatHint,
-                hintStyle: TextStyle(
-                  fontSize: 13,
-                  color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+          child: Container(
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerHigh,
+              borderRadius: BorderRadius.circular(14),
+            ),
+            padding: const EdgeInsets.fromLTRB(4, 4, 4, 4),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Focus(
+                  onKeyEvent: (node, event) {
+                    if (canSend && _isSendKey(event)) {
+                      widget.onSend();
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  child: TextField(
+                    controller: widget.inputCtrl,
+                    minLines: 1,
+                    maxLines: maxLines,
+                    style: textTheme.bodyMedium?.copyWith(height: 1.4),
+                    decoration: InputDecoration(
+                      hintText: l10n.optChatHint,
+                      hintStyle: textTheme.bodyMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+                      ),
+                      border: InputBorder.none,
+                      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                    ),
+                  ),
                 ),
-                filled: true,
-                fillColor: colorScheme.surfaceContainerHigh,
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(14),
-                  borderSide: BorderSide.none,
+                LayoutBuilder(
+                  builder: (context, constraints) {
+                    // The keyboard hint is the first thing to go: it is a
+                    // nicety, while the attachment count changes what gets
+                    // sent and the button is the action itself. Below this the
+                    // three together do not fit, and a squeezed pane is
+                    // exactly where the composer must not overflow.
+                    final showHint = constraints.maxWidth >= 460;
+
+                    return Row(
+                      children: [
+                        if (attachedCount > 0) ...[
+                          Flexible(
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                              decoration: BoxDecoration(
+                                color: colorScheme.surface,
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.image_outlined, size: 14, color: colorScheme.onSurfaceVariant),
+                                  const SizedBox(width: 6),
+                                  Flexible(
+                                    child: Text(
+                                      l10n.optAttachedImages(attachedCount),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: textTheme.labelMedium
+                                          ?.copyWith(color: colorScheme.onSurfaceVariant),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                        ],
+                        Expanded(
+                          child: showHint
+                              ? Align(
+                                  alignment: Alignment.centerRight,
+                                  child: Text(
+                                    l10n.optSendHint,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: textTheme.labelSmall
+                                        ?.copyWith(color: colorScheme.onSurfaceVariant),
+                                  ),
+                                )
+                              : const SizedBox.shrink(),
+                        ),
+                        const SizedBox(width: 8),
+                        IconButton.filled(
+                          icon: const Icon(Icons.send_rounded, size: 18),
+                          tooltip: l10n.optSend,
+                          visualDensity: VisualDensity.compact,
+                          onPressed: canSend ? widget.onSend : null,
+                        ),
+                      ],
+                    );
+                  },
                 ),
-                contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                suffixIcon: IconButton(
-                  icon: const Icon(Icons.send_rounded, size: 20),
-                  tooltip: l10n.optSend,
-                  color: colorScheme.primary,
-                  onPressed: canSend ? widget.onSend : null,
-                ),
-              ),
+              ],
             ),
           ),
         ),

--- a/lib/screens/workbench/widgets/workbench_top_bar.dart
+++ b/lib/screens/workbench/widgets/workbench_top_bar.dart
@@ -9,6 +9,7 @@ import '../../../models/llm_model.dart';
 import '../../../state/app_state.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
+import '../../../widgets/app_segmented_control.dart';
 import '../../../widgets/app_tool_button.dart';
 import '../workbench_layout.dart';
 
@@ -106,10 +107,20 @@ class WorkbenchTopBar extends StatelessWidget {
                         scrollDirection: Axis.horizontal,
                         child: Row(
                           children: [
-                            _PrimarySegment(
-                              destinations: primary,
-                              activeIndex: active,
-                              onSelect: (i) => tabController.animateTo(i),
+                            AppSegmentedControl<int>(
+                              segments: [
+                                for (final d in primary)
+                                  AppSegment(value: d.index, label: d.label, icon: d.icon),
+                              ],
+                              value: primary.any((d) => d.index == active)
+                                  // A tool tab is open, so neither mode is
+                                  // "current"; keep the one the user last
+                                  // created in rather than flicking the
+                                  // selection somewhere arbitrary.
+                                  ? active
+                                  : primary.first.index,
+                              onChanged: tabController.animateTo,
+                              style: AppSegmentStyle.raised,
                             ),
                             const SizedBox(width: 12),
                             Container(
@@ -254,83 +265,6 @@ class WorkbenchTopBar extends StatelessWidget {
             ],
           );
         },
-      ),
-    );
-  }
-}
-
-/// Prominent iOS-style segmented control for the primary creation modes.
-class _PrimarySegment extends StatelessWidget {
-  final List<_WbDest> destinations;
-  final int activeIndex;
-  final ValueChanged<int> onSelect;
-
-  const _PrimarySegment({
-    required this.destinations,
-    required this.activeIndex,
-    required this.onSelect,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.all(3),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest.withAlpha(140),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: destinations.map((d) {
-          final selected = activeIndex == d.index;
-          return AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeOut,
-            margin: const EdgeInsets.symmetric(horizontal: 1),
-            decoration: BoxDecoration(
-              color: selected ? colorScheme.surface : Colors.transparent,
-              borderRadius: BorderRadius.circular(9),
-              boxShadow: selected
-                  ? [
-                      BoxShadow(
-                        color: Colors.black.withAlpha(18),
-                        blurRadius: 4,
-                        offset: const Offset(0, 1),
-                      )
-                    ]
-                  : null,
-            ),
-            child: Material(
-              color: Colors.transparent,
-              child: InkWell(
-                borderRadius: BorderRadius.circular(9),
-                onTap: () => onSelect(d.index),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        d.icon,
-                        size: 18,
-                        color: selected ? colorScheme.primary : colorScheme.onSurfaceVariant,
-                      ),
-                      const SizedBox(width: 7),
-                      Text(
-                        d.label,
-                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                              fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-                              color: selected ? colorScheme.onSurface : colorScheme.onSurfaceVariant,
-                            ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          );
-        }).toList(),
       ),
     );
   }

--- a/lib/screens/workbench/workbench_layout.dart
+++ b/lib/screens/workbench/workbench_layout.dart
@@ -92,6 +92,14 @@ class _WorkbenchLayoutState extends State<WorkbenchLayout> {
               child: Padding(
                 padding: EdgeInsets.fromLTRB(8, 8, 8, widget.bottomPanel == null ? 8 : 0),
                 child: Row(
+                  // Stretch, not the default centre. PanelCard is a SizedBox
+                  // with a width and no height, so under the loose vertical
+                  // constraint a centred Row hands out, a panel whose body is
+                  // a bare SingleChildScrollView shrink-wraps to its content
+                  // and then floats in the middle of the canvas with bare
+                  // surface above and below it. Panels are columns of a
+                  // layout; they should always be the height of the row.
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     // Left Panel
                     if (widget.leftPanel != null && widget.showLeftPanel && !isTablet) ...[

--- a/lib/screens/workbench/workbench_screen.dart
+++ b/lib/screens/workbench/workbench_screen.dart
@@ -759,6 +759,14 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
                       onApply: () => _handleOptimizerApply(session.refinedPrompt ?? ''),
                       isRefining: isBusy,
                       canApply: session.refinedPrompt != null,
+                      modeLabel: switch (session.mode) {
+                        AssistantMode.systemPrompt =>
+                          AppLocalizations.of(context)!.optModeSystemPrompt,
+                        AssistantMode.knowledgeBase =>
+                          AppLocalizations.of(context)!.optModeKnowledge,
+                        AssistantMode.knowledgeEdit =>
+                          AppLocalizations.of(context)!.optModeKnowledgeEdit,
+                      },
                     ),
                     Expanded(
                       child: _optIsLoadingData
@@ -840,6 +848,9 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
               onScaffoldKb: _handleScaffoldKb,
               tags: _optTags,
               filteredSysPrompts: _optFilteredSysPrompts,
+              citedKnowledgeFiles: PromptOptimizerAgent.citedKnowledgeFiles(
+                workbenchUIState.optimizerSession,
+              ),
               onModelChanged: (v) => workbenchUIState.setOptimizerModel(v),
               onTagChanged: (v) {
                 workbenchUIState.setOptimizerTag(v);

--- a/lib/services/knowledge_base_service.dart
+++ b/lib/services/knowledge_base_service.dart
@@ -21,6 +21,24 @@ class KbFileInfo {
       };
 }
 
+/// What a knowledge base contains, as the agent sees it.
+///
+/// [newestModified] is the most recent modification time among the markdown
+/// files counted — the honest answer to "will the assistant see the edit I
+/// just made", which is what a freshness line on the status card is really
+/// being asked. Null when the base holds no readable files.
+class KbTreeStats {
+  final int files;
+  final int directories;
+  final DateTime? newestModified;
+
+  const KbTreeStats({
+    required this.files,
+    required this.directories,
+    this.newestModified,
+  });
+}
+
 class KbReadResult {
   final String content;
   final int page;
@@ -163,6 +181,52 @@ class KnowledgeBaseService {
     }
     entries.sort((a, b) => a.relPath.compareTo(b.relPath));
     return entries;
+  }
+
+  /// Walks the whole tree, counting what the agent can reach and noting when
+  /// that content last changed.
+  ///
+  /// Built on [listFiles] rather than a raw directory walk so the numbers
+  /// match exactly what the model is shown — same hidden-segment skip, same
+  /// markdown-only filter. A count that included files the agent cannot read
+  /// would be worse than no count.
+  ///
+  /// Deliberately not cached, and deliberately not an "index". This service
+  /// reads the folder on demand and is therefore never stale; a stored count
+  /// would be the only stale thing in the subsystem. Callers that want to show
+  /// freshness should show [KbTreeStats.newestModified] — the content's own
+  /// timestamp — rather than when some scan last ran.
+  KbTreeStats scanTree(String root, {String? dir, int depth = 0}) {
+    // Symlink loops inside the root survive resolvePath's containment check,
+    // which is lexical. A depth cap is cheaper than tracking visited inodes
+    // and no real knowledge base nests this far.
+    if (depth > 12) return const KbTreeStats(files: 0, directories: 0);
+
+    var files = 0;
+    var directories = 0;
+    DateTime? newest;
+
+    for (final entry in listFiles(root, dir: dir)) {
+      if (entry.isDir) {
+        directories++;
+        final nested = scanTree(root, dir: entry.relPath, depth: depth + 1);
+        files += nested.files;
+        directories += nested.directories;
+        newest = _laterOf(newest, nested.newestModified);
+      } else {
+        files++;
+        final stat = File(resolvePath(root, entry.relPath)).statSync();
+        newest = _laterOf(newest, stat.modified);
+      }
+    }
+
+    return KbTreeStats(files: files, directories: directories, newestModified: newest);
+  }
+
+  static DateTime? _laterOf(DateTime? a, DateTime? b) {
+    if (a == null) return b;
+    if (b == null) return a;
+    return a.isAfter(b) ? a : b;
   }
 
   /// Reads a knowledge file in full, unpaged. Returns null when it does not

--- a/lib/services/prompt_optimizer_agent.dart
+++ b/lib/services/prompt_optimizer_agent.dart
@@ -1218,30 +1218,72 @@ class PromptOptimizerAgent {
 
   static String _deriveTitle(List<LLMMessage> history) {
     final first = history
-        .where((m) =>
-            m.role == LLMRole.user &&
-            !m.content.startsWith(viewResultMarker) &&
-            !m.content.startsWith(summaryMarker))
+        .where(_isRealUserTurn)
         .map((m) => m.content.trim())
         .firstWhere((c) => c.isNotEmpty, orElse: () => '');
     final oneLine = first.replaceAll(RegExp(r'\s+'), ' ');
     return oneLine.length <= 40 ? oneLine : '${oneLine.substring(0, 40)}…';
   }
 
+  /// Whether [m] is something the *user* actually said, as opposed to a
+  /// message the agent injects into the user role.
+  ///
+  /// `view_image` results and compaction summaries both arrive as user
+  /// messages; counting either as a turn would split a turn in half or make
+  /// the protected window shorter than it claims. Shared so the two callers
+  /// that need this cannot drift apart.
+  static bool _isRealUserTurn(LLMMessage m) =>
+      m.role == LLMRole.user &&
+      !m.content.startsWith(viewResultMarker) &&
+      !m.content.startsWith(summaryMarker);
+
   /// Index of the user message that opens the protected "recent" window
   /// (the last [_keepRecentTurns] real user turns). 0 = protect everything.
   static int _recentBoundary(List<LLMMessage> history) {
     int userSeen = 0;
     for (int i = history.length - 1; i >= 0; i--) {
-      final m = history[i];
-      if (m.role == LLMRole.user &&
-          !m.content.startsWith(viewResultMarker) &&
-          !m.content.startsWith(summaryMarker)) {
+      if (_isRealUserTurn(history[i])) {
         userSeen++;
         if (userSeen >= _keepRecentTurns) return i;
       }
     }
     return 0;
+  }
+
+  /// The knowledge files the current answer rests on, in the order the agent
+  /// consulted them.
+  ///
+  /// The window is the live one — from [_recentBoundary] — rather than
+  /// strictly "this turn". A template read three turns ago and still being
+  /// sent with every request *is* something the answer is grounded in, and a
+  /// list that dropped it the moment the model stopped re-requesting it would
+  /// shrink as the conversation went on, for no reason the user could see.
+  /// Once layer 1 elides that read it genuinely has left the request, and it
+  /// correctly leaves this list with it.
+  ///
+  /// Scans tool **results**, like every other "what has been read" question in
+  /// this file — see the invariant documented on [_liveReadPages]. A failed
+  /// read carries neither content nor a path, so it cannot appear here.
+  static List<String> citedKnowledgeFiles(PromptOptimizerSession session) {
+    final history = session.history;
+    final paths = <String>{};
+
+    for (int i = _recentBoundary(history); i < history.length; i++) {
+      final m = history[i];
+      if (m.role != LLMRole.tool || m.toolName != 'read_knowledge_file') continue;
+      final Object? decoded;
+      try {
+        decoded = jsonDecode(m.content);
+      } catch (_) {
+        continue;
+      }
+      if (decoded is! Map) continue;
+      final path = decoded['path'];
+      if (path is String && path.isNotEmpty) paths.add(path);
+    }
+
+    // Insertion-ordered, so the list reads in the order the agent worked.
+    return paths.toList();
   }
 
   /// Below this many chars a read is not worth doing: the model would get a
@@ -1576,6 +1618,13 @@ class PromptOptimizerAgent {
         if (_liveReadPages(session, relPath).contains(page)) {
           return {
             'status': 'ok',
+            // Named even though the content is not repeated, so the UI can
+            // still credit the file as something this answer rests on. A
+            // cache hit means the model is *using* it, not ignoring it, and a
+            // citation list that dropped it would shrink as a conversation
+            // went on. `_liveReadPages` is unaffected: it requires a non-null
+            // `content` (see the invariant it documents), which this lacks.
+            'path': relPath,
             'note': 'This page is already in the conversation — refer to the earlier result instead of re-reading it.',
           };
         }

--- a/lib/widgets/app_card.dart
+++ b/lib/widgets/app_card.dart
@@ -49,7 +49,19 @@ class AppCard extends StatelessWidget {
       ),
       child: InkWell(
         onTap: onTap,
-        child: Padding(padding: padding, child: child),
+        // Spans its parent rather than hugging its content. A card in a
+        // column is a band across that column; left to shrink-wrap, one whose
+        // body happens to be a short line comes out a stub beside its
+        // neighbours, and whether any given card looked right became an
+        // accident of whether something inside it was full-width already.
+        //
+        // Requires a bounded width, which every column and list gives. An
+        // AppCard directly inside a Row needs an Expanded around it, as any
+        // full-width child there would.
+        child: SizedBox(
+          width: double.infinity,
+          child: Padding(padding: padding, child: child),
+        ),
       ),
     );
   }

--- a/lib/widgets/app_segmented_control.dart
+++ b/lib/widgets/app_segmented_control.dart
@@ -18,6 +18,19 @@ class AppSegment<T> {
   });
 }
 
+/// How an [AppSegmentedControl] marks the chosen option.
+enum AppSegmentStyle {
+  /// Accent tint and outline. Reads as "on" against the track, which suits a
+  /// control whose options are settings — streaming on/off, a filter.
+  tinted,
+
+  /// The chosen option lifts out of the track on a plain surface, the way a
+  /// physical switch would. For a control that picks *which view you are in*
+  /// rather than a value: the accent is then free to mean "selected" inside
+  /// that view instead of being spent on the navigation.
+  raised,
+}
+
 /// A single-choice control: a track holding its options, with the chosen one
 /// filled in.
 ///
@@ -38,6 +51,9 @@ class AppSegmentedControl<T> extends StatelessWidget {
   /// Tighter type and padding, for controls tucked into a toolbar.
   final bool compact;
 
+  /// How the chosen option is marked.
+  final AppSegmentStyle style;
+
   const AppSegmentedControl({
     super.key,
     required this.segments,
@@ -45,6 +61,7 @@ class AppSegmentedControl<T> extends StatelessWidget {
     required this.onChanged,
     this.expand = false,
     this.compact = false,
+    this.style = AppSegmentStyle.tinted,
   });
 
   @override
@@ -74,28 +91,48 @@ class AppSegmentedControl<T> extends StatelessWidget {
 
   Widget _buildSegment(BuildContext context, ColorScheme colorScheme, AppSegment<T> segment) {
     final selected = segment.value == value;
+    final raised = style == AppSegmentStyle.raised;
+
     final Color color;
     if (!segment.enabled) {
       color = colorScheme.onSurface.withValues(alpha: 0.38);
+    } else if (!selected) {
+      color = colorScheme.onSurfaceVariant;
     } else {
-      color = selected ? colorScheme.primary : colorScheme.onSurfaceVariant;
+      // Raised spends no accent on the label: the lift already says which one
+      // is chosen, and the accent is needed for state *inside* the view.
+      color = raised ? colorScheme.onSurface : colorScheme.primary;
     }
 
     return InkWell(
       onTap: selected || !segment.enabled ? null : () => onChanged(segment.value),
       borderRadius: BorderRadius.circular(9),
-      child: Container(
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOut,
         padding: EdgeInsets.symmetric(
           horizontal: compact ? 10 : 14,
           vertical: compact ? 7 : 11,
         ),
-        decoration: selected
-            ? BoxDecoration(
-                color: colorScheme.primary.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(9),
-                border: Border.all(color: colorScheme.primary.withValues(alpha: 0.6)),
-              )
-            : null,
+        decoration: !selected
+            ? null
+            : raised
+                ? BoxDecoration(
+                    color: colorScheme.surface,
+                    borderRadius: BorderRadius.circular(9),
+                    boxShadow: [
+                      BoxShadow(
+                        color: colorScheme.shadow.withValues(alpha: 0.08),
+                        blurRadius: 4,
+                        offset: const Offset(0, 1),
+                      ),
+                    ],
+                  )
+                : BoxDecoration(
+                    color: colorScheme.primary.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(9),
+                    border: Border.all(color: colorScheme.primary.withValues(alpha: 0.6)),
+                  ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/widgets/chat_model_selector.dart
+++ b/lib/widgets/chat_model_selector.dart
@@ -7,12 +7,25 @@ import '../models/llm_channel.dart';
 import '../models/llm_model.dart';
 import '../state/app_state.dart';
 
+/// How a [ChatModelSelector] presents itself.
+enum ChatModelSelectorStyle {
+  /// A bordered form field, for a selector standing among other inputs in a
+  /// dialog or toolbar.
+  field,
+
+  /// A card with the label above the value, for a selector that is a section
+  /// of a panel rather than one field of a form. Matches the [AppCard] blocks
+  /// it sits between, which a boxed input in the same column does not.
+  card,
+}
+
 class ChatModelSelector extends StatelessWidget {
   final int? selectedModelId;
   final ValueChanged<int?> onChanged;
   final String? label;
   final IconData? prefixIcon;
   final List<LLMModel>? models;
+  final ChatModelSelectorStyle style;
 
   const ChatModelSelector({
     super.key,
@@ -21,6 +34,7 @@ class ChatModelSelector extends StatelessWidget {
     this.label,
     this.prefixIcon,
     this.models,
+    this.style = ChatModelSelectorStyle.field,
   });
 
   @override
@@ -28,17 +42,43 @@ class ChatModelSelector extends StatelessWidget {
     final appState = Provider.of<AppState>(context);
     final l10n = AppLocalizations.of(context)!;
     final chatModels = models ?? appState.chatModels;
+    final colorScheme = Theme.of(context).colorScheme;
+    final isCard = style == ChatModelSelectorStyle.card;
 
     return DropdownButtonFormField<int>(
       initialValue: selectedModelId,
-      decoration: InputDecoration(
-        labelText: label ?? l10n.model,
-        // The selector's corner matches the buttons it sits beside, rather than
-        // Material's default 4 — a toolbar of mixed radii reads as mixed parts.
-        border: OutlineInputBorder(borderRadius: BorderRadius.circular(appButtonRadius)),
-        prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      ),
+      decoration: isCard
+          ? InputDecoration(
+              labelText: label ?? l10n.model,
+              labelStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+              filled: true,
+              fillColor: colorScheme.surface,
+              prefixIcon: prefixIcon != null ? Icon(prefixIcon, size: 18) : null,
+              // An outline, not a fill step: this sits inside a panel whose
+              // other blocks are outlined AppCards, and a second fill tone
+              // here would make it read as a different kind of thing.
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(color: colorScheme.outlineVariant),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+                borderSide: BorderSide(color: colorScheme.outlineVariant),
+              ),
+              contentPadding: const EdgeInsets.fromLTRB(12, 14, 12, 10),
+            )
+          : InputDecoration(
+              labelText: label ?? l10n.model,
+              // The selector's corner matches the buttons it sits beside, rather
+              // than Material's default 4 — a toolbar of mixed radii reads as
+              // mixed parts.
+              border: OutlineInputBorder(borderRadius: BorderRadius.circular(appButtonRadius)),
+              prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            ),
       items: chatModels.map((m) {
         final channel = appState.allChannels.cast<LLMChannel?>().firstWhere(
           (c) => c?.id == m.channelId, 

--- a/test/app_card_test.dart
+++ b/test/app_card_test.dart
@@ -28,4 +28,47 @@ void main() {
     await tester.tap(find.text('Row'));
     expect(tapped, isTrue);
   });
+
+  testWidgets('spans its column rather than hugging a short child', (tester) async {
+    // Cards stacked in a panel are bands across it. Left to shrink-wrap, one
+    // whose body is a short line came out a stub beside its neighbours — and
+    // whether any given card looked right was an accident of whether
+    // something inside it happened to be full-width already.
+    await tester.pumpWidget(MaterialApp(
+      theme: buildAppTheme(seedColor: seed, brightness: Brightness.light),
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          child: Column(
+            children: const [
+              AppCard(child: Text('short')),
+              AppCard(child: SizedBox(width: 300, height: 20)),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    final cards = find.byType(AppCard);
+    expect(tester.getSize(cards.at(0)).width, 400);
+    expect(tester.getSize(cards.at(1)).width, 400,
+        reason: 'A card sized itself from its content instead of its column');
+  });
+
+  testWidgets('a wide child still drives the height, not a fixed box', (tester) async {
+    // Full width must not mean a fixed size: the card still grows to whatever
+    // its body needs vertically.
+    await tester.pumpWidget(MaterialApp(
+      theme: buildAppTheme(seedColor: seed, brightness: Brightness.light),
+      home: const Scaffold(
+        body: SizedBox(
+          width: 400,
+          child: Column(children: [AppCard(child: SizedBox(height: 120))]),
+        ),
+      ),
+    ));
+
+    // 120 plus the card's default 12pt padding top and bottom.
+    expect(tester.getSize(find.byType(AppCard)).height, 144);
+  });
 }

--- a/test/knowledge_base_scan_tree_test.dart
+++ b/test/knowledge_base_scan_tree_test.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/services/knowledge_base_service.dart';
+import 'package:path/path.dart' as p;
+
+/// Counts behind the knowledge-base status card.
+///
+/// The number shown to the user is a promise about what the assistant can
+/// reach. If it counts files the agent cannot read, it is worse than showing
+/// nothing — so these pin it to exactly `listFiles`' rules rather than to a
+/// raw directory walk.
+void main() {
+  late Directory root;
+
+  setUp(() => root = Directory.systemTemp.createTempSync('kb_scan_'));
+  tearDown(() => root.deleteSync(recursive: true));
+
+  void writeFile(String relPath, {String body = '# rule'}) {
+    final file = File(p.join(root.path, relPath));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(body);
+  }
+
+  KbTreeStats scan() => KnowledgeBaseService().scanTree(root.path);
+
+  test('counts markdown files across the whole tree, not just the top level', () {
+    writeFile('README.md');
+    writeFile('04_cosplay.md');
+    writeFile('07_footwear/07b_socks.md');
+    writeFile('07_footwear/deep/nested.md');
+
+    final stats = scan();
+    expect(stats.files, 4);
+    expect(stats.directories, 2);
+  });
+
+  test('ignores anything the agent cannot read', () {
+    // listFiles surfaces only non-hidden .md; the count has to agree, or the
+    // card advertises documents the assistant will never open.
+    writeFile('README.md');
+    writeFile('notes.txt');
+    writeFile('image.png');
+    writeFile('.hidden/secret.md');
+
+    final stats = scan();
+    expect(stats.files, 1);
+    expect(stats.directories, 0, reason: 'A hidden directory was counted');
+  });
+
+  test('an empty base reports zero and no timestamp', () {
+    final stats = scan();
+    expect(stats.files, 0);
+    expect(stats.directories, 0);
+    expect(stats.newestModified, isNull);
+  });
+
+  test('reports the newest modification time in the tree', () async {
+    // This is what the card shows as "content updated at" — the honest answer
+    // to "will the assistant see the edit I just made". It has to track the
+    // newest file anywhere, including nested ones.
+    writeFile('README.md');
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    writeFile('07_footwear/07b_socks.md');
+
+    final newest = File(p.join(root.path, '07_footwear', '07b_socks.md')).statSync().modified;
+    final stats = scan();
+
+    expect(stats.newestModified, isNotNull);
+    expect(
+      stats.newestModified!.difference(newest).abs(),
+      lessThan(const Duration(seconds: 1)),
+      reason: 'Did not pick up the most recently written file',
+    );
+  });
+
+  test('a deeply nested base terminates instead of recursing forever', () {
+    // The containment check is lexical, so a symlink loop inside the root
+    // would pass it. A depth cap is the cheap guard; this pins that it holds.
+    var path = 'a';
+    for (var i = 0; i < 30; i++) {
+      path = p.join(path, 'a');
+    }
+    writeFile(p.join(path, 'deep.md'));
+
+    expect(scan, returnsNormally);
+  });
+}

--- a/test/optimizer_citations_test.dart
+++ b/test/optimizer_citations_test.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
+import 'package:joycai_image_ai_toolkits/services/prompt_optimizer_agent.dart';
+
+/// Which knowledge files the assistant's current answer rests on.
+///
+/// Shown to the user as "cited this round", so it has to mean something they
+/// can check: a file named here should be one the model actually still has in
+/// front of it. Derived from tool results rather than tracked in a set, for
+/// the same reason every other "what has been read" question in this
+/// subsystem is — see the deadlock documented in
+/// `test/optimizer_kb_liveness_test.dart`.
+void main() {
+  /// The assistant call + tool result pair the agent writes for one
+  /// `read_knowledge_file` that actually returned content.
+  void recordRead(PromptOptimizerSession session, String path, {int page = 1}) {
+    final callId = 'call_${session.history.length}';
+    session.history.add(LLMMessage(
+      role: LLMRole.assistant,
+      content: '',
+      toolCalls: [
+        LLMToolCall(id: callId, name: 'read_knowledge_file', arguments: {'path': path, 'page': page}),
+      ],
+    ));
+    session.history.add(LLMMessage(
+      role: LLMRole.tool,
+      content: jsonEncode({'path': path, 'page': page, 'total_pages': 1, 'content': 'rule body'}),
+      toolCallId: callId,
+      toolName: 'read_knowledge_file',
+    ));
+  }
+
+  /// What the agent returns when the model asks for a page it already has.
+  void recordCacheHit(PromptOptimizerSession session, String path) {
+    final callId = 'call_${session.history.length}';
+    session.history.add(LLMMessage(
+      role: LLMRole.assistant,
+      content: '',
+      toolCalls: [
+        LLMToolCall(id: callId, name: 'read_knowledge_file', arguments: {'path': path, 'page': 1}),
+      ],
+    ));
+    session.history.add(LLMMessage(
+      role: LLMRole.tool,
+      content: jsonEncode({'status': 'ok', 'path': path, 'note': 'already in the conversation'}),
+      toolCallId: callId,
+      toolName: 'read_knowledge_file',
+    ));
+  }
+
+  void recordFailedRead(PromptOptimizerSession session, String path) {
+    final callId = 'call_${session.history.length}';
+    session.history.add(LLMMessage(
+      role: LLMRole.assistant,
+      content: '',
+      toolCalls: [
+        LLMToolCall(id: callId, name: 'read_knowledge_file', arguments: {'path': path, 'page': 1}),
+      ],
+    ));
+    session.history.add(LLMMessage(
+      role: LLMRole.tool,
+      content: jsonEncode({'status': 'error', 'message': 'Directory not found: $path'}),
+      toolCallId: callId,
+      toolName: 'read_knowledge_file',
+    ));
+  }
+
+  void userSays(PromptOptimizerSession session, String text) {
+    session.history.add(LLMMessage(role: LLMRole.user, content: text));
+  }
+
+  PromptOptimizerSession newSession() => PromptOptimizerSession(mode: AssistantMode.knowledgeBase);
+
+  List<String> cited(PromptOptimizerSession s) => PromptOptimizerAgent.citedKnowledgeFiles(s);
+
+  test('a file read this turn is cited', () {
+    final s = newSession();
+    userSays(s, 'make it cinematic');
+    recordRead(s, '04_cosplay.md');
+
+    expect(cited(s), ['04_cosplay.md']);
+  });
+
+  test('files are listed in the order the agent consulted them', () {
+    // The list reads as a trail of the agent's work, so order carries meaning.
+    final s = newSession();
+    userSays(s, 'go');
+    recordRead(s, '07_footwear.md');
+    recordRead(s, '04_cosplay.md');
+
+    expect(cited(s), ['07_footwear.md', '04_cosplay.md']);
+  });
+
+  test('a file read once is cited once, however many pages', () {
+    final s = newSession();
+    userSays(s, 'go');
+    recordRead(s, '04_cosplay.md', page: 1);
+    recordRead(s, '04_cosplay.md', page: 2);
+
+    expect(cited(s), ['04_cosplay.md']);
+  });
+
+  test('a cache hit still counts — the model is using the file, not ignoring it', () {
+    // The whole reason the agent puts a `path` on the "already in the
+    // conversation" result. Without it, a template the answer leans on
+    // vanishes from the list the moment the model stops re-reading it.
+    final s = newSession();
+    userSays(s, 'first');
+    recordRead(s, '04_cosplay.md');
+    userSays(s, 'second');
+    recordCacheHit(s, '04_cosplay.md');
+
+    expect(cited(s), contains('04_cosplay.md'));
+  });
+
+  test('a failed read is not a citation', () {
+    // It carries no path and no content; claiming the answer rests on a file
+    // the agent could not open would be a lie the user cannot check.
+    final s = newSession();
+    userSays(s, 'go');
+    recordFailedRead(s, 'nope.md');
+
+    expect(cited(s), isEmpty);
+  });
+
+  test('a read still inside the live window survives a later turn', () {
+    // Grounded-in, not read-this-turn: the file is still going out with every
+    // request, so it is still holding the answer up.
+    final s = newSession();
+    userSays(s, 'first');
+    recordRead(s, '04_cosplay.md');
+    userSays(s, 'second');
+
+    expect(cited(s), ['04_cosplay.md']);
+  });
+
+  test('a read that has fallen out of the live window is dropped', () {
+    // Once layer 1 elides it, the model genuinely no longer has it, so the
+    // claim would stop being true. This is the property that keeps the list
+    // honest rather than ever-growing.
+    final s = newSession();
+    userSays(s, 'first');
+    recordRead(s, 'ancient.md');
+    for (var i = 0; i < 6; i++) {
+      userSays(s, 'turn $i');
+      recordRead(s, 'recent_$i.md');
+    }
+
+    expect(cited(s), isNot(contains('ancient.md')));
+    expect(cited(s), contains('recent_5.md'));
+  });
+
+  test('other knowledge tools are not citations', () {
+    // Listing a directory is not reading a document.
+    final s = newSession();
+    userSays(s, 'go');
+    s.history.add(LLMMessage(
+      role: LLMRole.tool,
+      content: jsonEncode({'files': [], 'path': '07_footwear'}),
+      toolCallId: 'c1',
+      toolName: 'list_knowledge_files',
+    ));
+
+    expect(cited(s), isEmpty);
+  });
+
+  test('a session that read nothing cites nothing', () {
+    final s = newSession();
+    userSays(s, 'just chat');
+
+    expect(cited(s), isEmpty);
+  });
+}

--- a/test/optimizer_kb_init_button_test.dart
+++ b/test/optimizer_kb_init_button_test.dart
@@ -113,7 +113,15 @@ void main() {
     await pumpPanel(tester, KbStatus.ok);
     final l10n = await en();
 
-    final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+    // Scoped to this button: once the base is valid the card also offers
+    // rescan and open-in-folder, and the folder action carries a tooltip of
+    // its own.
+    final tooltip = tester.widget<Tooltip>(
+      find.ancestor(
+        of: find.text(l10n.kbScaffoldCreate),
+        matching: find.byType(Tooltip),
+      ),
+    );
     expect(
       tooltip.message,
       l10n.kbScaffoldAlreadyInit(KnowledgeBaseService.entryFileName),

--- a/untranslated_messages.txt
+++ b/untranslated_messages.txt
@@ -1,15 +1,9 @@
 {
   "ja": [
-    "noTasks",
-    "sendToFirstFrame",
-    "sendToLastFrame",
-    "sendToVideoReferences"
+    "noTasks"
   ],
 
   "zh_Hant": [
-    "noTasks",
-    "sendToFirstFrame",
-    "sendToLastFrame",
-    "sendToVideoReferences"
+    "noTasks"
   ]
 }


### PR DESCRIPTION
## Summary

The seven-point Prompt Assistant redesign, plus the data it needed. Three commits, reviewable in order — layout fix, service derivations, then the UI.

## The one thing I changed from the design

The knowledge-base card was specced as **"last indexed 21:02"** with a **"re-index"** button. There is no index. `KnowledgeBaseService` is a stateless on-demand file reader, and the agent re-reads the entry file at the start of every turn — so it is never stale; only the card can be. Building an index would add the subsystem's only cache to invalidate, for nothing.

Agreed with @Joycai to show **"content updated at"** (the newest file's own mtime) and **"rescan"** instead. That answers the question actually being asked — *will the assistant see the edit I just made* — and stays true across a restart.

"Cited this round" similarly derives from tool results over the live window rather than a tracked set, following the discipline the subsystem already documents (a tracked set is what deadlocked it before — see `docs/architecture/assistant-context.md`).

## Two bugs found along the way

- **Panels were shrink-wrapping and floating mid-canvas.** The layout `Row` used the default centre alignment, so a panel whose body is a bare `SingleChildScrollView` collapsed to its content height. That is what the "empty space below the settings panel" was — not a float. The **metadata inspector had the identical bug**, unnoticed; stretching the row fixes both.
- **zh_Hant and ja were each missing three workbench strings**, silently falling back to English on the video send-to actions. Backfilled.

## Behaviour changes worth flagging

- **Enter now sends; Shift+Enter breaks the line.** Was Ctrl+Enter. The design calls for it and every other chat box works this way, but it is muscle memory for anyone using this today.
- The initialize button **stays visible-and-disabled** once the base is valid. I had removed it, then put it back: the rationale for showing it disabled is recorded in a comment next to it and pinned by three tests. Rescan sits alongside rather than replacing it.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 362 pass, including 14 new ones covering the citation derivation (ordering, cache hits, failed reads, the live-window boundary) and the tree scan (nested counts, hidden-file exclusion, newest mtime, depth cap)
- [ ] **Needs a real run.** Dialog and layout work is hard to assert on visually. Worth checking: the timeline card on a turn with many tool calls, the KB card against a real knowledge base, and the composer with the bottom console dragged up.

Two carried-over items still unverified from earlier PRs: the Windows caption colour (#63) and the channel wizard / model discovery dialogs (#64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)