### PR TITLE
refactor(ui): rebuild Crop & Resize to the new design

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -101,6 +101,31 @@ ThemeData buildAppTheme({
         visualDensity: VisualDensity.standard,
       ),
     ),
+    // The other two button types need the same shape, or the library's own
+    // abstraction leaks: AppButton's `text` and `destructiveOutline` variants
+    // are built on TextButton and OutlinedButton, and with no theme of their
+    // own they keep Material 3's StadiumBorder. A row of Reset / Overwrite /
+    // Save then renders as two pills beside a rounded rectangle — the shared
+    // component is being used, but the theme never reaches through it.
+    //
+    // Only geometry is set here. Foreground colour is deliberately left to
+    // Material, so a dialog's "Cancel" keeps the accent tint it is supposed
+    // to have; a button that wants to be quiet says so at its call site.
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(appButtonRadius)),
+        minimumSize: const Size(0, appButtonMinHeight),
+        side: BorderSide(color: colorScheme.outline.withValues(alpha: 0.6)),
+        visualDensity: VisualDensity.standard,
+      ),
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(appButtonRadius)),
+        minimumSize: const Size(0, appButtonMinHeight),
+        visualDensity: VisualDensity.standard,
+      ),
+    ),
   );
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -963,11 +963,75 @@
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",
+  "cropResizeFreeRatio": "Free",
   "resize": "Resize",
   "maintainAspectRatio": "Maintain Aspect Ratio",
   "width": "Width",
   "height": "Height",
   "sampling": "Sampling",
+  "reset": "Reset",
+  "cropResizeOriginalInfo": "Original {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name} (Original Preview)",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "Crop",
+  "cropResizeCropAndScale": "Crop + Scale {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "Output Preview",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "Copy will save to {path}",
+  "cropResizeTempWorkspaceLabel": "Temporary Workspace",
+  "saveCopy": "Save Copy",
+  "cropResizeSaveDestinationHint": "to Workspace",
+  "cropResizeResample": "Resample",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "Fit to Window",
   "drawMask": "Draw Mask",
   "maskEditor": "Mask Editor",
   "brushSize": "Brush Size",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -823,11 +823,75 @@
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",
+  "cropResizeFreeRatio": "フリー",
   "resize": "サイズ変更",
   "maintainAspectRatio": "アスペクト比を維持",
   "width": "幅",
   "height": "高さ",
   "sampling": "サンプリング",
+  "reset": "リセット",
+  "cropResizeOriginalInfo": "元画像 {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name}（元画像プレビュー）",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "切り抰き",
+  "cropResizeCropAndScale": "切り抰き + 拡大縮小 {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "出力プレビュー",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "コピーの保存先: {path}",
+  "cropResizeTempWorkspaceLabel": "一時ワークスペース",
+  "saveCopy": "コピーを保存",
+  "cropResizeSaveDestinationHint": "ワークスペースへ",
+  "cropResizeResample": "リサンプル",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "ウィンドウに合わせる",
   "drawMask": "マスクを描画",
   "maskEditor": "マスクエディタ",
   "brushSize": "ブラシサイズ",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3641,6 +3641,12 @@ abstract class AppLocalizations {
   /// **'Custom'**
   String get custom;
 
+  /// No description provided for @cropResizeFreeRatio.
+  ///
+  /// In en, this message translates to:
+  /// **'Free'**
+  String get cropResizeFreeRatio;
+
   /// No description provided for @resize.
   ///
   /// In en, this message translates to:
@@ -3670,6 +3676,89 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sampling'**
   String get sampling;
+
+  /// No description provided for @reset.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset'**
+  String get reset;
+
+  /// No description provided for @cropResizeOriginalInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Original {width}×{height} · {size}'**
+  String cropResizeOriginalInfo(int width, int height, String size);
+
+  /// No description provided for @cropResizeCanvasLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} (Original Preview)'**
+  String cropResizeCanvasLabel(String name);
+
+  /// No description provided for @cropResizeCropOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Crop'**
+  String get cropResizeCropOnly;
+
+  /// No description provided for @cropResizeCropAndScale.
+  ///
+  /// In en, this message translates to:
+  /// **'Crop + Scale {percent}%'**
+  String cropResizeCropAndScale(int percent);
+
+  /// No description provided for @cropResizeOutputPreview.
+  ///
+  /// In en, this message translates to:
+  /// **'Output Preview'**
+  String get cropResizeOutputPreview;
+
+  /// No description provided for @cropResizeOutputSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'{originalSize} → {outputSize} · {operation} · {sampling}'**
+  String cropResizeOutputSummary(
+    String originalSize,
+    String outputSize,
+    String operation,
+    String sampling,
+  );
+
+  /// No description provided for @cropResizeWillSaveTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy will save to {path}'**
+  String cropResizeWillSaveTo(String path);
+
+  /// No description provided for @cropResizeTempWorkspaceLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Temporary Workspace'**
+  String get cropResizeTempWorkspaceLabel;
+
+  /// No description provided for @saveCopy.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Copy'**
+  String get saveCopy;
+
+  /// No description provided for @cropResizeSaveDestinationHint.
+  ///
+  /// In en, this message translates to:
+  /// **'to Workspace'**
+  String get cropResizeSaveDestinationHint;
+
+  /// No description provided for @cropResizeResample.
+  ///
+  /// In en, this message translates to:
+  /// **'Resample'**
+  String get cropResizeResample;
+
+  /// No description provided for @fitToWindow.
+  ///
+  /// In en, this message translates to:
+  /// **'Fit to Window'**
+  String get fitToWindow;
 
   /// No description provided for @drawMask.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1949,6 +1949,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get custom => 'Custom';
 
   @override
+  String get cropResizeFreeRatio => 'Free';
+
+  @override
   String get resize => 'Resize';
 
   @override
@@ -1962,6 +1965,60 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sampling => 'Sampling';
+
+  @override
+  String get reset => 'Reset';
+
+  @override
+  String cropResizeOriginalInfo(int width, int height, String size) {
+    return 'Original $width×$height · $size';
+  }
+
+  @override
+  String cropResizeCanvasLabel(String name) {
+    return '$name (Original Preview)';
+  }
+
+  @override
+  String get cropResizeCropOnly => 'Crop';
+
+  @override
+  String cropResizeCropAndScale(int percent) {
+    return 'Crop + Scale $percent%';
+  }
+
+  @override
+  String get cropResizeOutputPreview => 'Output Preview';
+
+  @override
+  String cropResizeOutputSummary(
+    String originalSize,
+    String outputSize,
+    String operation,
+    String sampling,
+  ) {
+    return '$originalSize → $outputSize · $operation · $sampling';
+  }
+
+  @override
+  String cropResizeWillSaveTo(String path) {
+    return 'Copy will save to $path';
+  }
+
+  @override
+  String get cropResizeTempWorkspaceLabel => 'Temporary Workspace';
+
+  @override
+  String get saveCopy => 'Save Copy';
+
+  @override
+  String get cropResizeSaveDestinationHint => 'to Workspace';
+
+  @override
+  String get cropResizeResample => 'Resample';
+
+  @override
+  String get fitToWindow => 'Fit to Window';
 
   @override
   String get drawMask => 'Draw Mask';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1905,6 +1905,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get custom => 'カスタム';
 
   @override
+  String get cropResizeFreeRatio => 'フリー';
+
+  @override
   String get resize => 'サイズ変更';
 
   @override
@@ -1918,6 +1921,60 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get sampling => 'サンプリング';
+
+  @override
+  String get reset => 'リセット';
+
+  @override
+  String cropResizeOriginalInfo(int width, int height, String size) {
+    return '元画像 $width×$height · $size';
+  }
+
+  @override
+  String cropResizeCanvasLabel(String name) {
+    return '$name（元画像プレビュー）';
+  }
+
+  @override
+  String get cropResizeCropOnly => '切り抰き';
+
+  @override
+  String cropResizeCropAndScale(int percent) {
+    return '切り抰き + 拡大縮小 $percent%';
+  }
+
+  @override
+  String get cropResizeOutputPreview => '出力プレビュー';
+
+  @override
+  String cropResizeOutputSummary(
+    String originalSize,
+    String outputSize,
+    String operation,
+    String sampling,
+  ) {
+    return '$originalSize → $outputSize · $operation · $sampling';
+  }
+
+  @override
+  String cropResizeWillSaveTo(String path) {
+    return 'コピーの保存先: $path';
+  }
+
+  @override
+  String get cropResizeTempWorkspaceLabel => '一時ワークスペース';
+
+  @override
+  String get saveCopy => 'コピーを保存';
+
+  @override
+  String get cropResizeSaveDestinationHint => 'ワークスペースへ';
+
+  @override
+  String get cropResizeResample => 'リサンプル';
+
+  @override
+  String get fitToWindow => 'ウィンドウに合わせる';
 
   @override
   String get drawMask => 'マスクを描画';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1891,6 +1891,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get custom => '自定义';
 
   @override
+  String get cropResizeFreeRatio => '自由';
+
+  @override
   String get resize => '缩放';
 
   @override
@@ -1904,6 +1907,60 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get sampling => '采样方式';
+
+  @override
+  String get reset => '重置';
+
+  @override
+  String cropResizeOriginalInfo(int width, int height, String size) {
+    return '原图 $width×$height · $size';
+  }
+
+  @override
+  String cropResizeCanvasLabel(String name) {
+    return '$name（原图预览）';
+  }
+
+  @override
+  String get cropResizeCropOnly => '裁剪';
+
+  @override
+  String cropResizeCropAndScale(int percent) {
+    return '裁剪 + 缩放 $percent%';
+  }
+
+  @override
+  String get cropResizeOutputPreview => '输出预览';
+
+  @override
+  String cropResizeOutputSummary(
+    String originalSize,
+    String outputSize,
+    String operation,
+    String sampling,
+  ) {
+    return '$originalSize → $outputSize · $operation · $sampling';
+  }
+
+  @override
+  String cropResizeWillSaveTo(String path) {
+    return '副本将存入 $path';
+  }
+
+  @override
+  String get cropResizeTempWorkspaceLabel => '临时工作区';
+
+  @override
+  String get saveCopy => '保存副本';
+
+  @override
+  String get cropResizeSaveDestinationHint => '到工作区';
+
+  @override
+  String get cropResizeResample => '重采样';
+
+  @override
+  String get fitToWindow => '适应窗口';
 
   @override
   String get drawMask => '绘制蒙版';
@@ -4274,6 +4331,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get custom => '自訂';
 
   @override
+  String get cropResizeFreeRatio => '自由';
+
+  @override
   String get resize => '調整大小';
 
   @override
@@ -4287,6 +4347,60 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get sampling => '採樣';
+
+  @override
+  String get reset => '重設';
+
+  @override
+  String cropResizeOriginalInfo(int width, int height, String size) {
+    return '原圖 $width×$height · $size';
+  }
+
+  @override
+  String cropResizeCanvasLabel(String name) {
+    return '$name（原圖預覽）';
+  }
+
+  @override
+  String get cropResizeCropOnly => '裁切';
+
+  @override
+  String cropResizeCropAndScale(int percent) {
+    return '裁切 + 縮放 $percent%';
+  }
+
+  @override
+  String get cropResizeOutputPreview => '輸出預覽';
+
+  @override
+  String cropResizeOutputSummary(
+    String originalSize,
+    String outputSize,
+    String operation,
+    String sampling,
+  ) {
+    return '$originalSize → $outputSize · $operation · $sampling';
+  }
+
+  @override
+  String cropResizeWillSaveTo(String path) {
+    return '副本將存入 $path';
+  }
+
+  @override
+  String get cropResizeTempWorkspaceLabel => '臨時工作區';
+
+  @override
+  String get saveCopy => '儲存副本';
+
+  @override
+  String get cropResizeSaveDestinationHint => '到工作區';
+
+  @override
+  String get cropResizeResample => '重新取樣';
+
+  @override
+  String get fitToWindow => '適應視窗';
 
   @override
   String get drawMask => '繪製遮罩';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -949,11 +949,75 @@
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",
+  "cropResizeFreeRatio": "自由",
   "resize": "缩放",
   "maintainAspectRatio": "保持纵横比",
   "width": "宽度",
   "height": "高度",
   "sampling": "采样方式",
+  "reset": "重置",
+  "cropResizeOriginalInfo": "原图 {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name}（原图预览）",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "裁剪",
+  "cropResizeCropAndScale": "裁剪 + 缩放 {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "输出预览",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "副本将存入 {path}",
+  "cropResizeTempWorkspaceLabel": "临时工作区",
+  "saveCopy": "保存副本",
+  "cropResizeSaveDestinationHint": "到工作区",
+  "cropResizeResample": "重采样",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "适应窗口",
   "drawMask": "绘制蒙版",
   "maskEditor": "蒙版编辑器",
   "brushSize": "画笔大小",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -823,11 +823,75 @@
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",
+  "cropResizeFreeRatio": "自由",
   "resize": "調整大小",
   "maintainAspectRatio": "保持長寬比",
   "width": "寬度",
   "height": "高度",
   "sampling": "採樣",
+  "reset": "重設",
+  "cropResizeOriginalInfo": "原圖 {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name}（原圖預覽）",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "裁切",
+  "cropResizeCropAndScale": "裁切 + 縮放 {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "輸出預覽",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "副本將存入 {path}",
+  "cropResizeTempWorkspaceLabel": "臨時工作區",
+  "saveCopy": "儲存副本",
+  "cropResizeSaveDestinationHint": "到工作區",
+  "cropResizeResample": "重新取樣",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "適應視窗",
   "drawMask": "繪製遮罩",
   "maskEditor": "遮罩編輯器",
   "brushSize": "畫筆大小",

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -154,11 +154,75 @@
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",
+  "cropResizeFreeRatio": "Free",
   "resize": "Resize",
   "maintainAspectRatio": "Maintain Aspect Ratio",
   "width": "Width",
   "height": "Height",
   "sampling": "Sampling",
+  "reset": "Reset",
+  "cropResizeOriginalInfo": "Original {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name} (Original Preview)",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "Crop",
+  "cropResizeCropAndScale": "Crop + Scale {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "Output Preview",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "Copy will save to {path}",
+  "cropResizeTempWorkspaceLabel": "Temporary Workspace",
+  "saveCopy": "Save Copy",
+  "cropResizeSaveDestinationHint": "to Workspace",
+  "cropResizeResample": "Resample",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "Fit to Window",
   "drawMask": "Draw Mask",
   "maskEditor": "Mask Editor",
   "brushSize": "Brush Size",

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -154,11 +154,75 @@
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",
+  "cropResizeFreeRatio": "フリー",
   "resize": "サイズ変更",
   "maintainAspectRatio": "アスペクト比を維持",
   "width": "幅",
   "height": "高さ",
   "sampling": "サンプリング",
+  "reset": "リセット",
+  "cropResizeOriginalInfo": "元画像 {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name}（元画像プレビュー）",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "切り抰き",
+  "cropResizeCropAndScale": "切り抰き + 拡大縮小 {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "出力プレビュー",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "コピーの保存先: {path}",
+  "cropResizeTempWorkspaceLabel": "一時ワークスペース",
+  "saveCopy": "コピーを保存",
+  "cropResizeSaveDestinationHint": "ワークスペースへ",
+  "cropResizeResample": "リサンプル",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "ウィンドウに合わせる",
   "drawMask": "マスクを描画",
   "maskEditor": "マスクエディタ",
   "brushSize": "ブラシサイズ",

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -154,11 +154,75 @@
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",
+  "cropResizeFreeRatio": "自由",
   "resize": "缩放",
   "maintainAspectRatio": "保持纵横比",
   "width": "宽度",
   "height": "高度",
   "sampling": "采样方式",
+  "reset": "重置",
+  "cropResizeOriginalInfo": "原图 {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name}（原图预览）",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "裁剪",
+  "cropResizeCropAndScale": "裁剪 + 缩放 {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "输出预览",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "副本将存入 {path}",
+  "cropResizeTempWorkspaceLabel": "临时工作区",
+  "saveCopy": "保存副本",
+  "cropResizeSaveDestinationHint": "到工作区",
+  "cropResizeResample": "重采样",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "适应窗口",
   "drawMask": "绘制蒙版",
   "maskEditor": "蒙版编辑器",
   "brushSize": "画笔大小",

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -154,11 +154,75 @@
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",
+  "cropResizeFreeRatio": "自由",
   "resize": "調整大小",
   "maintainAspectRatio": "保持長寬比",
   "width": "寬度",
   "height": "高度",
   "sampling": "採樣",
+  "reset": "重設",
+  "cropResizeOriginalInfo": "原圖 {width}×{height} · {size}",
+  "@cropResizeOriginalInfo": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      },
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCanvasLabel": "{name}（原圖預覽）",
+  "@cropResizeCanvasLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeCropOnly": "裁切",
+  "cropResizeCropAndScale": "裁切 + 縮放 {percent}%",
+  "@cropResizeCropAndScale": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "cropResizeOutputPreview": "輸出預覽",
+  "cropResizeOutputSummary": "{originalSize} → {outputSize} · {operation} · {sampling}",
+  "@cropResizeOutputSummary": {
+    "placeholders": {
+      "originalSize": {
+        "type": "String"
+      },
+      "outputSize": {
+        "type": "String"
+      },
+      "operation": {
+        "type": "String"
+      },
+      "sampling": {
+        "type": "String"
+      }
+    }
+  },
+  "cropResizeWillSaveTo": "副本將存入 {path}",
+  "cropResizeTempWorkspaceLabel": "臨時工作區",
+  "saveCopy": "儲存副本",
+  "cropResizeSaveDestinationHint": "到工作區",
+  "cropResizeResample": "重新取樣",
+  "@cropResizeWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "fitToWindow": "適應視窗",
   "drawMask": "繪製遮罩",
   "maskEditor": "遮罩編輯器",
   "brushSize": "畫筆大小",

--- a/lib/screens/workbench/widgets/crop_resize_toolbar.dart
+++ b/lib/screens/workbench/widgets/crop_resize_toolbar.dart
@@ -6,14 +6,41 @@ import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 
 import '../../../core/app_paths.dart';
+import '../../../core/app_theme.dart';
 import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/app_image.dart';
+import '../../../services/image_metadata_service.dart';
 import '../../../services/image_processing_service.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
+import '../../../widgets/app_icon_button.dart';
+import '../../../widgets/app_segmented_control.dart';
+import '../../../widgets/app_snackbar.dart';
+import '../../../widgets/app_tool_button.dart';
+
+/// The fixed set of ratio presets shown as segments, plus a `custom` mode
+/// whose X:Y fields only appear once it's selected — folding them into the
+/// segmented control instead of always occupying toolbar width.
+enum _RatioPreset { free, r1x1, r4x3, r16x9, r3x4, r9x16, custom }
+
+/// Everything the bar spends before any group gets a say: its own horizontal
+/// padding, the back button, the two dividers, and the gap before the
+/// actions.
+const double _kFixedChrome = 32 + 48 + 25 + 25 + 12;
+
+/// The file caption is given a fixed column so a long filename ellipsizes
+/// rather than pushing the controls along.
+const double _kFileInfoWidth = 190;
+
+/// Room for the number inside a dimension field — wide enough for five
+/// digits, which covers any image the editor can open.
+const double _kNumberFieldWidth = 46;
+
+/// The X:Y pair that unfolds under the "Custom" segment.
+const double _kCustomRatioFieldsWidth = 80;
 
 class CropResizeToolbar extends StatefulWidget {
   const CropResizeToolbar({super.key});
@@ -27,8 +54,26 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
   final TextEditingController _heightController = TextEditingController();
   final TextEditingController _ratioXController = TextEditingController();
   final TextEditingController _ratioYController = TextEditingController();
-  bool _isProcessing = false;
+
+  /// null: no save in flight, otherwise 'save' or 'overwrite' — tracks which
+  /// button to spin rather than blanking the whole action group.
+  String? _processingAction;
   bool _isAutoUpdating = false;
+  bool _customRatioMode = false;
+
+  /// Source dimensions for the toolbar caption. The view loads this too;
+  /// [ImageMetadataService] caches by path, so the second reader costs a map
+  /// lookup rather than a second decode.
+  ImageMetadata? _meta;
+  String? _metaPath;
+
+  void _loadMeta(String path) {
+    if (_metaPath == path) return;
+    _metaPath = path;
+    ImageMetadataService().getMetadata(path).then((meta) {
+      if (mounted && _metaPath == path) setState(() => _meta = meta);
+    });
+  }
 
   @override
   void initState() {
@@ -51,39 +96,37 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
   void _onWidthChanged() {
     if (_isAutoUpdating) return;
     final uiState = Provider.of<WorkbenchUIState>(context, listen: false);
-    if (!uiState.maintainAspectRatio) return;
+    final w = int.tryParse(_widthController.text);
 
-    final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
-    if (state == null) return;
-    final cropRect = state.getCropRect();
-    if (cropRect == null) return;
-
-    final double ratio = cropRect.width / cropRect.height;
-    final int? w = int.tryParse(_widthController.text);
-    if (w != null) {
-      _isAutoUpdating = true;
-      _heightController.text = (w / ratio).round().toString();
-      _isAutoUpdating = false;
+    if (uiState.maintainAspectRatio) {
+      final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
+      final cropRect = state?.getCropRect();
+      if (cropRect != null && w != null) {
+        final double ratio = cropRect.width / cropRect.height;
+        _isAutoUpdating = true;
+        _heightController.text = (w / ratio).round().toString();
+        _isAutoUpdating = false;
+      }
     }
+    uiState.setTargetDimensions(w, int.tryParse(_heightController.text));
   }
 
   void _onHeightChanged() {
     if (_isAutoUpdating) return;
     final uiState = Provider.of<WorkbenchUIState>(context, listen: false);
-    if (!uiState.maintainAspectRatio) return;
+    final h = int.tryParse(_heightController.text);
 
-    final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
-    if (state == null) return;
-    final cropRect = state.getCropRect();
-    if (cropRect == null) return;
-
-    final double ratio = cropRect.width / cropRect.height;
-    final int? h = int.tryParse(_heightController.text);
-    if (h != null) {
-      _isAutoUpdating = true;
-      _widthController.text = (h * ratio).round().toString();
-      _isAutoUpdating = false;
+    if (uiState.maintainAspectRatio) {
+      final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
+      final cropRect = state?.getCropRect();
+      if (cropRect != null && h != null) {
+        final double ratio = cropRect.width / cropRect.height;
+        _isAutoUpdating = true;
+        _widthController.text = (h * ratio).round().toString();
+        _isAutoUpdating = false;
+      }
     }
+    uiState.setTargetDimensions(int.tryParse(_widthController.text), h);
   }
 
   @override
@@ -115,6 +158,56 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
     }
     _isAutoUpdating = false;
     Provider.of<WorkbenchUIState>(context, listen: false).setCropAspectRatio(ratio);
+  }
+
+  void _selectRatioPreset(_RatioPreset preset) {
+    setState(() => _customRatioMode = preset == _RatioPreset.custom);
+    switch (preset) {
+      case _RatioPreset.free:
+        _updateAspectRatio(null);
+      case _RatioPreset.r1x1:
+        _updateAspectRatio(1.0);
+      case _RatioPreset.r4x3:
+        _updateAspectRatio(4 / 3);
+      case _RatioPreset.r16x9:
+        _updateAspectRatio(16 / 9);
+      case _RatioPreset.r3x4:
+        _updateAspectRatio(3 / 4);
+      case _RatioPreset.r9x16:
+        _updateAspectRatio(9 / 16);
+      case _RatioPreset.custom:
+        // Expands the X:Y fields only; the ratio itself changes once the
+        // user actually types into them (via _onRatioChanged).
+        break;
+    }
+  }
+
+  _RatioPreset _currentPreset(double? ratio) {
+    if (_customRatioMode) return _RatioPreset.custom;
+    if (ratio == null) return _RatioPreset.free;
+    if (ratio == 1.0) return _RatioPreset.r1x1;
+    if (ratio > 1.3 && ratio < 1.4) return _RatioPreset.r4x3;
+    if (ratio > 1.7 && ratio < 1.8) return _RatioPreset.r16x9;
+    if (ratio > 0.7 && ratio < 0.8) return _RatioPreset.r3x4;
+    if (ratio > 0.5 && ratio < 0.6) return _RatioPreset.r9x16;
+    return _RatioPreset.custom;
+  }
+
+  void _handleReset() {
+    final uiState = Provider.of<WorkbenchUIState>(context, listen: false);
+    final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
+    state?.reset();
+
+    _isAutoUpdating = true;
+    _widthController.clear();
+    _heightController.clear();
+    _ratioXController.clear();
+    _ratioYController.clear();
+    _isAutoUpdating = false;
+
+    setState(() => _customRatioMode = false);
+    uiState.setCropAspectRatio(null);
+    uiState.setTargetDimensions(null, null);
   }
 
   Future<void> _handleSave({bool overwrite = false}) async {
@@ -149,7 +242,7 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
     }
 
     if (!mounted) return;
-    setState(() => _isProcessing = true);
+    setState(() => _processingAction = overwrite ? 'overwrite' : 'save');
 
     try {
       final sourceImage = uiState.cropResizeSourceImage;
@@ -206,28 +299,21 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
 
       if (!mounted) return;
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(successMessage),
-          backgroundColor: Colors.green,
-        ),
-      );
+      AppSnackBar.success(context, successMessage);
 
       if (!overwrite) {
         final newFile = AppImage(path: targetPath, name: targetName);
         appState.galleryState.addDroppedFiles([newFile]);
       }
-      
+
       appState.galleryState.refreshImages();
       appState.setWorkbenchTab(0);
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Error: $e"), backgroundColor: Colors.red),
-        );
+        AppSnackBar.error(context, "Error: $e");
       }
     } finally {
-      if (mounted) setState(() => _isProcessing = false);
+      if (mounted) setState(() => _processingAction = null);
     }
   }
 
@@ -242,11 +328,43 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
       return _buildMobileToolbar(context, l10n, uiState, colorScheme);
     }
 
+    final source = uiState.cropResizeSourceImage;
+    if (source != null) _loadMeta(source.path);
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final double width = constraints.maxWidth;
-        final bool isMedium = width < 1250;
-        final bool isSmall = width < 1050;
+        final busy = _processingAction != null;
+
+        // Degradation order, loosest thing first: the file caption (the
+        // canvas repeats the name anyway), then the sampler's own label,
+        // then the two portrait presets, then the save button's destination
+        // hint. The action *labels* go last — telling copy from overwrite is
+        // the whole point of the bar, and three unlabelled icons is exactly
+        // what this redesign set out to remove.
+        //
+        // Each step is taken only if what is left still does not fit, and
+        // "fit" is measured rather than guessed. A pixel threshold tuned
+        // against English collapses the bar far too early in Japanese, and
+        // far too late once the user scales text up.
+        var showFileInfo = source != null;
+        var showSamplingLabel = true;
+        var showAllRatios = true;
+        var showSaveHint = true;
+        var labelledActions = true;
+
+        double needed() =>
+            _kFixedChrome +
+            (showFileInfo ? _kFileInfoWidth + 4 : 0) +
+            _ratioGroupWidth(l10n, showAllRatios) +
+            _sizeGroupWidth(l10n, showSamplingLabel) +
+            _actionsWidth(l10n, labelledActions, showSaveHint);
+
+        if (needed() > width) showFileInfo = false;
+        if (needed() > width) showSamplingLabel = false;
+        if (needed() > width) showAllRatios = false;
+        if (needed() > width) showSaveHint = false;
+        if (needed() > width) labelledActions = false;
 
         return Container(
           height: 64,
@@ -262,29 +380,30 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
                 onPressed: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
                 tooltip: l10n.cancel,
               ),
-              VerticalDivider(width: isSmall ? 16 : 24, indent: 16, endIndent: 16),
-              
-              // Aspect Ratio Section
-              Flexible(
-                flex: 4,
-                child: _buildDesktopRatioSelector(l10n, uiState, colorScheme, isSmall),
+              if (showFileInfo && source != null) ...[
+                const SizedBox(width: 4),
+                _buildFileInfo(source, l10n, colorScheme),
+              ],
+              _divider(colorScheme),
+
+              // Ratio and size share one scroller: whatever the breakpoints
+              // fail to predict scrolls out of reach instead of clipping,
+              // which is how the gallery toolbar's overflow bug read.
+              Expanded(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      _buildDesktopRatioSelector(l10n, uiState, colorScheme, !showAllRatios),
+                      _divider(colorScheme),
+                      _buildDesktopResizeControls(l10n, uiState, colorScheme, !showSamplingLabel),
+                    ],
+                  ),
+                ),
               ),
-              
-              VerticalDivider(width: isSmall ? 24 : 32, indent: 16, endIndent: 16),
 
-              // Resize Section
-              Flexible(
-                flex: 3,
-                child: _buildDesktopResizeControls(l10n, uiState, colorScheme, isSmall),
-              ),
-
-              const SizedBox(width: 8),
-
-              // Actions Section
-              if (_isProcessing)
-                const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2))
-              else
-                _buildDesktopSaveActions(l10n, colorScheme, isMedium),
+              const SizedBox(width: 12),
+              _buildDesktopSaveActions(l10n, colorScheme, !labelledActions, showSaveHint, busy),
             ],
           ),
         );
@@ -292,22 +411,140 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
     );
   }
 
-  Widget _buildDesktopSaveActions(AppLocalizations l10n, ColorScheme colorScheme, bool compact) {
+  Widget _divider(ColorScheme colorScheme) => Container(
+        width: 1,
+        height: 28,
+        margin: const EdgeInsets.symmetric(horizontal: 12),
+        // An explicit box, not VerticalDivider: a Row centres its children by
+        // default, so the divider gets a loose height constraint and collapses
+        // to nothing.
+        color: colorScheme.outlineVariant.withValues(alpha: 0.7),
+      );
+
+  /// Natural width of [text] at [style], honouring the user's text scale.
+  double _textWidth(String text, TextStyle? style) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: Directionality.of(context),
+      maxLines: 1,
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout();
+    return painter.width;
+  }
+
+  /// Width the ratio segments occupy. 20 is a segment's own compact padding,
+  /// 8 the track's — see [AppSegmentedControl]. Measured at the selected
+  /// weight, which is the wider of the two.
+  double _ratioGroupWidth(AppLocalizations l10n, bool allRatios) {
+    const style = TextStyle(fontSize: 11.5, fontWeight: FontWeight.w700);
+    final labels = <String>[
+      l10n.cropResizeFreeRatio,
+      '1:1',
+      '4:3',
+      '16:9',
+      if (allRatios) ...['3:4', '9:16'],
+      l10n.custom,
+    ];
+
+    var width = 8.0;
+    for (final label in labels) {
+      width += 20 + _textWidth(label, style);
+    }
+    if (_customRatioMode) width += 8 + _kCustomRatioFieldsWidth;
+    return width;
+  }
+
+  double _sizeGroupWidth(AppLocalizations l10n, bool samplingLabel) {
+    final textTheme = Theme.of(context).textTheme;
+
+    double field(String label) =>
+        22 + _textWidth(label, textTheme.bodySmall) + 8 + _kNumberFieldWidth + _textWidth('px', textTheme.bodySmall);
+
+    var width = 28.0 + field(l10n.width) + 6 + 28 + 6 + field(l10n.height) + 10;
+    if (samplingLabel) width += _textWidth(l10n.cropResizeResample, textTheme.bodySmall) + 6;
+    // The dropdown sizes to its widest option, plus its box and chevron.
+    width += 38 + _textWidth('Lanczos', textTheme.bodyMedium);
+    return width;
+  }
+
+  /// Material's own icon-button padding, spelled out so the estimate tracks
+  /// what the buttons actually render: text 12/16, filled and outlined 16/24,
+  /// each around an 18px icon with an 8px gap.
+  double _actionsWidth(AppLocalizations l10n, bool labelled, bool saveHint) {
+    if (!labelled) return appButtonMinHeight * 3 + 16;
+
+    final style = Theme.of(context).textTheme.labelLarge;
+    // AppToolButton pads 12 a side; the two AppButtons take Material's
+    // icon-button padding of 16/24 around an 18px icon and its 8px gap.
+    final reset = 44 + _textWidth(l10n.reset, style);
+    final overwrite = 68 + _textWidth(l10n.overwriteSource, style);
+    var save = 66 + _textWidth(l10n.saveCopy, style);
+    if (saveHint) save += 6 + _textWidth(l10n.cropResizeSaveDestinationHint, style);
+    return reset + 8 + overwrite + 12 + save;
+  }
+
+  /// Filename over its native resolution and weight — the crop is always
+  /// expressed against these numbers, and the canvas only ever shows a
+  /// fitted preview, so without them the source's real size is invisible.
+  Widget _buildFileInfo(AppImage source, AppLocalizations l10n, ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
+    final meta = _meta;
+
+    return SizedBox(
+      width: _kFileInfoWidth,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            source.name,
+            style: textTheme.titleSmall,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (meta != null && meta.width > 0)
+            Text(
+              l10n.cropResizeOriginalInfo(meta.width, meta.height, meta.sizeString),
+              style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDesktopSaveActions(
+    AppLocalizations l10n,
+    ColorScheme colorScheme,
+    bool compact,
+    bool showSaveHint,
+    bool busy,
+  ) {
     if (compact) {
       return Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          IconButton.outlined(
-            onPressed: () => _handleSave(overwrite: false),
-            icon: const Icon(Icons.save_alt, size: 20),
-            tooltip: l10n.saveToTemp,
+          AppToolButton(
+            icon: Icons.restart_alt,
+            label: l10n.reset,
+            showLabel: false,
+            onPressed: busy ? null : _handleReset,
           ),
           const SizedBox(width: 8),
-          IconButton.filled(
-            onPressed: () => _handleSave(overwrite: true),
-            icon: const Icon(Icons.save, size: 20),
+          AppIconButton(
+            icon: Icons.warning_amber_rounded,
             tooltip: l10n.overwriteSource,
-            style: IconButton.styleFrom(backgroundColor: colorScheme.error),
+            color: colorScheme.error,
+            onPressed: busy ? null : () => _handleSave(overwrite: true),
+          ),
+          const SizedBox(width: 8),
+          AppIconButton(
+            icon: Icons.save_outlined,
+            tooltip: l10n.saveCopy,
+            selected: true,
+            onPressed: busy ? null : () => _handleSave(overwrite: false),
           ),
         ],
       );
@@ -316,76 +553,88 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        OutlinedButton.icon(
-          onPressed: () => _handleSave(overwrite: false),
-          icon: const Icon(Icons.save_alt, size: 18),
-          label: Text(l10n.saveToTemp, style: const TextStyle(fontSize: 12)),
+        // Not AppButton's text variant: that one keeps Material's accent
+        // tint, which would put reset at the same visual weight as the two
+        // actions that actually write a file.
+        AppToolButton(
+          icon: Icons.restart_alt,
+          label: l10n.reset,
+          onPressed: busy ? null : _handleReset,
+        ),
+        const SizedBox(width: 8),
+        AppButton(
+          label: l10n.overwriteSource,
+          icon: Icons.warning_amber_rounded,
+          variant: AppButtonVariant.destructiveOutline,
+          loading: _processingAction == 'overwrite',
+          onPressed: busy ? null : () => _handleSave(overwrite: true),
         ),
         const SizedBox(width: 12),
-        FilledButton.icon(
-          onPressed: () => _handleSave(overwrite: true),
-          icon: const Icon(Icons.save, size: 18),
-          label: Text(l10n.overwriteSource, style: const TextStyle(fontSize: 12)),
-          style: FilledButton.styleFrom(backgroundColor: colorScheme.error),
+        AppButton(
+          label: l10n.saveCopy,
+          secondaryLabel: showSaveHint ? l10n.cropResizeSaveDestinationHint : null,
+          icon: Icons.save_outlined,
+          variant: AppButtonVariant.primary,
+          loading: _processingAction == 'save',
+          onPressed: busy ? null : () => _handleSave(overwrite: false),
         ),
       ],
     );
   }
 
   Widget _buildDesktopRatioSelector(AppLocalizations l10n, WorkbenchUIState uiState, ColorScheme colorScheme, bool compact) {
+    final preset = _currentPreset(uiState.cropAspectRatio);
+    final segments = <AppSegment<_RatioPreset>>[
+      AppSegment(value: _RatioPreset.free, label: l10n.cropResizeFreeRatio),
+      AppSegment(value: _RatioPreset.r1x1, label: "1:1"),
+      AppSegment(value: _RatioPreset.r4x3, label: "4:3"),
+      AppSegment(value: _RatioPreset.r16x9, label: "16:9"),
+      if (!compact) ...[
+        AppSegment(value: _RatioPreset.r3x4, label: "3:4"),
+        AppSegment(value: _RatioPreset.r9x16, label: "9:16"),
+      ],
+      AppSegment(value: _RatioPreset.custom, label: l10n.custom),
+    ];
+
+    // No leading icon: the segments are self-describing ("1:1", "16:9"), and
+    // an aspect-ratio glyph in front of them only competes with the track's
+    // own edge for the eye.
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(Icons.aspect_ratio, size: 20, color: colorScheme.onSurfaceVariant),
-        const SizedBox(width: 12),
-        Flexible(
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                _buildRatioItem("Free", null, uiState.cropAspectRatio),
-                _buildRatioItem("1:1", 1.0, uiState.cropAspectRatio),
-                _buildRatioItem("4:3", 4/3, uiState.cropAspectRatio),
-                _buildRatioItem("16:9", 16/9, uiState.cropAspectRatio),
-                if (!compact) ...[
-                  _buildRatioItem("3:4", 3/4, uiState.cropAspectRatio),
-                  _buildRatioItem("9:16", 9/16, uiState.cropAspectRatio),
-                ],
-              ],
-            ),
-          ),
+        AppSegmentedControl<_RatioPreset>(
+          segments: segments,
+          value: preset,
+          onChanged: _selectRatioPreset,
+          style: AppSegmentStyle.raised,
+          compact: true,
         ),
-        const SizedBox(width: 8),
-        // Custom Ratio Inputs
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest.withAlpha(100),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _buildRatioField(_ratioXController),
-              const Padding(padding: EdgeInsets.symmetric(horizontal: 2), child: Text(":", style: TextStyle(fontSize: 12))),
-              _buildRatioField(_ratioYController),
-            ],
-          ),
-        ),
+        if (_customRatioMode) ...[
+          const SizedBox(width: 8),
+          _buildCustomRatioFields(colorScheme),
+        ],
       ],
     );
   }
 
-  Widget _buildRatioItem(String label, double? ratio, double? current) {
-    final isSelected = ratio == current;
-    return Padding(
-      padding: const EdgeInsets.only(right: 4),
-      child: ChoiceChip(
-        label: Text(label, style: const TextStyle(fontSize: 11)),
-        selected: isSelected,
-        onSelected: (v) => _updateAspectRatio(ratio),
-        visualDensity: VisualDensity.compact,
-        padding: EdgeInsets.zero,
+  /// Only rendered once the "Custom" segment is selected — folded away
+  /// otherwise instead of permanently occupying toolbar width next to the
+  /// preset chips.
+  Widget _buildCustomRatioFields(ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withAlpha(150),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildRatioField(_ratioXController),
+          const Padding(padding: EdgeInsets.symmetric(horizontal: 2), child: Text(":", style: TextStyle(fontSize: 12))),
+          _buildRatioField(_ratioYController),
+        ],
       ),
     );
   }
@@ -407,79 +656,115 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(Icons.photo_size_select_large, size: 20, color: colorScheme.onSurfaceVariant),
-        const SizedBox(width: 12),
-        _buildDimensionField(_widthController, compact ? null : l10n.width),
-        Padding(padding: const EdgeInsets.symmetric(horizontal: 4), child: Text("×", style: TextStyle(color: colorScheme.onSurfaceVariant))),
-        _buildDimensionField(_heightController, compact ? null : l10n.height),
-        const SizedBox(width: 4),
-        IconButton(
-          icon: Icon(uiState.maintainAspectRatio ? Icons.lock : Icons.lock_open, size: 18),
-          onPressed: () => uiState.setMaintainAspectRatio(!uiState.maintainAspectRatio),
-          tooltip: l10n.maintainAspectRatio,
-          color: uiState.maintainAspectRatio ? colorScheme.primary : null,
-          visualDensity: VisualDensity.compact,
-        ),
-        const SizedBox(width: 4),
-        
-        if (!compact)
-          DropdownButton<String>(
-            value: uiState.samplingMethod,
-            underline: const SizedBox(),
-            style: TextStyle(fontSize: 12, color: colorScheme.onSurface),
-            items: const [
-              DropdownMenuItem(value: 'lanczos', child: Text("Lanczos")),
-              DropdownMenuItem(value: 'cubic', child: Text("Cubic")),
-              DropdownMenuItem(value: 'linear', child: Text("Linear")),
-              DropdownMenuItem(value: 'nearest', child: Text("Nearest")),
-            ],
-            onChanged: (v) => uiState.setSamplingMethod(v!),
-          )
-        else
-          PopupMenuButton<String>(
-            icon: const Icon(Icons.tune, size: 18),
-            tooltip: l10n.sampling,
-            onSelected: (v) => uiState.setSamplingMethod(v),
-            itemBuilder: (context) => [
-              _buildSamplingItem(context, 'lanczos', 'Lanczos', uiState.samplingMethod),
-              _buildSamplingItem(context, 'cubic', 'Cubic', uiState.samplingMethod),
-              _buildSamplingItem(context, 'linear', 'Linear', uiState.samplingMethod),
-              _buildSamplingItem(context, 'nearest', 'Nearest', uiState.samplingMethod),
-            ],
+        Icon(Icons.photo_size_select_large, size: 18, color: colorScheme.onSurfaceVariant),
+        const SizedBox(width: 10),
+        _buildDimensionField(_widthController, l10n.width, colorScheme),
+        const SizedBox(width: 6),
+        // Between the two fields, not after both — this is the control that
+        // links them, so it reads as sitting on the link rather than as a
+        // third, unrelated field.
+        Tooltip(
+          message: l10n.maintainAspectRatio,
+          child: InkWell(
+            onTap: () => uiState.setMaintainAspectRatio(!uiState.maintainAspectRatio),
+            borderRadius: BorderRadius.circular(14),
+            child: Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: uiState.maintainAspectRatio
+                    ? colorScheme.primary.withValues(alpha: 0.14)
+                    : Colors.transparent,
+              ),
+              child: Icon(
+                uiState.maintainAspectRatio ? Icons.link : Icons.link_off,
+                size: 15,
+                color: uiState.maintainAspectRatio ? colorScheme.primary : colorScheme.onSurfaceVariant,
+              ),
+            ),
           ),
+        ),
+        const SizedBox(width: 6),
+        _buildDimensionField(_heightController, l10n.height, colorScheme),
+        const SizedBox(width: 10),
+        if (!compact) ...[
+          Text(
+            l10n.cropResizeResample,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+          ),
+          const SizedBox(width: 6),
+        ],
+        Container(
+          height: appButtonMinHeight,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(appButtonRadius),
+            border: Border.all(color: colorScheme.outlineVariant),
+          ),
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              value: uiState.samplingMethod,
+              isDense: true,
+              icon: Icon(Icons.expand_more, size: 16, color: colorScheme.onSurfaceVariant),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.onSurface),
+              items: const [
+                DropdownMenuItem(value: 'lanczos', child: Text("Lanczos")),
+                DropdownMenuItem(value: 'cubic', child: Text("Cubic")),
+                DropdownMenuItem(value: 'linear', child: Text("Linear")),
+                DropdownMenuItem(value: 'nearest', child: Text("Nearest")),
+              ],
+              onChanged: (v) => uiState.setSamplingMethod(v!),
+            ),
+          ),
+        ),
       ],
     );
   }
 
-  PopupMenuItem<String> _buildSamplingItem(BuildContext context, String value, String label, String current) {
-    return PopupMenuItem(
-      value: value,
-      child: Row(
-        children: [
-          Text(label, style: const TextStyle(fontSize: 13)),
-          if (value == current) ...[
-            const Spacer(),
-            Icon(Icons.check, size: 16, color: Theme.of(context).colorScheme.primary),
-          ],
-        ],
-      ),
-    );
-  }
+  /// A boxed "W [1200] px" cell.
+  ///
+  /// Built by hand rather than from [InputDecoration]: Material only reveals
+  /// `prefixText`/`suffixText` once a field has focus or content, so an empty
+  /// box would lose both its "width" label and its unit — exactly when the
+  /// user most needs to be told what the box is for. Drawing the chrome here
+  /// keeps the label and the unit standing regardless of state, and leaves a
+  /// borderless field to hold just the number.
+  Widget _buildDimensionField(TextEditingController ctrl, String label, ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
 
-  Widget _buildDimensionField(TextEditingController ctrl, String? label) {
-    return SizedBox(
-      width: label == null ? 50 : 70,
-      child: TextField(
-        controller: ctrl,
-        decoration: InputDecoration(
-          isDense: true,
-          labelText: label,
-          labelStyle: const TextStyle(fontSize: 10),
-          border: const OutlineInputBorder(),
-          contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-        ),
-        style: const TextStyle(fontSize: 12),
-        keyboardType: TextInputType.number,
+    return Container(
+      height: appButtonMinHeight,
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(appButtonRadius),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant)),
+          const SizedBox(width: 8),
+          SizedBox(
+            width: _kNumberFieldWidth,
+            child: TextField(
+              controller: ctrl,
+              decoration: const InputDecoration(
+                isDense: true,
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.zero,
+              ),
+              style: textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+              keyboardType: TextInputType.number,
+            ),
+          ),
+          Text(
+            'px',
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7)),
+          ),
+        ],
       ),
     );
   }
@@ -599,6 +884,7 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
   }
 
   void _showMobileResizeDialog(BuildContext context, AppLocalizations l10n, WorkbenchUIState uiState) {
+    final colorScheme = Theme.of(context).colorScheme;
     AppDialog.show<void>(
       context,
       title: l10n.resize,
@@ -608,9 +894,9 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
           children: [
             Row(
               children: [
-                Expanded(child: _buildDimensionField(_widthController, l10n.width)),
+                Expanded(child: _buildDimensionField(_widthController, l10n.width, colorScheme)),
                 const Padding(padding: EdgeInsets.symmetric(horizontal: 8), child: Text("×")),
-                Expanded(child: _buildDimensionField(_heightController, l10n.height)),
+                Expanded(child: _buildDimensionField(_heightController, l10n.height, colorScheme)),
               ],
             ),
             const SizedBox(height: 12),
@@ -653,11 +939,19 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
               },
             ),
             ListTile(
-              leading: Icon(Icons.save, color: Theme.of(context).colorScheme.error),
+              leading: Icon(Icons.restore_page_outlined, color: Theme.of(context).colorScheme.error),
               title: Text(l10n.overwriteSource, style: TextStyle(color: Theme.of(context).colorScheme.error)),
               onTap: () {
                 Navigator.pop(context);
                 _handleSave(overwrite: true);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.refresh),
+              title: Text(l10n.reset),
+              onTap: () {
+                Navigator.pop(context);
+                _handleReset();
               },
             ),
             const SizedBox(height: 16),

--- a/lib/screens/workbench/widgets/crop_resize_view.dart
+++ b/lib/screens/workbench/widgets/crop_resize_view.dart
@@ -1,12 +1,23 @@
 import 'dart:io';
 
 import 'package:extended_image/extended_image.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../core/app_paths.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../services/image_metadata_service.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_button.dart';
+
+const Map<String, String> _kSamplingLabels = {
+  'lanczos': 'Lanczos',
+  'cubic': 'Cubic',
+  'linear': 'Linear',
+  'nearest': 'Nearest',
+};
 
 class CropResizeView extends StatefulWidget {
   const CropResizeView({super.key});
@@ -16,6 +27,62 @@ class CropResizeView extends StatefulWidget {
 }
 
 class _CropResizeViewState extends State<CropResizeView> {
+  /// Crop rect in the editor's own local (Stack) coordinate space — used to
+  /// position the floating badge over the live selection.
+  Rect? _screenCropRect;
+
+  /// The same crop rect in source-image pixel space — used for the numbers
+  /// the badge and output strip actually print, so they always agree with
+  /// what a save would produce.
+  Rect? _pixelCropRect;
+
+  double _zoomPercent = 100;
+
+  ImageMetadata? _meta;
+  String? _metaPath;
+  String? _tempWorkspaceDir;
+
+  /// Wraps the editor so the zoom pill can find its render box and simulate
+  /// a mouse-wheel event at its center — extended_image's editor doesn't
+  /// expose a public "set scale" call, only the gesture path a real wheel
+  /// takes, so the +/- buttons replay that same path instead of a click.
+  final GlobalKey _canvasKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    AppPaths.getTempDirectory().then((dir) {
+      if (mounted) setState(() => _tempWorkspaceDir = dir);
+    });
+  }
+
+  void _loadMeta(String path) {
+    if (_metaPath == path) return;
+    _metaPath = path;
+    ImageMetadataService().getMetadata(path).then((meta) {
+      if (mounted && _metaPath == path) setState(() => _meta = meta);
+    });
+  }
+
+  void _handleEditChanged(EditActionDetails? details) {
+    if (details == null || !mounted) return;
+    final uiState = Provider.of<WorkbenchUIState>(context, listen: false);
+    final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
+    final pixelRect = state?.getCropRect();
+    final destRect = details.screenDestinationRect;
+
+    double? zoomPercent;
+    if (destRect != null && _meta != null && _meta!.width > 0) {
+      zoomPercent = destRect.width / _meta!.width * 100;
+    }
+
+    setState(() {
+      _screenCropRect = details.screenCropRect;
+      _pixelCropRect = pixelRect;
+      if (zoomPercent != null) _zoomPercent = zoomPercent;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final uiState = Provider.of<WorkbenchUIState>(context);
@@ -24,41 +91,410 @@ class _CropResizeViewState extends State<CropResizeView> {
     final sourceImage = uiState.cropResizeSourceImage;
 
     if (sourceImage == null) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.crop, size: 64, color: colorScheme.outlineVariant),
-            const SizedBox(height: 16),
-            Text(l10n.noImagesSelected),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
-              child: Text(l10n.goToGallery),
+      // The output strip stays even with nothing loaded: it is the screen's
+      // chrome, not a result panel, and a bar that appears only once an image
+      // arrives makes the whole layout jump under the user.
+      return Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.crop, size: 64, color: colorScheme.outlineVariant),
+                  const SizedBox(height: 16),
+                  Text(l10n.noImagesSelected),
+                  const SizedBox(height: 16),
+                  AppButton(
+                    label: l10n.goToGallery,
+                    variant: AppButtonVariant.secondary,
+                    onPressed: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
+                  ),
+                ],
+              ),
             ),
-          ],
-        ),
+          ),
+          _OutputPreviewBar(
+            meta: null,
+            pixelCropRect: null,
+            targetWidth: null,
+            targetHeight: null,
+            samplingMethod: uiState.samplingMethod,
+            tempWorkspaceDir: null,
+            sourceName: null,
+            l10n: l10n,
+            colorScheme: colorScheme,
+          ),
+        ],
       );
     }
 
-    return Container(
-      color: Colors.black87,
-      child: ExtendedImage.file(
-        File(sourceImage.path),
-        key: ValueKey("${sourceImage.path}_${uiState.cropAspectRatio}"),
-        fit: BoxFit.contain,
-        mode: ExtendedImageMode.editor,
-        enableLoadState: true,
-        extendedImageEditorKey: uiState.cropKey,
-        initEditorConfigHandler: (state) {
-          return EditorConfig(
-            maxScale: 8.0,
-            cropRectPadding: const EdgeInsets.all(20.0),
-            hitTestSize: 20.0,
-            cropAspectRatio: uiState.cropAspectRatio,
-          );
-        },
+    _loadMeta(sourceImage.path);
+
+    return Column(
+      children: [
+        Expanded(
+          child: Container(
+            color: Colors.black87,
+            child: Stack(
+              children: [
+                Positioned.fill(
+                  child: KeyedSubtree(
+                    key: _canvasKey,
+                    child: ExtendedImage.file(
+                      File(sourceImage.path),
+                      key: ValueKey("${sourceImage.path}_${uiState.cropAspectRatio}"),
+                      fit: BoxFit.contain,
+                      mode: ExtendedImageMode.editor,
+                      enableLoadState: true,
+                      extendedImageEditorKey: uiState.cropKey,
+                      initEditorConfigHandler: (state) {
+                        return EditorConfig(
+                          maxScale: 8.0,
+                          cropRectPadding: const EdgeInsets.all(20.0),
+                          hitTestSize: 20.0,
+                          cropAspectRatio: uiState.cropAspectRatio,
+                          cropLayerPainter: const _EightHandleCropLayerPainter(),
+                          editActionDetailsIsChanged: _handleEditChanged,
+                        );
+                      },
+                    ),
+                  ),
+                ),
+                Positioned(
+                  left: 16,
+                  top: 14,
+                  right: 16,
+                  child: _CanvasLabel(name: sourceImage.name, l10n: l10n),
+                ),
+                if (_screenCropRect != null && _pixelCropRect != null)
+                  _CropBadge(screenRect: _screenCropRect!, pixelRect: _pixelCropRect!),
+                Positioned(
+                  right: 12,
+                  bottom: 12,
+                  child: _ZoomPill(
+                    percent: _zoomPercent,
+                    onZoomIn: () => _nudgeZoom(1),
+                    onZoomOut: () => _nudgeZoom(-1),
+                    onFit: () => _fitToWindow(uiState),
+                    l10n: l10n,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        _OutputPreviewBar(
+          meta: _meta,
+          pixelCropRect: _pixelCropRect,
+          targetWidth: uiState.targetWidth,
+          targetHeight: uiState.targetHeight,
+          samplingMethod: uiState.samplingMethod,
+          tempWorkspaceDir: _tempWorkspaceDir,
+          sourceName: sourceImage.name,
+          l10n: l10n,
+          colorScheme: colorScheme,
+        ),
+      ],
+    );
+  }
+
+  void _fitToWindow(WorkbenchUIState uiState) {
+    final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
+    state?.reset();
+  }
+
+  /// extended_image's editor exposes zoom only through gestures (touch
+  /// pinch, mouse wheel), not a public "set scale" call. Rather than a dead
+  /// button, this replays one mouse-wheel notch at the canvas' center —
+  /// the same [PointerScrollEvent] path `_handlePointerSignal` already
+  /// listens for — so +/- drive the exact mechanism scrolling does.
+  void _nudgeZoom(int direction) {
+    final renderObject = _canvasKey.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.attached) return;
+    final center = renderObject.localToGlobal(renderObject.size.center(Offset.zero));
+    GestureBinding.instance.handlePointerEvent(
+      PointerScrollEvent(
+        position: center,
+        kind: PointerDeviceKind.mouse,
+        scrollDelta: Offset(0, direction * 120),
       ),
     );
+  }
+}
+
+/// Draws the package's default 4 corner marks plus 4 edge-midpoint handles,
+/// so the crop rect reads as fully grabbable along every edge, not just at
+/// its corners.
+class _EightHandleCropLayerPainter extends EditorCropLayerPainter {
+  const _EightHandleCropLayerPainter();
+
+  @override
+  void paintCorners(
+    Canvas canvas,
+    Size size,
+    ExtendedImageCropLayerPainter painter,
+  ) {
+    super.paintCorners(canvas, size, painter);
+
+    final Rect cropRect = painter.cropRect;
+    final Paint paint = Paint()
+      ..color = painter.cornerColor
+      ..style = PaintingStyle.fill;
+
+    const double handleLength = 14.0;
+    const double handleThickness = 3.0;
+    final double midX = cropRect.left + cropRect.width / 2;
+    final double midY = cropRect.top + cropRect.height / 2;
+
+    void horizontal(double cx, double cy) => canvas.drawRect(
+          Rect.fromCenter(center: Offset(cx, cy), width: handleLength, height: handleThickness),
+          paint,
+        );
+    void vertical(double cx, double cy) => canvas.drawRect(
+          Rect.fromCenter(center: Offset(cx, cy), width: handleThickness, height: handleLength),
+          paint,
+        );
+
+    horizontal(midX, cropRect.top);
+    horizontal(midX, cropRect.bottom);
+    vertical(cropRect.left, midY);
+    vertical(cropRect.right, midY);
+  }
+}
+
+/// Floating "{w}×{h} · {ratio}" readout anchored to the live crop rect's
+/// top-left, so the numbers a save will actually use are visible while
+/// dragging rather than only after releasing.
+class _CropBadge extends StatelessWidget {
+  final Rect screenRect;
+  final Rect pixelRect;
+
+  const _CropBadge({required this.screenRect, required this.pixelRect});
+
+  @override
+  Widget build(BuildContext context) {
+    final w = pixelRect.width.round();
+    final h = pixelRect.height.round();
+    final ratio = _simplifiedRatio(w, h);
+
+    return Positioned(
+      left: screenRect.left.clamp(0, double.infinity),
+      top: (screenRect.top - 30).clamp(0, double.infinity),
+      child: IgnorePointer(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.72),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            ratio == null ? '$w × $h' : '$w × $h · $ratio',
+            style: const TextStyle(color: Colors.white, fontSize: 11, fontWeight: FontWeight.w600),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String? _simplifiedRatio(int w, int h) {
+    if (w <= 0 || h <= 0) return null;
+    final g = _gcd(w, h);
+    if (g == 0) return null;
+    return '${w ~/ g}:${h ~/ g}';
+  }
+
+  int _gcd(int a, int b) => b == 0 ? a : _gcd(b, a % b);
+}
+
+/// "{name}（original preview）" over the canvas' top-left.
+///
+/// Names what is under the crop overlay, and — the reason it says *preview* —
+/// marks the canvas as the untouched source rather than a render of the
+/// pending output. The file's native size lives in the toolbar caption
+/// instead; repeating it here would be two answers to one question.
+class _CanvasLabel extends StatelessWidget {
+  final String name;
+  final AppLocalizations l10n;
+
+  const _CanvasLabel({required this.name, required this.l10n});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Text(
+        l10n.cropResizeCanvasLabel(name),
+        style: TextStyle(
+          color: Colors.white.withValues(alpha: 0.7),
+          fontSize: 12,
+          fontFamily: 'monospace',
+          shadows: const [Shadow(color: Colors.black54, blurRadius: 4)],
+        ),
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+}
+
+/// Bottom-right floating readout: current zoom against the source image's
+/// native resolution (100% = one screen pixel per source pixel), plus a fit
+/// action. The +/- steps mirror the package's own mouse-wheel zoom rather
+/// than driving a scale setter the package doesn't expose publicly.
+class _ZoomPill extends StatelessWidget {
+  final double percent;
+  final VoidCallback onZoomIn;
+  final VoidCallback onZoomOut;
+  final VoidCallback onFit;
+  final AppLocalizations l10n;
+
+  const _ZoomPill({
+    required this.percent,
+    required this.onZoomIn,
+    required this.onZoomOut,
+    required this.onFit,
+    required this.l10n,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.55),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _pillIcon(Icons.remove, onZoomOut),
+          SizedBox(
+            width: 44,
+            child: Text(
+              '${percent.round()}%',
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.white, fontSize: 11.5, fontWeight: FontWeight.w600),
+            ),
+          ),
+          _pillIcon(Icons.add, onZoomIn),
+          Container(width: 1, height: 14, color: Colors.white24, margin: const EdgeInsets.symmetric(horizontal: 4)),
+          InkWell(
+            onTap: onFit,
+            borderRadius: BorderRadius.circular(14),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Text(l10n.fitToWindow, style: const TextStyle(color: Colors.white, fontSize: 11)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _pillIcon(IconData icon, VoidCallback onTap) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(14),
+      child: Padding(
+        padding: const EdgeInsets.all(6),
+        child: Icon(icon, size: 14, color: Colors.white),
+      ),
+    );
+  }
+}
+
+/// Summary strip below the canvas: original size -> output size, whether
+/// scaling is happening on top of the crop, which sampler will run, and
+/// where the copy will land — the same numbers a save is about to use, shown
+/// before the user commits.
+class _OutputPreviewBar extends StatelessWidget {
+  final ImageMetadata? meta;
+  final Rect? pixelCropRect;
+  final int? targetWidth;
+  final int? targetHeight;
+  final String samplingMethod;
+  final String? tempWorkspaceDir;
+  final String? sourceName;
+  final AppLocalizations l10n;
+  final ColorScheme colorScheme;
+
+  const _OutputPreviewBar({
+    required this.meta,
+    required this.pixelCropRect,
+    required this.targetWidth,
+    required this.targetHeight,
+    required this.samplingMethod,
+    required this.tempWorkspaceDir,
+    required this.sourceName,
+    required this.l10n,
+    required this.colorScheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cropW = pixelCropRect?.width.round();
+    final cropH = pixelCropRect?.height.round();
+    final outW = targetWidth ?? cropW;
+    final outH = targetHeight ?? cropH;
+
+    final originalSize = meta != null ? '${meta!.width}×${meta!.height}' : '–';
+    final outputSize = (outW != null && outH != null) ? '$outW×$outH' : '–';
+
+    final isScaling = cropW != null && cropW > 0 && outW != null && outW != cropW;
+    final percent = isScaling ? (outW / cropW * 100).round() : 100;
+    final operation = isScaling ? l10n.cropResizeCropAndScale(percent) : l10n.cropResizeCropOnly;
+    final samplingLabel = _kSamplingLabels[samplingMethod] ?? samplingMethod;
+
+    final name = sourceName;
+    final destination = (name == null || tempWorkspaceDir == null)
+        ? null
+        : '${l10n.cropResizeTempWorkspaceLabel} / crop_${_baseName(name)}${_extension(name)}';
+
+    final textTheme = Theme.of(context).textTheme;
+    final labelStyle = textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant);
+
+    return Container(
+      height: 34,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        border: Border(top: BorderSide(color: colorScheme.outlineVariant.withAlpha(80))),
+      ),
+      child: Row(
+        children: [
+          Text(l10n.cropResizeOutputPreview, style: labelStyle),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              l10n.cropResizeOutputSummary(originalSize, outputSize, operation, samplingLabel),
+              style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (destination != null) ...[
+            const SizedBox(width: 12),
+            Icon(Icons.subdirectory_arrow_right, size: 14, color: colorScheme.onSurfaceVariant),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                l10n.cropResizeWillSaveTo(destination),
+                style: labelStyle,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.right,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _baseName(String name) {
+    final dot = name.lastIndexOf('.');
+    return dot > 0 ? name.substring(0, dot) : name;
+  }
+
+  String _extension(String name) {
+    final dot = name.lastIndexOf('.');
+    return dot > 0 ? name.substring(dot) : '';
   }
 }

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -25,6 +25,12 @@ enum AppButtonVariant {
   /// An action that destroys or removes something, coloured from
   /// [ColorScheme.error] rather than the seed.
   destructive,
+
+  /// A destructive action that hasn't been confirmed yet — an outline rather
+  /// than [destructive]'s solid fill, so the loudest colour on screen is
+  /// reserved for the confirmation the user actually commits with (inside the
+  /// dialog this button opens), not the toolbar button that only proposes it.
+  destructiveOutline,
 }
 
 /// A labelled action button in one of four roles ([AppButtonVariant]).
@@ -39,6 +45,13 @@ enum AppButtonVariant {
 /// always renders a label.
 class AppButton extends StatelessWidget {
   final String label;
+
+  /// A qualifier trailing [label] in a lighter weight — "Save copy
+  /// *to workspace*". For an action whose destination or scope is worth
+  /// stating on the button itself, without giving it the same weight as the
+  /// verb. Dropped by the caller, not by this widget, when space is tight.
+  final String? secondaryLabel;
+
   final IconData? icon;
   final VoidCallback? onPressed;
   final AppButtonVariant variant;
@@ -51,10 +64,32 @@ class AppButton extends StatelessWidget {
     super.key,
     required this.label,
     required this.onPressed,
+    this.secondaryLabel,
     this.icon,
     this.variant = AppButtonVariant.primary,
     this.loading = false,
   });
+
+  /// The label, plus [secondaryLabel] trailing it when set.
+  ///
+  /// The qualifier carries no colour of its own — it inherits the button's
+  /// foreground through [DefaultTextStyle] and is dimmed with opacity, so it
+  /// reads as subordinate on a filled, outlined or text button alike without
+  /// this widget having to know which one it is.
+  Widget _label() {
+    if (secondaryLabel == null) return Text(label);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(label),
+        const SizedBox(width: 6),
+        Opacity(
+          opacity: 0.78,
+          child: Text(secondaryLabel!, style: const TextStyle(fontWeight: FontWeight.w400)),
+        ),
+      ],
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -72,10 +107,10 @@ class AppButton extends StatelessWidget {
     }
 
     if (icon != null) {
-      return _iconButton(style: style, onPressed: effectiveOnPressed, icon: icon!, label: label);
+      return _iconButton(style: style, onPressed: effectiveOnPressed, icon: icon!, label: _label());
     }
 
-    return _button(style: style, onPressed: effectiveOnPressed, child: Text(label));
+    return _button(style: style, onPressed: effectiveOnPressed, child: _label());
   }
 
   Widget _button({required ButtonStyle? style, required VoidCallback? onPressed, required Widget child}) {
@@ -86,6 +121,8 @@ class AppButton extends StatelessWidget {
         return FilledButton(style: style, onPressed: onPressed, child: child);
       case AppButtonVariant.text:
         return TextButton(style: style, onPressed: onPressed, child: child);
+      case AppButtonVariant.destructiveOutline:
+        return OutlinedButton(style: style, onPressed: onPressed, child: child);
     }
   }
 
@@ -93,7 +130,7 @@ class AppButton extends StatelessWidget {
     required ButtonStyle? style,
     required VoidCallback? onPressed,
     required IconData icon,
-    required String label,
+    required Widget label,
   }) {
     switch (variant) {
       case AppButtonVariant.primary:
@@ -103,14 +140,21 @@ class AppButton extends StatelessWidget {
           style: style,
           onPressed: onPressed,
           icon: Icon(icon, size: 18),
-          label: Text(label),
+          label: label,
         );
       case AppButtonVariant.text:
         return TextButton.icon(
           style: style,
           onPressed: onPressed,
           icon: Icon(icon, size: 18),
-          label: Text(label),
+          label: label,
+        );
+      case AppButtonVariant.destructiveOutline:
+        return OutlinedButton.icon(
+          style: style,
+          onPressed: onPressed,
+          icon: Icon(icon, size: 18),
+          label: label,
         );
     }
   }
@@ -131,6 +175,12 @@ class AppButton extends StatelessWidget {
           disabledBackgroundColor: colorScheme.onSurface.withValues(alpha: 0.12),
           disabledForegroundColor: colorScheme.onSurface.withValues(alpha: 0.38),
         );
+      case AppButtonVariant.destructiveOutline:
+        return OutlinedButton.styleFrom(
+          foregroundColor: colorScheme.error,
+          side: BorderSide(color: colorScheme.error.withValues(alpha: 0.5)),
+          disabledForegroundColor: colorScheme.onSurface.withValues(alpha: 0.38),
+        );
     }
   }
 
@@ -149,6 +199,8 @@ class AppButton extends StatelessWidget {
         return colorScheme.primary;
       case AppButtonVariant.destructive:
         return colorScheme.onError;
+      case AppButtonVariant.destructiveOutline:
+        return colorScheme.error;
     }
   }
 }

--- a/lib/widgets/app_tool_button.dart
+++ b/lib/widgets/app_tool_button.dart
@@ -5,12 +5,17 @@ import '../core/app_theme.dart';
 /// A quiet icon+label action for a toolbar: no fill of its own until the
 /// pointer is on it.
 ///
-/// These sit in the workbench's top bar next to the image/video segmented
-/// control, and the two are not peers — the segmented control says which mode
-/// the workbench is in, while these open a tool. Giving each tool a box or a
-/// fill puts them at the same weight as that control and the row turns into
-/// six things competing; leaving them bare until hover keeps the row legible
-/// and still tells the user they are targets the moment the pointer arrives.
+/// For the tertiary action in a toolbar — the one that must be reachable but
+/// must not compete. The workbench top bar's tool switches are the original
+/// case: they sit next to the image/video segmented control and the two are
+/// not peers, so giving each tool a box or a fill would turn the row into six
+/// things competing. Leaving them bare until hover keeps the row legible and
+/// still tells the user they are targets the moment the pointer arrives.
+///
+/// The same reasoning covers a "Reset" beside a screen's real actions: use
+/// this rather than [AppButton]'s `text` variant when the action should read
+/// as neutral, since that variant keeps Material's accent tint (correct for a
+/// dialog's "Cancel", wrong for a third button in a row of three).
 ///
 /// The rest state is deliberately neutral rather than accented: with the
 /// greys already free of the seed hue (see [buildAppColorScheme]), reserving

--- a/test/app_theme_test.dart
+++ b/test/app_theme_test.dart
@@ -115,6 +115,46 @@ void main() {
         reason: 'A density default shrank the button below its floor');
   });
 
+  testWidgets('all three button types carry the app corner, not just the filled one', (tester) async {
+    // The theme used to define filledButtonTheme alone, so AppButton's `text`
+    // and `destructiveOutline` variants — built on TextButton and
+    // OutlinedButton — silently kept Material 3's StadiumBorder. A toolbar row
+    // of Reset / Overwrite / Save rendered as two pills beside a rounded
+    // rectangle. Reaching for the shared component is not enough on its own;
+    // the theme has to reach through it.
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: light(),
+        home: const Scaffold(
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FilledButton(onPressed: _noop, child: Text('Save')),
+                OutlinedButton(onPressed: _noop, child: Text('Overwrite')),
+                TextButton(onPressed: _noop, child: Text('Reset')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (final type in [FilledButton, OutlinedButton, TextButton]) {
+      final painted = find
+          .descendant(of: find.byType(type), matching: find.byType(Material))
+          .first;
+      final shape = tester.widget<Material>(painted).shape;
+
+      expect(shape, isA<RoundedRectangleBorder>(), reason: '$type kept a stadium shape');
+      expect((shape! as RoundedRectangleBorder).borderRadius,
+          BorderRadius.circular(appButtonRadius),
+          reason: '$type does not use the app corner');
+      expect(tester.getSize(painted).height, greaterThanOrEqualTo(appButtonMinHeight),
+          reason: '$type sits below the shared height floor');
+    }
+  });
+
   test('tonal buttons keep their own colours despite the filled theme', () {
     // FilledButton.tonal reads the same FilledButtonTheme, and a theme's
     // background outranks the tonal variant's default — so every tonal button
@@ -129,3 +169,5 @@ void main() {
     }
   });
 }
+
+void _noop() {}

--- a/test/crop_resize_toolbar_test.dart
+++ b/test/crop_resize_toolbar_test.dart
@@ -1,0 +1,215 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/l10n/app_localizations.dart';
+import 'package:joycai_image_ai_toolkits/models/app_image.dart';
+import 'package:joycai_image_ai_toolkits/screens/workbench/widgets/crop_resize_toolbar.dart';
+import 'package:joycai_image_ai_toolkits/state/app_state.dart';
+import 'package:joycai_image_ai_toolkits/state/workbench_ui_state.dart';
+import 'package:provider/provider.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// The crop toolbar as its own width shrinks.
+///
+/// The bug this pins: the bar chose between labelled buttons and bare icons
+/// from a hardcoded `width < 1250`. A perfectly ordinary maximised window
+/// leaves this bar under that, so the three save actions collapsed to three
+/// unlabelled icons — one of which overwrites the user's original file. The
+/// redesign's whole point was that the destructive action be named, and
+/// quieter than the safe one; the threshold silently undid both.
+///
+/// Widths here are **not** comparable to real ones. flutter_test lays text
+/// out in a placeholder font whose every glyph is a full square em, so labels
+/// measure roughly twice their shipping width and the bar sheds them far
+/// earlier. The assertions are therefore about the *order* things are dropped
+/// in, which is font-independent, rather than about the pixel each drop
+/// happens at — a constant tuned here would say nothing about the app.
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    const MethodChannel('plugins.flutter.io/path_provider'),
+    (MethodCall methodCall) async => Directory.systemTemp.path,
+  );
+
+  const fileName = 'yaxin_cowboy_1.png';
+
+  /// Renders the bar at [barWidth] while the window stays desktop-sized —
+  /// the centre panel is what squeezes this bar, not the screen.
+  Future<void> pumpAtWidth(WidgetTester tester, double barWidth) async {
+    // Two things the window size has to satisfy. It must exceed the bar — a
+    // SizedBox cannot outgrow the constraints handed to it, so a fixed 1600px
+    // window silently clamps every wider case and the sweep tests nothing
+    // above it. And it must stay desktop-sized (>= 1000), because a narrow
+    // *window* switches this widget to the mobile bottom bar entirely. The
+    // case under test is the real one: a wide window whose centre panel is
+    // squeezed by the two side panels.
+    tester.view.physicalSize = Size(barWidth + 200 > 1200 ? barWidth + 200 : 1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final appState = AppState();
+    final uiState = WorkbenchUIState()
+      ..cropResizeSourceImage = AppImage(path: '/tmp/$fileName', name: fileName);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(value: appState),
+          ChangeNotifierProvider.value(value: uiState),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(width: barWidth, child: const CropResizeToolbar()),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  /// Widest width at which [gone] has already been dropped, scanning down.
+  /// Comparing two of these is what pins the degradation order.
+  Future<double> widthWhereDropped(WidgetTester tester, Finder gone) async {
+    for (var w = 2800.0; w >= 400; w -= 25) {
+      await pumpAtWidth(tester, w);
+      if (gone.evaluate().isEmpty) return w;
+    }
+    return 400;
+  }
+
+  Future<AppLocalizations> en() => AppLocalizations.delegate.load(const Locale('en'));
+
+  testWidgets('given room, every control is named', (tester) async {
+    await pumpAtWidth(tester, 2800);
+    final l10n = await en();
+
+    expect(find.text(l10n.saveCopy), findsOneWidget);
+    expect(find.text(l10n.cropResizeSaveDestinationHint), findsOneWidget);
+    expect(find.text(l10n.overwriteSource), findsOneWidget);
+    expect(find.text(l10n.reset), findsOneWidget);
+    expect(find.text(l10n.cropResizeResample), findsOneWidget);
+    expect(find.text(fileName), findsOneWidget);
+  });
+
+  testWidgets('the bar sheds decoration before it sheds meaning', (tester) async {
+    // The regression, stated so the shipping font cannot hide it: whatever the
+    // pixel widths work out to, the filename caption and the save button's
+    // destination hint must both be gone before an action loses its label.
+    // Under the old single threshold every one of these vanished at once.
+    final l10n = await en();
+
+    final captionDropped = await widthWhereDropped(tester, find.text(fileName));
+    final hintDropped = await widthWhereDropped(tester, find.text(l10n.cropResizeSaveDestinationHint));
+    final labelDropped = await widthWhereDropped(tester, find.text(l10n.overwriteSource));
+
+    expect(labelDropped, lessThan(captionDropped),
+        reason: 'the overwrite label went at the same width as the filename, or before it');
+    expect(labelDropped, lessThan(hintDropped),
+        reason: 'the overwrite label went before the save button dropped its destination hint');
+  });
+
+  testWidgets('an action label outlives the sampler label and the portrait presets', (tester) async {
+    final l10n = await en();
+
+    final resampleDropped = await widthWhereDropped(tester, find.text(l10n.cropResizeResample));
+    final portraitDropped = await widthWhereDropped(tester, find.text('9:16'));
+    final labelDropped = await widthWhereDropped(tester, find.text(l10n.overwriteSource));
+
+    expect(labelDropped, lessThan(resampleDropped));
+    expect(labelDropped, lessThan(portraitDropped));
+  });
+
+  testWidgets('a genuinely narrow bar falls back to icons rather than clipping', (tester) async {
+    await pumpAtWidth(tester, 620);
+    final l10n = await en();
+
+    expect(find.text(l10n.overwriteSource), findsNothing);
+    // Still reachable, and still marked as the destructive one.
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.save_outlined), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('reset is the quiet one of the three', (tester) async {
+    // Reset must not read as a peer of the two actions that write a file.
+    // AppButton's `text` variant keeps Material's accent tint, which put it
+    // at the same weight as them; AppToolButton is the neutral one.
+    await pumpAtWidth(tester, 2800);
+    final l10n = await en();
+
+    expect(
+      find.ancestor(of: find.text(l10n.reset), matching: find.byType(FilledButton)),
+      findsNothing,
+      reason: 'reset is drawn as a filled action',
+    );
+    expect(
+      find.ancestor(of: find.text(l10n.reset), matching: find.byType(OutlinedButton)),
+      findsNothing,
+      reason: 'reset is drawn with a border, competing with overwrite',
+    );
+  });
+
+  testWidgets('the ratio presets are a segmented control, not the old chip row', (tester) async {
+    await pumpAtWidth(tester, 2800);
+
+    expect(find.byType(ChoiceChip), findsNothing,
+        reason: 'the chip row this redesign replaced is back');
+    expect(find.text('16:9'), findsOneWidget);
+    expect(find.text('9:16'), findsOneWidget);
+  });
+
+  testWidgets('the custom X:Y fields stay folded until Custom is chosen', (tester) async {
+    await pumpAtWidth(tester, 2800);
+    final l10n = await en();
+
+    // Two dimension fields (width/height) and nothing else, while folded.
+    expect(find.byType(TextField), findsNWidgets(2));
+
+    await tester.tap(find.text(l10n.custom));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNWidgets(4),
+        reason: 'choosing Custom did not unfold the X:Y pair');
+  });
+
+  testWidgets('the dimension boxes label themselves and their unit while empty', (tester) async {
+    // InputDecoration hides prefix/suffix text until a field has focus or
+    // content, which left an empty box with neither its name nor "px" — the
+    // exact moment the user most needs both.
+    await pumpAtWidth(tester, 2800);
+    final l10n = await en();
+
+    expect(find.text(l10n.width), findsOneWidget);
+    expect(find.text(l10n.height), findsOneWidget);
+    expect(find.text('px'), findsNWidgets(2));
+  });
+
+  testWidgets('no width in the working range overflows or clips the actions', (tester) async {
+    // A single threshold is a guess, and the width just above it is where a
+    // guess shows. Sweeping checks the fit calculation instead of trusting it.
+    for (var width = 560.0; width <= 2800.0; width += 40) {
+      await pumpAtWidth(tester, width);
+
+      expect(tester.takeException(), isNull, reason: 'Overflow at ${width}px');
+
+      final bar = tester.getRect(find.byType(CropResizeToolbar));
+      final save = tester.getRect(find.byIcon(Icons.save_outlined));
+      expect(save.right, lessThanOrEqualTo(bar.right + 0.01),
+          reason: 'the save action is clipped off the right edge at ${width}px');
+      expect(save.left, greaterThanOrEqualTo(bar.left),
+          reason: 'the save action starts before the bar does at ${width}px');
+    }
+  });
+}


### PR DESCRIPTION
Rebuilds the **Crop & Resize** screen against the design mockup, and fixes the
theme-level bug that the first attempt at it uncovered.

## The theme bug (first commit, app-wide)

`buildAppTheme()` defined `filledButtonTheme` and nothing else. `AppButton`'s
variants sit on three different Material widgets, so the two built on
`OutlinedButton` and `TextButton` silently kept Material 3's `StadiumBorder`
and default foreground. The Reset / Overwrite / Save row shipped as **two
pills beside a rounded rectangle**, with Reset tinted the accent colour.

Reaching for the shared component was not enough — the theme has to reach
through it. Both types now take `appButtonRadius` and `appButtonMinHeight`.
This affects every `OutlinedButton` and `TextButton` in the app, all of which
were stadium-shaped before.

Only geometry is themed. Foreground colour stays with Material so a dialog's
"Cancel" keeps the accent tint it should have; a button that wants to be quiet
says so at its call site.

Library additions:

| | |
|---|---|
| `AppButtonVariant.destructiveOutline` | Proposes a destructive action that a dialog then confirms. The loudest colour belongs to the confirm button, not to the toolbar button that opens it. |
| `AppButton.secondaryLabel` | A qualifier trailing the label in lighter weight — "Save Copy *to Workspace*". Inherits the button's foreground and dims with opacity, so it works on any variant. |
| `AppToolButton` doc | Widened past the workbench top bar: it is the component for any neutral toolbar action, since `AppButtonVariant.text` keeps Material's accent tint. |

## The screen (second commit)

Seven points from the mockup:

1. **Save actions read as a hierarchy** — filled primary "Save Copy to
   Workspace"; red *outline* "Overwrite Original" opening a confirmation,
   instead of the solid red icon button that used to be the loudest thing in
   the bar; neutral "Reset".
2. **Ratio presets** move from a `ChoiceChip` row onto `AppSegmentedControl`.
3. **The stray "X : Y" inputs** fold into a "Custom" segment and unfold only
   when chosen.
4. **Dimension fields draw their own chrome** — `W [1200] px`. Material hides
   `prefixText`/`suffixText` until a field has focus or content, so an empty
   `InputDecoration` box showed neither its name nor its unit — exactly when
   the user most needs both. The aspect lock moves *between* the fields, since
   it is what links them.
5. **A live badge** on the crop rect showing pixel size and simplified ratio
   while dragging; the crop layer painter gains four edge-midpoint handles,
   eight in total.
6. **An output strip** under the canvas: source size → output size, whether
   scaling rides on top of the crop, the sampler, and where the copy lands.
   Always present — a bar that appears only once an image loads makes the
   layout jump.
7. **Filename and native resolution** in the toolbar caption, a canvas label,
   and a zoom readout with fit-to-window bottom right.

## Responsive fit is measured, not guessed

The bar chose its layout from a hardcoded `width < 1250`. An ordinary window
falls under that, so all three save actions collapsed into unlabelled icons —
**including the one that overwrites the user's original file** — silently
undoing point 1.

Widths now come from `TextPainter`, and features drop in a declared order:
file caption → sampler label → the two portrait presets → the save hint →
and only last, the action labels. A constant tuned against English is wrong in
the other three languages and wrong again the moment the user scales text.
Ratio and size share one horizontal scroller so a mispredicted fit scrolls
rather than clips.

This is the second time a hardcoded threshold has shipped a visible bug here
(the gallery toolbar clipped 全部来源 mid-word), so the rule is now recorded
alongside the component-library conventions.

## Tests

- `test/app_theme_test.dart` — all three button types carry the app corner and
  height floor. Had this existed, the theme bug would not have shipped.
- `test/crop_resize_toolbar_test.dart` — 9 cases: a 560–2800px overflow sweep,
  plus the **drop order** rather than pixel widths. flutter_test's placeholder
  font makes every glyph a full em, so widths measured there say nothing about
  the shipping build; asserting the order is font-independent.

`flutter analyze` clean, 374 tests pass. l10n covers en / zh / zh_Hant / ja.

## Reviewer notes

**Not verified on a real run.** Everything that needs an image loaded is
compile-and-test-verified only: the crop badge's placement (I derived the
coordinate space by reading `extended_image`'s source), the eight handles, and
the zoom readout. The zoom +/- buttons replay a synthetic `PointerScrollEvent`
because the package exposes zoom through gestures only — no public scale
setter — so that path deserves a look too.

31 files in `lib/` still call raw Material buttons directly. They at least have
the right shape now, but still bypass `AppButton`'s variant semantics; that is
the migration debt already logged in #63 and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
