### PR TITLE
refactor(ui): move every toast onto AppSnackBar, extract AppSidePanel

### DIFF
--- a/lib/screens/batch/task_queue_screen.dart
+++ b/lib/screens/batch/task_queue_screen.dart
@@ -13,6 +13,7 @@ import '../../state/app_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
 import '../../widgets/app_icon_button.dart';
+import '../../widgets/app_snackbar.dart';
 import '../../widgets/dialogs/task_log_dialog.dart';
 
 /// Which subset of tasks the list shows.
@@ -931,8 +932,9 @@ class _TaskCardState extends State<_TaskCard> {
         if (val == 'copy_prompt') {
           final prompt = task.parameters['prompt'] ?? '';
           Clipboard.setData(ClipboardData(text: prompt));
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.copiedToClipboard(prompt.length > 30 ? '${prompt.substring(0, 30)}…' : prompt))),
+          AppSnackBar.info(
+            context,
+            l10n.copiedToClipboard(prompt.length > 30 ? '${prompt.substring(0, 30)}…' : prompt),
           );
         }
       },

--- a/lib/screens/browser/ai_rename_dialog.dart
+++ b/lib/screens/browser/ai_rename_dialog.dart
@@ -14,6 +14,7 @@ import '../../services/task_queue_service.dart';
 import '../../state/app_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
+import '../../widgets/app_snackbar.dart';
 import '../../widgets/chat_model_selector.dart';
 
 class AiRenameDialog extends StatefulWidget {
@@ -142,25 +143,22 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
     final l10n = AppLocalizations.of(context)!;
 
     if (_selectedModelDbId == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(l10n.noModelsConfigured),
-          action: SnackBarAction(
-            label: l10n.settings,
-            onPressed: () {
-              Navigator.pop(context); // Close dialog
-              appState.navigateToScreen(6); // Settings screen index
-            },
-          ),
+      AppSnackBar.warning(
+        context,
+        l10n.noModelsConfigured,
+        action: AppSnackBarAction(
+          label: l10n.settings,
+          onPressed: () {
+            Navigator.pop(context); // Close dialog
+            appState.navigateToScreen(6); // Settings screen index
+          },
         ),
       );
       return;
     }
 
     if (_selectedSystemPrompt == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.selectTemplateFirst)),
-      );
+      AppSnackBar.warning(context, l10n.selectTemplateFirst);
       return;
     }
 
@@ -223,9 +221,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) {
             setState(() => _isProcessing = false);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text("Error: $e"), backgroundColor: Colors.red),
-            );
+            AppSnackBar.error(context, "Error: $e");
           }
         });
       }
@@ -261,7 +257,6 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
     if (_conflicts.isNotEmpty) return;
 
     final l10n = AppLocalizations.of(context)!;
-    final scaffoldMessenger = ScaffoldMessenger.of(context);
     final appState = Provider.of<AppState>(context, listen: false);
     
     setState(() => _isProcessing = true);
@@ -289,15 +284,11 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
       
       if (mounted) {
         Navigator.pop(context);
-        scaffoldMessenger.showSnackBar(
-          SnackBar(content: Text(l10n.taskSubmitted), backgroundColor: Colors.blue),
-        );
+        AppSnackBar.info(context, l10n.taskSubmitted);
       }
     } catch (e) {
       if (mounted) {
-        scaffoldMessenger.showSnackBar(
-          SnackBar(content: Text("Failed to start task: $e"), backgroundColor: Colors.red),
-        );
+        AppSnackBar.error(context, "Failed to start task: $e");
         setState(() => _isProcessing = false);
       }
     }

--- a/lib/screens/browser/widgets/file_context_menu.dart
+++ b/lib/screens/browser/widgets/file_context_menu.dart
@@ -10,6 +10,7 @@ import '../../../models/app_image.dart';
 import '../../../models/browser_file.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/dialogs/file_rename_dialog.dart';
 import '../../workbench/widgets/preview/media_preview_dialog.dart';
 
@@ -139,9 +140,7 @@ void showFileContextMenu({
             );
           } catch (e) {
             if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Share failed: $e')),
-              );
+              AppSnackBar.error(context, 'Share failed: $e');
             }
           }
         },

--- a/lib/screens/downloader/image_downloader_screen.dart
+++ b/lib/screens/downloader/image_downloader_screen.dart
@@ -10,6 +10,7 @@ import '../../l10n/app_localizations.dart';
 import '../../services/task_queue_service.dart';
 import '../../services/web_scraper_service.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_snackbar.dart';
 import '../../widgets/panel_resizer.dart';
 import 'widgets/downloader_results_area.dart';
 import 'widgets/downloader_toolbar.dart';
@@ -75,23 +76,17 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
     final state = appState.downloaderState;
 
     if (_urlController.text.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.urlRequired), backgroundColor: Colors.orange),
-      );
+      AppSnackBar.warning(context, l10n.urlRequired);
       return;
     }
 
     if (_requirementController.text.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.requirementRequired), backgroundColor: Colors.orange),
-      );
+      AppSnackBar.warning(context, l10n.requirementRequired);
       return;
     }
 
     if (state.isManualHtml && state.manualHtml.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.manualHtmlRequired), backgroundColor: Colors.orange),
-      );
+      AppSnackBar.warning(context, l10n.manualHtmlRequired);
       return;
     }
 
@@ -101,13 +96,12 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
 
     if (state.selectedModelDbId == null) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(l10n.noModelsConfigured),
-            action: SnackBarAction(
-              label: l10n.settings,
-              onPressed: () => appState.navigateToScreen(6),
-            ),
+        AppSnackBar.warning(
+          context,
+          l10n.noModelsConfigured,
+          action: AppSnackBarAction(
+            label: l10n.settings,
+            onPressed: () => appState.navigateToScreen(6),
           ),
         );
       }
@@ -126,9 +120,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text("Analysis failed: $e"), backgroundColor: Colors.red),
-        );
+        AppSnackBar.error(context, "Analysis failed: $e");
       }
     }
   }
@@ -149,7 +141,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
     if (!mounted) return;
 
     if (outputDir == null || outputDir.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.setOutputDirFirst)));
+      AppSnackBar.warning(context, l10n.setOutputDirFirst);
       return;
     }
 
@@ -167,7 +159,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
       await File(filePath).writeAsString(html);
       state.addLog('HTML saved to: $filePath');
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.htmlSavedTo(filePath))));
+        AppSnackBar.info(context, l10n.htmlSavedTo(filePath));
       }
     } catch (e) {
       state.addLog('Failed to save HTML: $e');
@@ -193,7 +185,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
       type: TaskType.imageDownload,
     );
 
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.addedToQueue(selected.length))));
+    AppSnackBar.info(context, l10n.addedToQueue(selected.length));
   }
 
   Future<void> _importCookieFile() async {
@@ -237,9 +229,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
 
       if (parsedCookies.isEmpty) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.cookieFileInvalid), backgroundColor: Colors.orange),
-          );
+          AppSnackBar.warning(context, l10n.cookieFileInvalid);
         }
         return;
       }
@@ -248,9 +238,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
       state.setState(cookies: parsedCookies);
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.cookieImportSuccess(count)), backgroundColor: Colors.green),
-        );
+        AppSnackBar.success(context, l10n.cookieImportSuccess(count));
       }
     } catch (e) {
       state.addLog('Failed to import cookies: $e');

--- a/lib/screens/prompts/prompts_io.dart
+++ b/lib/screens/prompts/prompts_io.dart
@@ -11,6 +11,7 @@ import '../../models/tag.dart';
 import '../../state/app_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
+import '../../widgets/app_snackbar.dart';
 
 /// Import / export helpers for the Prompt Library.
 ///
@@ -26,7 +27,6 @@ Future<void> exportPrompts(
   required List<Prompt> userPrompts,
   required List<SystemPrompt> systemPrompts,
 }) async {
-  final messenger = ScaffoldMessenger.of(context);
   final data = {
     'tags': tags.map((t) => t.toMap()).toList(),
     'user_prompts': userPrompts.map((p) => {
@@ -56,7 +56,7 @@ Future<void> exportPrompts(
   }
 
   if (path != null && context.mounted) {
-    messenger.showSnackBar(SnackBar(content: Text(l10n.settingsExported)));
+    AppSnackBar.success(context, l10n.settingsExported);
   }
 }
 
@@ -64,9 +64,7 @@ Future<void> exportPrompts(
 /// Returns `true` if data was imported (caller should reload).
 Future<bool> importPrompts(BuildContext context, AppLocalizations l10n) async {
   final appState = Provider.of<AppState>(context, listen: false);
-  final messenger = ScaffoldMessenger.of(context);
   final successMsg = l10n.settingsImported;
-  final errorColor = Theme.of(context).colorScheme.error;
 
   FilePickerResult? result = await FilePicker.pickFiles(type: FileType.custom, allowedExtensions: ['json']);
   if (!context.mounted || result == null) return false;
@@ -103,13 +101,12 @@ Future<bool> importPrompts(BuildContext context, AppLocalizations l10n) async {
 
     await appState.importPromptData(data, replace: importMode == 'replace');
 
-    messenger.showSnackBar(SnackBar(content: Text(successMsg)));
+    if (!context.mounted) return true;
+    AppSnackBar.success(context, successMsg);
     return true;
   } catch (e) {
-    messenger.showSnackBar(SnackBar(
-      content: Text(l10n.importFailed(e.toString())),
-      backgroundColor: errorColor,
-    ));
+    if (!context.mounted) return false;
+    AppSnackBar.error(context, l10n.importFailed(e.toString()));
     return false;
   }
 }

--- a/lib/screens/prompts/widgets/system_template_list.dart
+++ b/lib/screens/prompts/widgets/system_template_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/prompt.dart';
 import '../../../services/database_service.dart';
+import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/prompt_card.dart';
 
 class SystemTemplateList extends StatefulWidget {
@@ -80,9 +81,7 @@ class _SystemTemplateListState extends State<SystemTemplateList> {
         // ignore: deprecated_member_use
         onReorder: (oldIndex, newIndex) async {
           if (widget.searchQuery.isNotEmpty) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(l10n.reorderDisabledWhileFiltered)),
-            );
+            AppSnackBar.info(context, l10n.reorderDisabledWhileFiltered);
             return;
           }
           setState(() {
@@ -137,9 +136,7 @@ class _SystemTemplateListState extends State<SystemTemplateList> {
                     icon: const Icon(Icons.copy_all, size: 18),
                     onPressed: () {
                       Clipboard.setData(ClipboardData(text: systemPrompt.content));
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text(l10n.copiedToClipboard(systemPrompt.title))),
-                      );
+                      AppSnackBar.info(context, l10n.copiedToClipboard(systemPrompt.title));
                     },
                   ),
                   IconButton(

--- a/lib/screens/prompts/widgets/user_prompt_list.dart
+++ b/lib/screens/prompts/widgets/user_prompt_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/prompt.dart';
 import '../../../services/database_service.dart';
+import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/prompt_card.dart';
 
 class UserPromptList extends StatefulWidget {
@@ -80,9 +81,7 @@ class _UserPromptListState extends State<UserPromptList> {
       // ignore: deprecated_member_use
       onReorder: (oldIndex, newIndex) async {
         if (widget.searchQuery.isNotEmpty || widget.selectedFilterTagIds.isNotEmpty) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.reorderDisabledWhileFiltered)),
-          );
+          AppSnackBar.info(context, l10n.reorderDisabledWhileFiltered);
           return;
         }
 
@@ -149,10 +148,8 @@ class _UserPromptListState extends State<UserPromptList> {
                 IconButton(
                   icon: const Icon(Icons.copy_all, size: 18),
                   onPressed: () {
-                    Clipboard.setData(ClipboardData(text: prompt.content));       
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text(l10n.copiedToClipboard(prompt.title))),
-                    );
+                    Clipboard.setData(ClipboardData(text: prompt.content));
+                    AppSnackBar.info(context, l10n.copiedToClipboard(prompt.title));
                   },
                 ),
                 IconButton(

--- a/lib/screens/settings/widgets/data_section.dart
+++ b/lib/screens/settings/widgets/data_section.dart
@@ -13,6 +13,7 @@ import '../../../state/app_state.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
 import '../../../widgets/app_section.dart';
+import '../../../widgets/app_snackbar.dart';
 import '../../wizard/setup_wizard.dart';
 
 class DataSection extends StatelessWidget {
@@ -43,7 +44,7 @@ class DataSection extends StatelessWidget {
         onPressed: () async {
           final appState = Provider.of<AppState>(context, listen: false);
           await appState.clearDownloaderCache();
-          if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.downloaderCacheCleared)));
+          if (context.mounted) AppSnackBar.success(context, AppLocalizations.of(context)!.downloaderCacheCleared);
         },
         icon: Icons.delete_sweep_outlined,
         label: l10n.clearDownloaderCache,
@@ -136,7 +137,7 @@ class DataSection extends StatelessWidget {
     if (!context.mounted) return;
 
     if (path != null) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.settingsExported)));
+      AppSnackBar.success(context, l10n.settingsExported);
     }
   }
 
@@ -285,13 +286,10 @@ class DataSection extends StatelessWidget {
       await appState.galleryState.reloadSettings();
       await appState.fileBrowserState.reloadSettings();
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(importedMsg)));
+      AppSnackBar.success(context, importedMsg);
     } catch (e) {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(backupImportErrorText(l10n, e)),
-        backgroundColor: Theme.of(context).colorScheme.error,
-      ));
+      AppSnackBar.error(context, backupImportErrorText(l10n, e));
     }
   }
 

--- a/lib/screens/wizard/setup_wizard.dart
+++ b/lib/screens/wizard/setup_wizard.dart
@@ -14,6 +14,7 @@ import '../../state/app_state.dart';
 import '../../widgets/api_key_field.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
+import '../../widgets/app_snackbar.dart';
 import '../../widgets/settings_widgets.dart';
 import 'wizard_import.dart';
 
@@ -493,7 +494,7 @@ class _SetupWizardState extends State<SetupWizard> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(e.toString())));
+        AppSnackBar.error(context, e.toString());
       }
     } finally {
       if (mounted) setState(() => _isFetchingModels = false);

--- a/lib/screens/wizard/wizard_import.dart
+++ b/lib/screens/wizard/wizard_import.dart
@@ -11,6 +11,7 @@ import '../../services/database_service.dart';
 import '../../state/app_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
+import '../../widgets/app_snackbar.dart';
 
 /// Backup-import flow for the setup wizard.
 ///
@@ -66,10 +67,7 @@ Future<void> importBackupSettings(BuildContext context, AppLocalizations l10n) a
     Navigator.of(context).pop();
   } catch (e) {
     if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text(backupImportErrorText(l10n, e)),
-      backgroundColor: Theme.of(context).colorScheme.error,
-    ));
+    AppSnackBar.error(context, backupImportErrorText(l10n, e));
   }
 }
 

--- a/lib/screens/workbench/widgets/gallery_file_actions.dart
+++ b/lib/screens/workbench/widgets/gallery_file_actions.dart
@@ -12,6 +12,7 @@ import '../../../models/app_image.dart';
 import '../../../state/app_state.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
+import '../../../widgets/app_snackbar.dart';
 
 /// File-system side effects for gallery items (save / share / delete).
 ///
@@ -39,9 +40,7 @@ Future<void> saveImageFile(
       );
 
       if (outputFile != null && context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.settingsExported), backgroundColor: Colors.green),
-        );
+        AppSnackBar.success(context, l10n.settingsExported);
       }
     } else {
       if (AppConstants.isVideoFile(sourcePath)) {
@@ -50,16 +49,12 @@ Future<void> saveImageFile(
         await Gal.putImage(sourcePath);
       }
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.savedToPhotos), backgroundColor: Colors.green),
-        );
+        AppSnackBar.success(context, l10n.savedToPhotos);
       }
     }
   } catch (e) {
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.saveFailed(e.toString())), backgroundColor: Colors.red),
-      );
+      AppSnackBar.error(context, l10n.saveFailed(e.toString()));
     }
   }
 }
@@ -86,9 +81,7 @@ Future<void> shareImageFiles(
     );
   } catch (e) {
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.shareFailed(e.toString()))),
-      );
+      AppSnackBar.error(context, l10n.shareFailed(e.toString()));
     }
   }
 }
@@ -154,16 +147,12 @@ Future<void> _deleteImageFile(
     }
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.deleteSuccess), backgroundColor: Colors.green),
-      );
+      AppSnackBar.success(context, l10n.deleteSuccess);
       appState.galleryState.refreshImages();
     }
   } catch (e) {
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.deleteFailed(e.toString())), backgroundColor: Colors.red),
-      );
+      AppSnackBar.error(context, l10n.deleteFailed(e.toString()));
     }
   }
 }

--- a/lib/screens/workbench/widgets/image_card_context_menu.dart
+++ b/lib/screens/workbench/widgets/image_card_context_menu.dart
@@ -10,6 +10,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../models/app_image.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/dialogs/file_rename_dialog.dart';
 import 'gallery_file_actions.dart';
 import 'preview/media_preview_dialog.dart';
@@ -193,9 +194,7 @@ void showImageCardContextMenu(
       onTap: () {
         final filename = imageFile.name;
         Clipboard.setData(ClipboardData(text: filename));
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.copiedToClipboard(filename)), duration: const Duration(seconds: 1)),
-        );
+        AppSnackBar.success(context, l10n.copiedToClipboard(filename));
       },
     ),
     PopupMenuItem(

--- a/lib/screens/workbench/widgets/preview/media_preview_dialog.dart
+++ b/lib/screens/workbench/widgets/preview/media_preview_dialog.dart
@@ -12,6 +12,7 @@ import '../../../../core/responsive.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../models/app_image.dart';
 import '../../../../state/workbench_ui_state.dart';
+import '../../../../widgets/app_snackbar.dart';
 import 'preview_handler.dart';
 
 /// Full-screen, swipeable preview for a list of media files of any supported
@@ -80,9 +81,7 @@ class _MediaPreviewDialogState extends State<MediaPreviewDialog> {
 
         if (outputFile != null) {
           if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(l10n.settingsExported), backgroundColor: Colors.green),
-            );
+            AppSnackBar.success(context, l10n.settingsExported);
           }
         }
       } else {
@@ -92,16 +91,12 @@ class _MediaPreviewDialogState extends State<MediaPreviewDialog> {
           await Gal.putImage(path);
         }
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.savedToPhotos), backgroundColor: Colors.green),
-          );
+          AppSnackBar.success(context, l10n.savedToPhotos);
         }
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.saveFailed(e.toString())), backgroundColor: Colors.red),
-        );
+        AppSnackBar.error(context, l10n.saveFailed(e.toString()));
       }
     }
   }
@@ -113,9 +108,7 @@ class _MediaPreviewDialogState extends State<MediaPreviewDialog> {
       await Share.shareXFiles([xFile], subject: file.name);
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.shareFailed(e.toString()))),
-        );
+        AppSnackBar.error(context, l10n.shareFailed(e.toString()));
       }
     }
   }

--- a/lib/screens/workbench/widgets/video_config_panel.dart
+++ b/lib/screens/workbench/widgets/video_config_panel.dart
@@ -13,6 +13,7 @@ import '../../../services/llm/model_capabilities.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
 import '../../../widgets/app_segmented_control.dart';
+import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/collapsible_card.dart';
 import '../../../widgets/dialogs/prompt_history_dialog.dart';
 import '../../../widgets/markdown_editor.dart';
@@ -53,7 +54,7 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
     // Find selected model
     final videoModels = appState.videoModels;
     if (videoModels.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.noModelsConfigured)));
+      AppSnackBar.warning(context, l10n.noModelsConfigured);
       return;
     }
 
@@ -79,9 +80,7 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
 
     appState.submitVideoTask(selectedModel.id, params, modelIdDisplay: selectedModel.modelName);
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(l10n.taskSubmitted), behavior: SnackBarBehavior.floating),
-    );
+    AppSnackBar.info(context, l10n.taskSubmitted);
   }
 
   @override

--- a/lib/screens/workbench/workbench_config_panel.dart
+++ b/lib/screens/workbench/workbench_config_panel.dart
@@ -14,6 +14,7 @@ import '../../state/workbench_ui_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_card.dart';
 import '../../widgets/app_icon_button.dart';
+import '../../widgets/app_snackbar.dart';
 import '../../widgets/dialogs/library_dialog.dart';
 import '../../widgets/dialogs/prompt_history_dialog.dart';
 import '../../widgets/markdown_editor.dart';
@@ -298,13 +299,12 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
                   : () {
                       final appState = Provider.of<AppState>(context, listen: false);
                       if (selectedModelDbId == null) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(l10n.noModelsConfigured),
-                            action: SnackBarAction(
-                              label: l10n.models,
-                              onPressed: () => appState.navigateToScreen(6),
-                            ),
+                        AppSnackBar.warning(
+                          context,
+                          l10n.noModelsConfigured,
+                          action: AppSnackBarAction(
+                            label: l10n.models,
+                            onPressed: () => appState.navigateToScreen(6),
                           ),
                         );
                         return;
@@ -324,14 +324,7 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
                         Navigator.pop(context);
                       }
 
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(l10n.taskSubmitted),
-                          duration: const Duration(seconds: 2),
-                          behavior: SnackBarBehavior.floating,
-                          width: 250,
-                        ),
-                      );
+                      AppSnackBar.info(context, l10n.taskSubmitted);
                     },
               icon: const Icon(Icons.play_arrow_rounded, size: 24),
               label: Text(

--- a/lib/screens/workbench/workbench_screen.dart
+++ b/lib/screens/workbench/workbench_screen.dart
@@ -27,6 +27,7 @@ import '../../state/gallery_state.dart';
 import '../../state/workbench_ui_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
+import '../../widgets/app_snackbar.dart';
 import '../../widgets/drawing_canvas.dart';
 import '../../widgets/unified_sidebar.dart';
 import 'gallery.dart';
@@ -188,7 +189,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     if (text.isEmpty) return;
 
     if (workbenchUIState.optSelectedModelDbId == null || _appState == null) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.noModelsConfigured)));
+      AppSnackBar.warning(context, l10n.noModelsConfigured);
       return;
     }
 
@@ -199,9 +200,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
       await _refreshKbStatus();
       if (_kbStatus != KbStatus.ok) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(AppLocalizations.of(context)!.optKbNotConfigured)),
-          );
+          AppSnackBar.warning(context, AppLocalizations.of(context)!.optKbNotConfigured);
         }
         return;
       }
@@ -232,16 +231,14 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     if (session.isRunning) return;
 
     if (workbenchUIState.optSelectedModelDbId == null || _appState == null) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.noModelsConfigured)));
+      AppSnackBar.warning(context, l10n.noModelsConfigured);
       return;
     }
     if (session.usesKnowledgeBase) {
       await _refreshKbStatus();
       if (_kbStatus != KbStatus.ok) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(AppLocalizations.of(context)!.optKbNotConfigured)),
-          );
+          AppSnackBar.warning(context, AppLocalizations.of(context)!.optKbNotConfigured);
         }
         return;
       }
@@ -261,16 +258,14 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     if (session.isRunning || session.history.isEmpty) return;
 
     if (workbenchUIState.optSelectedModelDbId == null || _appState == null) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.noModelsConfigured)));
+      AppSnackBar.warning(context, l10n.noModelsConfigured);
       return;
     }
     if (session.usesKnowledgeBase) {
       await _refreshKbStatus();
       if (_kbStatus != KbStatus.ok) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(AppLocalizations.of(context)!.optKbNotConfigured)),
-          );
+          AppSnackBar.warning(context, AppLocalizations.of(context)!.optKbNotConfigured);
         }
         return;
       }
@@ -301,7 +296,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     } catch (e) {
       if (mounted) {
         final l10n = AppLocalizations.of(context)!;
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.refineFailed(e.toString()))));
+        AppSnackBar.error(context, l10n.refineFailed(e.toString()));
       }
     }
   }
@@ -314,7 +309,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     final sessions = await workbenchUIState.listAssistantSessions();
     if (!mounted) return;
     if (sessions.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(l10n.optNoHistory)));
+      AppSnackBar.info(context, l10n.optNoHistory);
       return;
     }
     await showModalBottomSheet(
@@ -471,9 +466,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     if (KnowledgeBaseStarter.isInitialized(root)) {
       await _refreshKbStatus();
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(l10n.kbScaffoldAlreadyInit(KnowledgeBaseService.entryFileName)),
-      ));
+      AppSnackBar.info(context, l10n.kbScaffoldAlreadyInit(KnowledgeBaseService.entryFileName));
       return;
     }
 
@@ -496,14 +489,10 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
       final result = await KnowledgeBaseStarter.scaffold(root);
       await _refreshKbStatus();
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.kbScaffoldDone(result.created.length))),
-      );
+      AppSnackBar.success(context, l10n.kbScaffoldDone(result.created.length));
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.kbScaffoldFailed('$e'))),
-      );
+      AppSnackBar.error(context, l10n.kbScaffoldFailed('$e'));
     }
   }
 
@@ -516,9 +505,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
       await _refreshKbStatus();
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.kbEditFailed('$e'))),
-      );
+      AppSnackBar.error(context, l10n.kbEditFailed('$e'));
     }
   }
 
@@ -530,7 +517,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
     if (_appState == null || prompt.isEmpty) return;
     _appState!.updateWorkbenchConfig(prompt: prompt);
     _appState!.setWorkbenchTab(0);
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.promptApplied)));
+    AppSnackBar.info(context, AppLocalizations.of(context)!.promptApplied);
   }
 
   void _onAppStateChanged() {
@@ -607,15 +594,11 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
       }
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(AppLocalizations.of(context)!.maskSaved), backgroundColor: Colors.green),
-        );
+        AppSnackBar.success(context, AppLocalizations.of(context)!.maskSaved);
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(AppLocalizations.of(context)!.maskSaveError(e.toString())), backgroundColor: Colors.red),
-        );
+        AppSnackBar.error(context, AppLocalizations.of(context)!.maskSaveError(e.toString()));
       }
     } finally {
       if (binary != originalBinaryMode && mounted) {

--- a/lib/widgets/app_side_panel.dart
+++ b/lib/widgets/app_side_panel.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import '../core/responsive.dart';
+
+/// Width a side panel takes on a window wide enough to slide one in.
+const double appSidePanelWidth = 450;
+
+/// A panel that arrives from the right edge on a wide window, and from the
+/// bottom as a draggable sheet on a narrow one.
+///
+/// For content that is a *place* rather than a question — a prompt library, a
+/// history list — where [AppDialog]'s centred box would either crop a long
+/// list or float a tall column in the middle of the screen. A panel anchored
+/// to an edge can be as tall as the window and leaves the work it belongs to
+/// visible beside it.
+///
+/// Both presentations, and the surface itself, live here because the two
+/// panels that existed before this had each copied the whole thing: the same
+/// 46-line `isNarrow ? showModalBottomSheet : showGeneralDialog` branch, the
+/// same slide curve, and the same 450px shadowed container, duplicated
+/// verbatim. Anything that needs to change about how a panel arrives now has
+/// one place to change it.
+///
+/// Assumes a left-to-right layout — the panel enters from the right and its
+/// shadow falls left. Every locale this app ships is LTR; an RTL one would
+/// need both mirrored.
+class AppSidePanel extends StatelessWidget {
+  final Widget child;
+
+  /// Ignored on a narrow window, where the sheet always spans the width.
+  final double width;
+
+  const AppSidePanel({
+    super.key,
+    required this.child,
+    this.width = appSidePanelWidth,
+  });
+
+  /// Presents [builder]'s content as a side panel, picking the presentation
+  /// from the window width. Resolves with whatever the panel is popped with.
+  static Future<T?> show<T>(
+    BuildContext context, {
+    required WidgetBuilder builder,
+    double width = appSidePanelWidth,
+  }) {
+    if (Responsive.isNarrow(context)) {
+      return showModalBottomSheet<T>(
+        context: context,
+        isScrollControlled: true,
+        useSafeArea: true,
+        // The panel paints its own surface and corner; a colour here would
+        // sit behind them as a second, square one.
+        backgroundColor: Colors.transparent,
+        builder: (context) => DraggableScrollableSheet(
+          initialChildSize: 0.9,
+          minChildSize: 0.5,
+          maxChildSize: 0.95,
+          expand: false,
+          builder: (context, _) => AppSidePanel(width: width, child: builder(context)),
+        ),
+      );
+    }
+
+    return showGeneralDialog<T>(
+      context: context,
+      barrierDismissible: true,
+      // Material's own translated label, not the bare English "Dismiss" the
+      // copies used — this is what a screen reader announces for the barrier.
+      barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+      transitionDuration: const Duration(milliseconds: 300),
+      pageBuilder: (context, _, _) => Align(
+        alignment: Alignment.centerRight,
+        child: AppSidePanel(width: width, child: builder(context)),
+      ),
+      transitionBuilder: (context, animation, _, child) => SlideTransition(
+        position: Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
+            .animate(CurvedAnimation(parent: animation, curve: Curves.easeOutCubic)),
+        child: child,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isNarrow = Responsive.isNarrow(context);
+    final borderRadius =
+        isNarrow ? const BorderRadius.vertical(top: Radius.circular(20)) : null;
+
+    return Container(
+      width: isNarrow ? double.infinity : width,
+      height: double.infinity,
+      // Shadow only. The fill belongs to the Material below, which also does
+      // the clipping — a colour on both would be one painted over the other.
+      decoration: BoxDecoration(
+        borderRadius: borderRadius,
+        boxShadow: isNarrow
+            ? null
+            : [
+                BoxShadow(
+                  color: colorScheme.shadow.withValues(alpha: 0.2),
+                  blurRadius: 20,
+                  offset: const Offset(-5, 0),
+                ),
+              ],
+      ),
+      // Material, not a plain Container: these panels are lists of ListTiles
+      // and InkWells, whose ink a Container swallows.
+      child: Material(
+        color: colorScheme.surface,
+        borderRadius: borderRadius,
+        clipBehavior: Clip.antiAlias,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/widgets/app_snackbar.dart
+++ b/lib/widgets/app_snackbar.dart
@@ -1,6 +1,16 @@
 import 'package:flutter/material.dart';
 
-enum _AppSnackBarKind { success, error, info }
+enum _AppSnackBarKind { success, error, warning, info }
+
+/// A single button on a toast, for the case where the message names something
+/// the user has to go and do — "no model configured" is only actionable if
+/// the toast can also offer the way to Settings.
+class AppSnackBarAction {
+  final String label;
+  final VoidCallback onPressed;
+
+  const AppSnackBarAction({required this.label, required this.onPressed});
+}
 
 /// Shows a themed [SnackBar] for one of three outcomes.
 ///
@@ -13,14 +23,33 @@ enum _AppSnackBarKind { success, error, info }
 class AppSnackBar {
   AppSnackBar._();
 
-  static void success(BuildContext context, String message) => _show(context, message, _AppSnackBarKind.success);
+  static void success(BuildContext context, String message, {AppSnackBarAction? action}) =>
+      _show(context, message, _AppSnackBarKind.success, action);
 
-  static void error(BuildContext context, String message) => _show(context, message, _AppSnackBarKind.error);
+  static void error(BuildContext context, String message, {AppSnackBarAction? action}) =>
+      _show(context, message, _AppSnackBarKind.error, action);
 
-  static void info(BuildContext context, String message) => _show(context, message, _AppSnackBarKind.info);
+  /// A precondition the user has to satisfy before the thing they asked for
+  /// can happen — no model configured, no output folder chosen, a required
+  /// field left empty.
+  ///
+  /// Distinct from [error] on purpose: nothing has gone wrong and nothing was
+  /// lost, so painting it in the same red as a failed save teaches the user to
+  /// discount red. Distinct from [info] too — this one blocks.
+  static void warning(BuildContext context, String message, {AppSnackBarAction? action}) =>
+      _show(context, message, _AppSnackBarKind.warning, action);
 
-  static void _show(BuildContext context, String message, _AppSnackBarKind kind) {
+  static void info(BuildContext context, String message, {AppSnackBarAction? action}) =>
+      _show(context, message, _AppSnackBarKind.info, action);
+
+  static void _show(
+    BuildContext context,
+    String message,
+    _AppSnackBarKind kind,
+    AppSnackBarAction? action,
+  ) {
     final colorScheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     final (background, foreground, icon) = switch (kind) {
       _AppSnackBarKind.success => (
           colorScheme.primaryContainer,
@@ -28,6 +57,17 @@ class AppSnackBar {
           Icons.check_circle_outline,
         ),
       _AppSnackBarKind.error => (colorScheme.errorContainer, colorScheme.onErrorContainer, Icons.error_outline),
+      // Amber literals rather than a scheme role, and deliberately so. Material
+      // has no warning role; the nearest, tertiaryContainer, is derived from
+      // whatever seed the user picked, so "warning" would be teal for one user
+      // and pink for another — which is no signal at all. Amber is the one
+      // status colour that carries meaning independently of the palette, and
+      // the log console already spells its levels out the same way.
+      _AppSnackBarKind.warning => (
+          isDark ? const Color(0xFF4A3A00) : const Color(0xFFFFF1C7),
+          isDark ? const Color(0xFFFFD180) : const Color(0xFF6B4E00),
+          Icons.warning_amber_rounded,
+        ),
       // Not errorContainer/primaryContainer: info is neither good nor bad
       // news, so it takes the neutral inverse-surface tone Material reserves
       // for exactly this — a toast that stands out without implying a verdict.
@@ -43,8 +83,17 @@ class AppSnackBar {
         SnackBar(
           backgroundColor: background,
           behavior: SnackBarBehavior.floating,
-          duration: const Duration(seconds: 4),
+          // A toast the user is meant to act on has to outlast the four
+          // seconds it takes to read one they only have to notice.
+          duration: Duration(seconds: action == null ? 4 : 8),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          action: action == null
+              ? null
+              : SnackBarAction(
+                  label: action.label,
+                  textColor: foreground,
+                  onPressed: action.onPressed,
+                ),
           content: Row(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/lib/widgets/dialogs/file_rename_dialog.dart
+++ b/lib/widgets/dialogs/file_rename_dialog.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 import '../../l10n/app_localizations.dart';
 import '../app_button.dart';
 import '../app_dialog.dart';
+import '../app_snackbar.dart';
 
 Future<void> showFileRenameDialog({
   required BuildContext context,
@@ -63,9 +64,7 @@ Future<void> showFileRenameDialog({
 
     if (File(newPath).existsSync()) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.fileAlreadyExists), backgroundColor: Colors.orange),
-        );
+        AppSnackBar.warning(context, l10n.fileAlreadyExists);
       }
       return;
     }
@@ -74,15 +73,11 @@ Future<void> showFileRenameDialog({
       await file.rename(newPath);
       onSuccess();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.renameSuccess), backgroundColor: Colors.green),
-        );
+        AppSnackBar.success(context, l10n.renameSuccess);
       }
     } catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.renameFailed(e.toString())), backgroundColor: Colors.red),
-        );
+        AppSnackBar.error(context, l10n.renameFailed(e.toString()));
       }
     }
   }

--- a/lib/widgets/dialogs/library_dialog.dart
+++ b/lib/widgets/dialogs/library_dialog.dart
@@ -4,6 +4,7 @@ import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/prompt.dart';
 import '../../models/tag.dart';
+import '../app_side_panel.dart';
 
 class PromptLibrarySheet extends StatefulWidget {
   final List<Prompt> allPrompts;
@@ -26,56 +27,15 @@ class PromptLibrarySheet extends StatefulWidget {
     required String initialContent,
     required Function(String, bool isAppend) onApply,
   }) async {
-    final isNarrow = Responsive.isNarrow(context);
-    
-    if (isNarrow) {
-      await showModalBottomSheet(
-        context: context,
-        isScrollControlled: true,
-        useSafeArea: true,
-        backgroundColor: Theme.of(context).colorScheme.surface,
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-        ),
-        builder: (context) => DraggableScrollableSheet(
-          initialChildSize: 0.9,
-          minChildSize: 0.5,
-          maxChildSize: 0.95,
-          expand: false,
-          builder: (context, scrollController) => PromptLibrarySheet(
-            allPrompts: allPrompts,
-            tags: tags,
-            initialContent: initialContent,
-            onApply: onApply,
-          ),
-        ),
-      );
-    } else {
-      await showGeneralDialog(
-        context: context,
-        barrierDismissible: true,
-        barrierLabel: 'Dismiss',
-        transitionDuration: const Duration(milliseconds: 300),
-        pageBuilder: (context, anim1, anim2) => Align(
-          alignment: Alignment.centerRight,
-          child: PromptLibrarySheet(
-            allPrompts: allPrompts,
-            tags: tags,
-            initialContent: initialContent,
-            onApply: onApply,
-          ),
-        ),
-        transitionBuilder: (context, anim1, anim2, child) {
-          return SlideTransition(
-            position: Tween<Offset>(
-              begin: const Offset(1, 0),
-              end: Offset.zero,
-            ).animate(CurvedAnimation(parent: anim1, curve: Curves.easeOutCubic)),
-            child: child,
-          );
-        },
-      );
-    }
+    await AppSidePanel.show<void>(
+      context,
+      builder: (context) => PromptLibrarySheet(
+        allPrompts: allPrompts,
+        tags: tags,
+        initialContent: initialContent,
+        onApply: onApply,
+      ),
+    );
   }
 
   @override
@@ -115,31 +75,18 @@ class _PromptLibrarySheetState extends State<PromptLibrarySheet> {
       return matchesSearch && _selectedFilterTagIds.any((id) => promptTagIds.contains(id));
     }).toList();
 
-    final sheetContent = Container(
-      width: isNarrow ? double.infinity : 450,
-      height: double.infinity,
-      decoration: BoxDecoration(
-        color: colorScheme.surface,
-        borderRadius: isNarrow ? const BorderRadius.vertical(top: Radius.circular(20)) : null,
-        boxShadow: isNarrow ? null : [
-          BoxShadow(color: Colors.black.withAlpha(50), blurRadius: 20, offset: const Offset(-5, 0))
-        ],
-      ),
-      child: Material( // Need material for inkwell and text styles
-        child: Column(
-          children: [
-            _buildHeader(l10n, colorScheme, isNarrow),
-            _buildTagFilterBar(colorScheme),
-            const Divider(height: 1),
-            Expanded(
-              child: _buildPromptList(filteredPrompts, l10n, colorScheme),
-            ),
-          ],
+    // Surface, width and shadow belong to AppSidePanel, which is what
+    // presents this. All that is left here is what the panel contains.
+    return Column(
+      children: [
+        _buildHeader(l10n, colorScheme, isNarrow),
+        _buildTagFilterBar(colorScheme),
+        const Divider(height: 1),
+        Expanded(
+          child: _buildPromptList(filteredPrompts, l10n, colorScheme),
         ),
-      ),
+      ],
     );
-
-    return isNarrow ? sheetContent : sheetContent;
   }
 
   Widget _buildHeader(AppLocalizations l10n, ColorScheme colorScheme, bool isNarrow) {

--- a/lib/widgets/dialogs/prompt_history_dialog.dart
+++ b/lib/widgets/dialogs/prompt_history_dialog.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/prompt_history_entry.dart';
 import '../../state/app_state.dart';
 import '../app_button.dart';
 import '../app_dialog.dart';
+import '../app_side_panel.dart';
 
 /// Prompt-header action that opens the recent-prompt picker for [type].
 ///
@@ -76,54 +76,14 @@ class PromptHistorySheet extends StatefulWidget {
     required ValueChanged<String> onApply,
     required VoidCallback onClear,
   }) async {
-    final isNarrow = Responsive.isNarrow(context);
-
-    if (isNarrow) {
-      await showModalBottomSheet(
-        context: context,
-        isScrollControlled: true,
-        useSafeArea: true,
-        backgroundColor: Theme.of(context).colorScheme.surface,
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-        ),
-        builder: (context) => DraggableScrollableSheet(
-          initialChildSize: 0.9,
-          minChildSize: 0.5,
-          maxChildSize: 0.95,
-          expand: false,
-          builder: (context, scrollController) => PromptHistorySheet(
-            entries: entries,
-            onApply: onApply,
-            onClear: onClear,
-          ),
-        ),
-      );
-    } else {
-      await showGeneralDialog(
-        context: context,
-        barrierDismissible: true,
-        barrierLabel: 'Dismiss',
-        transitionDuration: const Duration(milliseconds: 300),
-        pageBuilder: (context, anim1, anim2) => Align(
-          alignment: Alignment.centerRight,
-          child: PromptHistorySheet(
-            entries: entries,
-            onApply: onApply,
-            onClear: onClear,
-          ),
-        ),
-        transitionBuilder: (context, anim1, anim2, child) {
-          return SlideTransition(
-            position: Tween<Offset>(
-              begin: const Offset(1, 0),
-              end: Offset.zero,
-            ).animate(CurvedAnimation(parent: anim1, curve: Curves.easeOutCubic)),
-            child: child,
-          );
-        },
-      );
-    }
+    await AppSidePanel.show<void>(
+      context,
+      builder: (context) => PromptHistorySheet(
+        entries: entries,
+        onApply: onApply,
+        onClear: onClear,
+      ),
+    );
   }
 
   @override
@@ -135,29 +95,15 @@ class _PromptHistorySheetState extends State<PromptHistorySheet> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
-    final isNarrow = Responsive.isNarrow(context);
 
-    return Container(
-      width: isNarrow ? double.infinity : 450,
-      height: double.infinity,
-      decoration: BoxDecoration(
-        color: colorScheme.surface,
-        borderRadius: isNarrow ? const BorderRadius.vertical(top: Radius.circular(20)) : null,
-        boxShadow: isNarrow
-            ? null
-            : [
-                BoxShadow(color: Colors.black.withAlpha(50), blurRadius: 20, offset: const Offset(-5, 0))
-              ],
-      ),
-      child: Material(
-        child: Column(
-          children: [
-            _buildHeader(l10n, colorScheme),
-            const Divider(height: 1),
-            Expanded(child: _buildList(l10n, colorScheme)),
-          ],
-        ),
-      ),
+    // Surface, width and shadow belong to AppSidePanel, which is what
+    // presents this. All that is left here is what the panel contains.
+    return Column(
+      children: [
+        _buildHeader(l10n, colorScheme),
+        const Divider(height: 1),
+        Expanded(child: _buildList(l10n, colorScheme)),
+      ],
     );
   }
 

--- a/lib/widgets/log_console.dart
+++ b/lib/widgets/log_console.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../models/log_entry.dart';
 import '../state/app_state.dart';
+import 'app_snackbar.dart';
 
 class LogConsoleWidget extends StatefulWidget {
   final bool showHeader;
@@ -149,7 +150,7 @@ class _LogConsoleWidgetState extends State<LogConsoleWidget> {
               onPressed: () {
                 final text = appState.logs.map((l) => '[${l.level}] ${l.message}').join('\n');
                 Clipboard.setData(ClipboardData(text: text));
-                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Logs copied to clipboard'), duration: Duration(seconds: 1)));
+                AppSnackBar.info(context, 'Logs copied to clipboard');
               },
               tooltip: 'Copy all',
             ),

--- a/lib/widgets/settings_widgets.dart
+++ b/lib/widgets/settings_widgets.dart
@@ -7,6 +7,7 @@ import '../state/app_state.dart';
 import 'app_button.dart';
 import 'app_dialog.dart';
 import 'app_segmented_control.dart';
+import 'app_snackbar.dart';
 
 class ThemeSelector extends StatelessWidget {
   final AppState appState;
@@ -285,9 +286,7 @@ class FontSelector extends StatelessWidget {
     if (ok == true && context.mounted) {
       await appState.setFontFamily(key);
     } else if (ok == false && context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l10n.fontDownloadFailed)),
-      );
+      AppSnackBar.error(context, l10n.fontDownloadFailed);
     }
   }
 }

--- a/test/app_side_panel_test.dart
+++ b/test/app_side_panel_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_side_panel.dart';
+
+/// Covers the panel shell the prompt library and prompt history share.
+///
+/// Both used to carry their own copy of this: the same 46-line
+/// `isNarrow ? showModalBottomSheet : showGeneralDialog` branch and the same
+/// 450px shadowed container, duplicated verbatim. These pin the behaviour
+/// that duplication was hiding, so the next panel inherits it rather than
+/// re-deriving it.
+void main() {
+  Future<void> pumpAndOpen(WidgetTester tester, Size size, {Locale? locale}) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        supportedLocales: const [Locale('en'), Locale('zh')],
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: TextButton(
+                onPressed: () => AppSidePanel.show<void>(
+                  context,
+                  builder: (context) => const Text('panel body'),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a wide window gets a panel of the shared width', (tester) async {
+    await pumpAndOpen(tester, const Size(1400, 900));
+
+    expect(find.text('panel body'), findsOneWidget);
+    expect(tester.getSize(find.byType(AppSidePanel)).width, appSidePanelWidth);
+  });
+
+  testWidgets('the wide panel is pinned to the right edge, full height', (tester) async {
+    // The point of a side panel over a dialog: it can be as tall as the
+    // window and leaves the work it belongs to visible beside it.
+    await pumpAndOpen(tester, const Size(1400, 900));
+
+    final panel = tester.getRect(find.byType(AppSidePanel));
+    expect(panel.right, 1400);
+    expect(panel.height, 900);
+  });
+
+  testWidgets('a narrow window gets a bottom sheet spanning the width', (tester) async {
+    await pumpAndOpen(tester, const Size(400, 800));
+
+    expect(find.text('panel body'), findsOneWidget);
+    expect(find.byType(DraggableScrollableSheet), findsOneWidget);
+    expect(tester.getSize(find.byType(AppSidePanel)).width, 400,
+        reason: 'the sheet kept the desktop panel width on a phone');
+  });
+
+  testWidgets('tapping outside the panel closes it', (tester) async {
+    await pumpAndOpen(tester, const Size(1400, 900));
+
+    expect(tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).dismissible, isTrue);
+
+    await tester.tapAt(const Offset(100, 450));
+    await tester.pumpAndSettle();
+    expect(find.text('panel body'), findsNothing);
+  });
+
+  testWidgets('the barrier announces itself in the reader\'s own language', (tester) async {
+    // The two copies hardcoded an English "Dismiss" here — this string is what
+    // a screen reader reads for the region outside the panel. Asserting it is
+    // not the English word would prove nothing, since Material's own English
+    // translation is also "Dismiss"; what matters is that it *moves* with the
+    // locale, which a hardcoded literal cannot.
+    // The route's barrier is the one carrying the label; the others in the
+    // tree have none, so pick by that rather than by position.
+    String currentLabel() => tester
+        .widgetList<ModalBarrier>(find.byType(ModalBarrier))
+        .map((barrier) => barrier.semanticsLabel)
+        .firstWhere((label) => label != null)!;
+
+    await pumpAndOpen(tester, const Size(1400, 900), locale: const Locale('en'));
+    final english = currentLabel();
+
+    // Dismiss before reopening: the first panel's barrier would otherwise
+    // swallow the tap meant for the button underneath it.
+    await tester.tapAt(const Offset(100, 450));
+    await tester.pumpAndSettle();
+
+    await pumpAndOpen(tester, const Size(1400, 900), locale: const Locale('zh'));
+    final chinese = currentLabel();
+
+    expect(english, isNotEmpty);
+    expect(chinese, isNot(english),
+        reason: 'the barrier label is a hardcoded string, not a translated one');
+  });
+
+  testWidgets('the panel paints one surface, not two stacked ones', (tester) async {
+    // The shell casts the shadow and the Material inside it paints the fill.
+    // Colouring both is how the copies ended up with a square surface behind
+    // a rounded one on mobile.
+    await pumpAndOpen(tester, const Size(1400, 900));
+
+    final container = tester.widget<Container>(
+      find.descendant(of: find.byType(AppSidePanel), matching: find.byType(Container)).first,
+    );
+    final decoration = container.decoration as BoxDecoration;
+
+    expect(decoration.color, isNull, reason: 'the shell is painting a fill of its own');
+    expect(decoration.boxShadow, isNotNull);
+  });
+
+  testWidgets('it resolves with whatever the panel is popped with', (tester) async {
+    // Panels are pickers as often as they are lists; a caller has to be able
+    // to hear what was chosen.
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    String? chosen;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: TextButton(
+                onPressed: () async {
+                  chosen = await AppSidePanel.show<String>(
+                    context,
+                    builder: (context) => TextButton(
+                      onPressed: () => Navigator.pop(context, 'picked'),
+                      child: const Text('choose'),
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('choose'));
+    await tester.pumpAndSettle();
+
+    expect(chosen, 'picked');
+  });
+}


### PR DESCRIPTION
Two of the four component-library debts from #63 paid off. Both are
migrations, and in both cases the call sites turned out to be saying
something the shared component could not express — so the component
grew rather than the call sites being flattened to fit it.

> **Note:** the raw-Material-button migration (81 sites) is in flight and
> will land on this branch as further commits. The `fontSize` → `textTheme`
> migration follows after. Reviewing the two commits here first is fine —
> each is self-contained.

## Toasts — 56 sites across 19 files

Every one had been picking its own colour, duration and shape by hand:
`Colors.green` beside `colorScheme.primary`, one-second durations next
to four-second ones, a 250px-wide floating toast in a single panel.
`AppSnackBar` already owned all of that.

Two gaps showed up while migrating, both forced by real call sites:

**A `warning` kind.** Fourteen sites are *preconditions* — no model
configured, no output folder chosen, a required field empty. Nothing
failed and nothing was lost, so `error` overstates them and teaches the
user to discount red; `info` understates them, because they do block.
Several sites had already reached for `Colors.orange` to say exactly
this. The amber is spelled out as literals rather than taken from the
scheme on purpose: Material has no warning role, and the nearest one
(`tertiaryContainer`) is seeded — "warning" would come out teal for one
user and pink for another, which is no signal at all. The log console
already spells its levels out the same way.

**An `action`.** Three sites carry a "Settings" button that is the
user's only route to fixing what the toast complains about. Dropping it
to fit the API would have been a genuine regression. A toast with an
action also gets eight seconds instead of four — long enough to act on,
not merely to read.

Async gaps were the trap. Several sites captured the messenger *before*
an await precisely to avoid holding a `BuildContext` across one; those
became explicit `context.mounted` guards rather than a silent
reintroduction of the problem.

## AppSidePanel — 139 lines fewer

The prompt library and the prompt history each carried their own copy of
the same 46-line `isNarrow ? showModalBottomSheet : showGeneralDialog`
branch, the same slide curve, and the same 450px shadowed container —
verbatim, down to a `return isNarrow ? sheetContent : sheetContent;`
whose two branches are identical.

Two bugs the duplication was hiding, now fixed once:

- The barrier label was a hardcoded English `'Dismiss'`. That string is
  what a screen reader announces for the region outside the panel;
  Material already translates it.
- The shell and the `Material` inside it both painted a fill, so on a
  narrow window a square surface sat behind the rounded one. The shell
  now casts the shadow; the `Material` paints and clips.

## Verification

`flutter analyze` clean, 381 tests pass.

Mid-migration I made a scripting error that briefly deleted the
arguments from 14 toast call sites. It was caught by `analyze`, repaired
by line, and then checked properly: a script extracted every
localisation key referenced inside a snackbar call before and after the
whole migration — **37 both times, none lost**. Worth knowing the check
exists, since "analyze is green" would not have caught a dropped
message.

New tests cover `AppSidePanel`'s responsive switch, edge anchoring,
dismissal, the single-fill rule, and that it resolves with whatever it
is popped with — the last because a panel is a picker as often as it is
a list, and neither copy had established that.

## Reviewer notes

- `AppSnackBar.warning`'s amber is the only colour in the library not
  derived from the scheme. The reasoning is in the code; if you would
  rather it tracked the seed, that is a one-line change and a different
  trade-off.
- Two duration/width customisations were deliberately dropped (a 2s
  toast at 250px, a 1s "copied" toast) — the helper owns those now.
- `log_console.dart`'s `'Logs copied to clipboard'` is still an
  unlocalised English literal. It was before this change too; flagging
  it rather than fixing it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
