### PR TITLE
refactor(ui): move the buttons onto AppButton and the type onto the scale

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -194,3 +194,50 @@ ButtonStyle tonalButtonStyle(ColorScheme colorScheme) {
     elevation: 0,
   );
 }
+
+/// Taking a type-scale slot's size without its colour.
+extension AppTextScaleMetrics on TextStyle {
+  /// This slot's metrics, carrying no colour of its own.
+  ///
+  /// Every slot of a Material 3 [TextTheme] arrives stamped with `onSurface`
+  /// — `Typography.material2021` puts it there — and an explicit colour on a
+  /// [Text] beats the ambient [DefaultTextStyle]. So handing a raw slot to a
+  /// label whose colour belongs to the widget *around* it paints `onSurface`
+  /// over that widget's own choice: near-invisible on a filled button, and
+  /// dead to the selected/unselected switch on a chip or list tile.
+  ///
+  /// The cases, all of which came up migrating the app onto the scale:
+  ///
+  /// - a [FilledButton]/[TextButton] label, whose colour is the button's
+  ///   resolved foreground;
+  /// - a [ChoiceChip]/[FilterChip] label, `onSecondaryContainer` when
+  ///   selected and `onSurfaceVariant` when not;
+  /// - a [ListTile] title or subtitle under `selected: true`, which tints to
+  ///   `primary`;
+  /// - an [ExpansionTile] header, whose colour is an animated tween between
+  ///   two of those.
+  ///
+  /// `copyWith(color: null)` cannot express this — null there means "leave it
+  /// alone" — so the metrics are restated explicitly.
+  /// `inherit: true` is forced, not copied. It is the switch that decides
+  /// whether [Text] merges this over the ambient [DefaultTextStyle] or
+  /// replaces it outright — `TextStyle.merge` returns the incoming style
+  /// wholesale when it is false, which would drop the very colour this is
+  /// trying to inherit. A `TextTheme` slot's own value for it is an
+  /// implementation detail of whoever built the theme.
+  TextStyle get metricsOnly => const TextStyle().copyWith(
+        inherit: true,
+        fontFamily: fontFamily,
+        fontFamilyFallback: fontFamilyFallback,
+        fontSize: fontSize,
+        fontWeight: fontWeight,
+        fontStyle: fontStyle,
+        letterSpacing: letterSpacing,
+        wordSpacing: wordSpacing,
+        height: height,
+        leadingDistribution: leadingDistribution,
+        textBaseline: textBaseline,
+        fontFeatures: fontFeatures,
+        fontVariations: fontVariations,
+      );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -395,7 +395,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                   children: [
                     Text(
                       l10n.appTitle,
-                      style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 14),
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                     ),
                   ],
                 ),
@@ -623,9 +623,8 @@ class _RailItemState extends State<_RailItem> {
                           child: Center(
                             child: Text(
                               widget.badge > 99 ? '99+' : '${widget.badge}',
-                              style: const TextStyle(
+                              style: Theme.of(context).textTheme.labelSmall?.copyWith(
                                 color: Colors.white,
-                                fontSize: 9,
                                 fontWeight: FontWeight.w700,
                                 fontFamily: 'monospace',
                               ),
@@ -639,8 +638,7 @@ class _RailItemState extends State<_RailItem> {
                   const SizedBox(height: 4),
                   Text(
                     widget.label,
-                    style: TextStyle(
-                      fontSize: 9.5,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
                       fontWeight: FontWeight.w600,
                       color: color,
                       letterSpacing: 0.2,
@@ -699,8 +697,7 @@ class _DrawerItem extends StatelessWidget {
             const SizedBox(width: 13),
             Text(
               label,
-              style: TextStyle(
-                fontSize: 14,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
                 fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
                 color: color,
               ),

--- a/lib/screens/batch/task_queue_screen.dart
+++ b/lib/screens/batch/task_queue_screen.dart
@@ -216,7 +216,7 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
             children: [
               Text(
                 l10n.taskQueueManager,
-                style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 20),
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
               ),
               const SizedBox(height: 3),
               _buildHeaderSummary(queue, l10n, colorScheme),
@@ -285,7 +285,7 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
 
     return Text.rich(
       TextSpan(
-        style: TextStyle(fontSize: 12.5, color: colorScheme.onSurfaceVariant),
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
         children: spans,
       ),
       maxLines: 1,
@@ -300,7 +300,7 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
         color: filled ? accent.withValues(alpha: 0.5) : colorScheme.outline.withValues(alpha: 0.45),
       ),
       foregroundColor: accent,
-      textStyle: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w600),
+      textStyle: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
       padding: const EdgeInsets.symmetric(horizontal: 14),
       minimumSize: const Size(0, appButtonMinHeight),
       visualDensity: VisualDensity.standard,
@@ -404,7 +404,10 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
         children: [
           Icon(Icons.assignment_outlined, size: 64, color: colorScheme.outlineVariant),
           const SizedBox(height: 16),
-          Text(l10n.noTasksInQueue, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          Text(
+            l10n.noTasksInQueue,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+          ),
           const SizedBox(height: 8),
           Text(l10n.submitTaskFromWorkbench, style: TextStyle(color: colorScheme.onSurfaceVariant)),
         ],
@@ -436,6 +439,7 @@ class _FilterPill extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final accent = selected ? colorScheme.primary : colorScheme.onSurfaceVariant;
 
     return Material(
@@ -460,8 +464,7 @@ class _FilterPill extends StatelessWidget {
             children: [
               Text(
                 label,
-                style: TextStyle(
-                  fontSize: 12.5,
+                style: textTheme.bodySmall?.copyWith(
                   fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
                   color: accent,
                 ),
@@ -477,8 +480,7 @@ class _FilterPill extends StatelessWidget {
                 ),
                 child: Text(
                   '$count',
-                  style: TextStyle(
-                    fontSize: 11,
+                  style: textTheme.labelMedium?.copyWith(
                     fontWeight: FontWeight.w700,
                     fontFamily: 'monospace',
                     color: accent,
@@ -519,6 +521,7 @@ class TaskInfoRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
       child: Row(
@@ -534,11 +537,11 @@ class TaskInfoRow extends StatelessWidget {
             child: Icon(icon, size: 14, color: colorScheme.onSurfaceVariant),
           ),
           const SizedBox(width: 8),
-          Text('$label: ', style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant)),
+          Text('$label: ', style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant)),
           Expanded(
             child: Text(
               value,
-              style: const TextStyle(fontSize: 12),
+              style: textTheme.bodySmall,
               // maxLines is what makes the ellipsis do anything: unbounded, the
               // overflow setting is inert and the text just keeps wrapping.
               maxLines: maxValueLines,
@@ -659,9 +662,8 @@ class _TaskCardState extends State<_TaskCard> {
           _taskDisplayName(task),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: TextStyle(
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
             fontWeight: FontWeight.w700,
-            fontSize: 14,
             color: task.status == TaskStatus.cancelled
                 ? colorScheme.onSurfaceVariant
                 : colorScheme.onSurface,
@@ -678,17 +680,18 @@ class _TaskCardState extends State<_TaskCard> {
     // Unless there is none: tasks reloaded from the database come back without
     // their logs, and a blank line says less about a failure than the model
     // that produced it does.
+    final textTheme = Theme.of(context).textTheme;
     final error = task.status == TaskStatus.failed ? _errorSummary(task) : '';
     if (error.isNotEmpty) {
       return Text(
         error,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
-        style: TextStyle(fontSize: 12, color: colorScheme.error),
+        style: textTheme.bodySmall?.copyWith(color: colorScheme.error),
       );
     }
 
-    final muted = TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant);
+    final muted = textTheme.bodySmall!.copyWith(color: colorScheme.onSurfaceVariant);
     final (marker, modelId) = _splitModelMarker(task.modelId);
     final children = <Widget>[];
 
@@ -696,7 +699,7 @@ class _TaskCardState extends State<_TaskCard> {
       if (children.isEmpty) return;
       children.add(Padding(
         padding: const EdgeInsets.symmetric(horizontal: 7),
-        child: Text('·', style: TextStyle(fontSize: 12, color: colorScheme.outline)),
+        child: Text('·', style: textTheme.bodySmall?.copyWith(color: colorScheme.outline)),
       ));
     }
 
@@ -762,15 +765,15 @@ class _TaskCardState extends State<_TaskCard> {
     ColorScheme colorScheme,
     AppLocalizations l10n,
   ) {
+    final textTheme = Theme.of(context).textTheme;
     final widgets = <Widget>[];
 
     switch (task.status) {
       case TaskStatus.processing:
         widgets.add(Text(
           _progressLabel(task),
-          style: TextStyle(
+          style: textTheme.bodySmall?.copyWith(
             fontFamily: 'monospace',
-            fontSize: 12,
             fontWeight: FontWeight.w600,
             color: colorScheme.primary,
           ),
@@ -786,7 +789,7 @@ class _TaskCardState extends State<_TaskCard> {
             side: BorderSide(color: colorScheme.error.withValues(alpha: 0.5)),
             backgroundColor: colorScheme.error.withValues(alpha: 0.12),
             foregroundColor: colorScheme.error,
-            textStyle: const TextStyle(fontSize: 11.5, fontWeight: FontWeight.w600),
+            textStyle: textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600),
             padding: const EdgeInsets.symmetric(horizontal: 12),
             minimumSize: const Size(0, 30),
             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
@@ -803,9 +806,8 @@ class _TaskCardState extends State<_TaskCard> {
     if (!widget.isMobile) {
       widgets.add(Text(
         _formatClock(task.endTime ?? task.startTime),
-        style: TextStyle(
+        style: textTheme.bodySmall?.copyWith(
           fontFamily: 'monospace',
-          fontSize: 12,
           color: colorScheme.onSurfaceVariant,
         ),
       ));
@@ -859,7 +861,9 @@ class _TaskCardState extends State<_TaskCard> {
               color: colorScheme.surfaceContainerHighest,
               child: Text(
                 '+$overflow',
-                style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           ),
@@ -876,7 +880,10 @@ class _TaskCardState extends State<_TaskCard> {
       ),
       child: Text(
         label,
-        style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: color),
+        style: Theme.of(context)
+            .textTheme
+            .labelMedium
+            ?.copyWith(fontWeight: FontWeight.w600, color: color),
       ),
     );
   }
@@ -1071,7 +1078,10 @@ class _TaskCardState extends State<_TaskCard> {
                     Expanded(
                       child: Text(
                         task.logs.last,
-                        style: TextStyle(fontFamily: 'monospace', fontSize: 11, color: colorScheme.onSurfaceVariant),
+                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                          fontFamily: 'monospace',
+                          color: colorScheme.onSurfaceVariant,
+                        ),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                       ),
@@ -1202,8 +1212,7 @@ class _MetaBadge extends StatelessWidget {
       ),
       child: Text(
         label,
-        style: TextStyle(
-          fontSize: 10,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
           fontWeight: FontWeight.w700,
           fontFamily: 'monospace',
           color: color,

--- a/lib/screens/browser/ai_rename_dialog.dart
+++ b/lib/screens/browser/ai_rename_dialog.dart
@@ -115,7 +115,17 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
               final t = templates[index];
               return ListTile(
                 title: Text(t.title, style: const TextStyle(fontWeight: FontWeight.bold)),
-                subtitle: Text(t.content, maxLines: 2, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 12)),
+                // ListTile's subtitle slot is `onSurfaceVariant`; the type slot
+                // carries `onSurface`, so the muted tone is restated here.
+                subtitle: Text(
+                  t.content,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                ),
                 onTap: () => Navigator.pop(context, t),
               );
             },
@@ -299,6 +309,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
     final appState = Provider.of<AppState>(context);
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final fileCount = appState.fileBrowserState.selectedFiles.length;
 
     final chatModels = appState.chatModels;
@@ -324,7 +335,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
           const SizedBox(height: 16),
 
           // System template: the whole card opens the picker.
-          Text(l10n.rulesInstructions, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+          Text(l10n.rulesInstructions, style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
           Material(
             color: colorScheme.surfaceContainerHighest.withAlpha(80),
@@ -344,7 +355,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
                         children: [
                           Text(
                             _selectedSystemPrompt?.title ?? l10n.noTemplateSelected,
-                            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                            style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                             overflow: TextOverflow.ellipsis,
                           ),
                           if (_selectedSystemPrompt != null) ...[
@@ -353,7 +364,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
                               _selectedSystemPrompt!.content,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                              style: textTheme.labelMedium?.copyWith(color: colorScheme.outline),
                             ),
                           ],
                         ],
@@ -412,6 +423,8 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
   }
 
   Widget _buildPreviewSection(ColorScheme colorScheme, AppLocalizations l10n) {
+    final textTheme = Theme.of(context).textTheme;
+
     // Waiting on the agent loop.
     if (_isProcessing && _proposedRenames.isEmpty) {
       return _buildPreviewPlaceholder(
@@ -423,7 +436,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
             _batchProgress == null
                 ? l10n.generatingSuggestions
                 : '${l10n.generatingSuggestions} ($_batchProgress)',
-            style: TextStyle(fontSize: 12, color: colorScheme.outline),
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.outline),
           ),
         ],
       );
@@ -435,7 +448,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
         children: [
           Icon(Icons.drive_file_rename_outline, size: 32, color: colorScheme.outlineVariant),
           const SizedBox(height: 8),
-          Text(l10n.noSuggestions, style: TextStyle(fontSize: 12, color: colorScheme.outline)),
+          Text(l10n.noSuggestions, style: textTheme.bodySmall?.copyWith(color: colorScheme.outline)),
         ],
       );
     }
@@ -457,7 +470,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
                 Expanded(
                   child: Text(
                     '${l10n.renamePreviewTitle} (${_proposedRenames.length})',
-                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                    style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
@@ -475,7 +488,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
                         const SizedBox(width: 4),
                         Text(
                           l10n.conflictsFound(_conflicts.length),
-                          style: TextStyle(fontSize: 11, color: colorScheme.onErrorContainer),
+                          style: textTheme.labelMedium?.copyWith(color: colorScheme.onErrorContainer),
                         ),
                       ],
                     ),
@@ -507,6 +520,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
   }
 
   Widget _buildPreviewItem(int index, ColorScheme colorScheme, AppLocalizations l10n) {
+    final textTheme = Theme.of(context).textTheme;
     final item = _proposedRenames[index];
     final conflictKey = _conflicts[item['path']];
     final hasConflict = conflictKey != null;
@@ -530,7 +544,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
               shape: BoxShape.circle,
             ),
             child: Center(
-              child: Text('${index + 1}', style: TextStyle(fontSize: 11, color: colorScheme.outline)),
+              child: Text('${index + 1}', style: textTheme.labelMedium?.copyWith(color: colorScheme.outline)),
             ),
           ),
           const SizedBox(width: 12),
@@ -540,7 +554,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
               children: [
                 Text(
                   item['old_name']!,
-                  style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                  style: textTheme.labelMedium?.copyWith(color: colorScheme.outline),
                   overflow: TextOverflow.ellipsis,
                 ),
                 const SizedBox(height: 3),
@@ -555,8 +569,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
                     Expanded(
                       child: Text(
                         item['new_name']!,
-                        style: TextStyle(
-                          fontSize: 13,
+                        style: textTheme.titleSmall?.copyWith(
                           fontWeight: FontWeight.w600,
                           color: hasConflict ? colorScheme.error : colorScheme.onSurface,
                         ),
@@ -570,7 +583,7 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
                     padding: const EdgeInsets.only(left: 18, top: 3),
                     child: Text(
                       conflictText!,
-                      style: TextStyle(fontSize: 11, color: colorScheme.error),
+                      style: textTheme.labelMedium?.copyWith(color: colorScheme.error),
                     ),
                   ),
               ],

--- a/lib/screens/browser/ai_rename_dialog.dart
+++ b/lib/screens/browser/ai_rename_dialog.dart
@@ -385,19 +385,11 @@ class _AiRenameDialogState extends State<AiRenameDialog> {
 
           SizedBox(
             width: double.infinity,
-            child: FilledButton.icon(
-              onPressed: _isProcessing ? null : _generateSuggestions,
-              style: FilledButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 14),
-              ),
-              icon: _isProcessing
-                  ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.bolt),
-              label: Text(l10n.generateSuggestions),
+            child: AppButton(
+              label: l10n.generateSuggestions,
+              icon: Icons.bolt,
+              loading: _isProcessing,
+              onPressed: _generateSuggestions,
             ),
           ),
           const SizedBox(height: 20),

--- a/lib/screens/browser/file_browser_screen.dart
+++ b/lib/screens/browser/file_browser_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../../core/app_theme.dart';
 import '../../core/constants.dart';
 import '../../core/file_utils.dart';
 import '../../core/responsive.dart';
@@ -160,7 +161,10 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
                     ? l10n.fileBrowseriOSHint
                     : l10n.fileBrowserAndroidHint,
                 textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 13, color: colorScheme.primary, fontWeight: FontWeight.w500),
+                style: Theme.of(context)
+                    .textTheme
+                    .labelLarge
+                    ?.copyWith(color: colorScheme.primary, fontWeight: FontWeight.w500),
               ),
             ],
           ),
@@ -213,7 +217,7 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
             children: [
               Text(
                 l10n.fileBrowser,
-                style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 20),
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
               ),
               const SizedBox(height: 3),
               _buildHeaderSummary(fileCount, selectedCount, l10n, colorScheme),
@@ -320,7 +324,7 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
   ) {
     return Text.rich(
       TextSpan(
-        style: TextStyle(fontSize: 12.5, color: colorScheme.onSurfaceVariant),
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
         children: [
           TextSpan(
             text: l10n.filesCount(fileCount),
@@ -347,10 +351,10 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
         controller: _searchController,
         focusNode: _searchFocusNode,
         onChanged: (v) => state.setSearchQuery(v),
-        style: const TextStyle(fontSize: 13),
+        style: Theme.of(context).textTheme.bodyMedium,
         decoration: InputDecoration(
           hintText: l10n.searchFilesHint,
-          hintStyle: TextStyle(fontSize: 13, color: colorScheme.outline),
+          hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.outline),
           prefixIcon: Icon(Icons.search, size: 18, color: colorScheme.outline),
           suffixIcon: state.searchQuery.isEmpty
               ? null
@@ -426,7 +430,14 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
           onDoubleTap: () => _openWithPreview(context, file, state),
           child: ListTile(
             leading: Icon(file.icon, color: file.color),
-            title: Text(file.name, style: const TextStyle(fontSize: 13)),
+            // ListTile tints a selected title with `primary`; the slot carries
+            // `onSurface`, so that tint has to be re-stated or it is lost.
+            title: Text(
+              file.name,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: isSelected ? Theme.of(context).colorScheme.primary : null,
+              ),
+            ),
             subtitle: _FileListItemSubtitle(file: file),
             selected: isSelected,
             onTap: () => state.toggleSelection(file),
@@ -522,7 +533,7 @@ class _FileListItemSubtitleState extends State<_FileListItemSubtitle> {
     final sizeStr = AppConstants.formatFileSize(widget.file.size);
     return Text(
       "$sizeStr | ${widget.file.modified.toString().substring(0, 16)}$_extraInfo",
-      style: const TextStyle(fontSize: 11),
+      style: Theme.of(context).textTheme.labelMedium?.metricsOnly,
     );
   }
 }

--- a/lib/screens/browser/widgets/browser_filter_bar.dart
+++ b/lib/screens/browser/widgets/browser_filter_bar.dart
@@ -82,18 +82,21 @@ class BrowserFilterBar extends StatelessWidget {
           CheckedPopupMenuItem(
             value: field,
             checked: state.sortField == field,
-            child: Text(_getSortFieldLabel(field, l10n), style: const TextStyle(fontSize: 13)),
+            child: Text(
+              _getSortFieldLabel(field, l10n),
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
           ),
         const PopupMenuDivider(),
         CheckedPopupMenuItem(
           value: true,
           checked: state.sortAscending,
-          child: Text(l10n.sortAsc, style: const TextStyle(fontSize: 13)),
+          child: Text(l10n.sortAsc, style: Theme.of(context).textTheme.labelLarge),
         ),
         CheckedPopupMenuItem(
           value: false,
           checked: !state.sortAscending,
-          child: Text(l10n.sortDesc, style: const TextStyle(fontSize: 13)),
+          child: Text(l10n.sortDesc, style: Theme.of(context).textTheme.labelLarge),
         ),
       ],
       child: Container(
@@ -114,8 +117,7 @@ class BrowserFilterBar extends StatelessWidget {
             const SizedBox(width: 7),
             Text(
               _getSortFieldLabel(state.sortField, l10n),
-              style: TextStyle(
-                fontSize: 12.5,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 fontWeight: FontWeight.w600,
                 color: colorScheme.onSurfaceVariant,
               ),
@@ -220,8 +222,7 @@ class _CategoryPill extends StatelessWidget {
               ],
               Text(
                 label,
-                style: TextStyle(
-                  fontSize: 12.5,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
                   color: color,
                 ),

--- a/lib/screens/browser/widgets/browser_selection_bar.dart
+++ b/lib/screens/browser/widgets/browser_selection_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../state/file_browser_state.dart';
+import '../../../widgets/app_button.dart';
 
 /// Floating contextual action bar shown at the bottom center of the file
 /// area while files are selected. Slides away when the selection is empty,
@@ -46,15 +47,15 @@ class BrowserSelectionBar extends StatelessWidget {
                     style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(width: 12),
-                  TextButton(
+                  AppButton(
+                    label: l10n.selectAll,
+                    variant: AppButtonVariant.text,
                     onPressed: () => state.selectAll(),
-                    style: TextButton.styleFrom(visualDensity: VisualDensity.compact),
-                    child: Text(l10n.selectAll, style: const TextStyle(fontSize: 12.5)),
                   ),
-                  TextButton(
+                  AppButton(
+                    label: l10n.clear,
+                    variant: AppButtonVariant.text,
                     onPressed: () => state.clearSelection(),
-                    style: TextButton.styleFrom(visualDensity: VisualDensity.compact),
-                    child: Text(l10n.clear, style: const TextStyle(fontSize: 12.5)),
                   ),
                   const SizedBox(width: 6),
                   SizedBox(

--- a/lib/screens/browser/widgets/browser_selection_bar.dart
+++ b/lib/screens/browser/widgets/browser_selection_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../core/app_theme.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../state/file_browser_state.dart';
 import '../../../widgets/app_button.dart';
@@ -44,7 +45,7 @@ class BrowserSelectionBar extends StatelessWidget {
                 children: [
                   Text(
                     l10n.imagesSelected(state.selectedFiles.length),
-                    style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
                   ),
                   const SizedBox(width: 12),
                   AppButton(
@@ -66,7 +67,7 @@ class BrowserSelectionBar extends StatelessWidget {
                   FilledButton.icon(
                     onPressed: onAiRename,
                     icon: const Icon(Icons.auto_fix_high, size: 17),
-                    label: Text(l10n.aiBatchRename, style: const TextStyle(fontSize: 12.5)),
+                    label: Text(l10n.aiBatchRename, style: Theme.of(context).textTheme.bodySmall?.metricsOnly),
                     style: FilledButton.styleFrom(
                       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
                       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),

--- a/lib/screens/browser/widgets/file_card.dart
+++ b/lib/screens/browser/widgets/file_card.dart
@@ -104,9 +104,8 @@ class _FileCardState extends State<FileCard> {
                     color: Colors.black.withValues(alpha: 0.55),
                     child: Text(
                       widget.file.name,
-                      style: const TextStyle(
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
                         color: Colors.white,
-                        fontSize: 10.5,
                         fontFamily: 'monospace',
                       ),
                       maxLines: 1,
@@ -133,9 +132,8 @@ class _FileCardState extends State<FileCard> {
                       ),
                       child: Text(
                         _dimensions,
-                        style: const TextStyle(
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
                           color: Colors.white,
-                          fontSize: 9.5,
                           fontWeight: FontWeight.w500,
                           fontFamily: 'monospace',
                         ),

--- a/lib/screens/downloader/image_downloader_screen.dart
+++ b/lib/screens/downloader/image_downloader_screen.dart
@@ -290,7 +290,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
                       Expanded(
                         child: Text(
                           l10n.iosOutputRecommend,
-                          style: TextStyle(fontSize: 11, color: colorScheme.onPrimaryContainer),
+                          style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.onPrimaryContainer),
                         ),
                       ),
                     ],
@@ -375,7 +375,7 @@ class _DownloaderLogPanel extends StatelessWidget {
                 const SizedBox(width: 9),
                 Text(
                   l10n.logs,
-                  style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w700),
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
                 ),
                 const SizedBox(width: 8),
                 Container(
@@ -386,8 +386,7 @@ class _DownloaderLogPanel extends StatelessWidget {
                   ),
                   child: Text(
                     '${logs.length}',
-                    style: TextStyle(
-                      fontSize: 10.5,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
                       fontWeight: FontWeight.w700,
                       fontFamily: 'monospace',
                       color: colorScheme.onSurfaceVariant,
@@ -447,8 +446,7 @@ class _DownloaderLogPanel extends StatelessWidget {
                       if (time != null) ...[
                         Text(
                           time,
-                          style: TextStyle(
-                            fontSize: 10,
+                          style: Theme.of(context).textTheme.labelSmall?.copyWith(
                             fontFamily: 'monospace',
                             color: colorScheme.outline,
                           ),
@@ -458,8 +456,7 @@ class _DownloaderLogPanel extends StatelessWidget {
                       Expanded(
                         child: Text(
                           message,
-                          style: TextStyle(
-                            fontSize: 11,
+                          style: Theme.of(context).textTheme.labelMedium?.copyWith(
                             fontFamily: 'monospace',
                             fontWeight: isNewest ? FontWeight.w600 : FontWeight.normal,
                             color: isError

--- a/lib/screens/downloader/widgets/downloader_results_area.dart
+++ b/lib/screens/downloader/widgets/downloader_results_area.dart
@@ -30,15 +30,14 @@ class DownloaderResultsArea extends StatelessWidget {
               children: [
                 Text(
                   l10n.selectImagesToDownload,
-                  style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                 ),
                 const SizedBox(width: 10),
                 Text(
                   '(${l10n.imagesSelected(selectedCount)})',
-                  style: TextStyle(
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
                     color: colorScheme.primary,
                     fontWeight: FontWeight.w600,
-                    fontSize: 13,
                   ),
                 ),
                 const Spacer(),
@@ -154,13 +153,13 @@ class _GuideStep extends StatelessWidget {
           Text(
             title,
             textAlign: TextAlign.center,
-            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 3),
           Text(
             description,
             textAlign: TextAlign.center,
-            style: TextStyle(fontSize: 11.5, color: colorScheme.outline),
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
           ),
         ],
       ),
@@ -240,8 +239,7 @@ class _ImageDiscoveryCard extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
                   child: Text(
                     image.url,
-                    style: const TextStyle(
-                      fontSize: 10.5,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
                       color: Colors.white,
                       fontFamily: 'monospace',
                     ),

--- a/lib/screens/downloader/widgets/downloader_results_area.dart
+++ b/lib/screens/downloader/widgets/downloader_results_area.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import '../../../core/file_utils.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../state/app_state.dart';
+import '../../../widgets/app_button.dart';
 
 class DownloaderResultsArea extends StatelessWidget {
   final VoidCallback onAddToQueue;
@@ -41,7 +42,9 @@ class DownloaderResultsArea extends StatelessWidget {
                   ),
                 ),
                 const Spacer(),
-                TextButton(
+                AppButton(
+                  label: l10n.selectAll,
+                  variant: AppButtonVariant.text,
                   onPressed: selectedCount == state.discoveredImages.length
                       ? null
                       : () {
@@ -50,13 +53,12 @@ class DownloaderResultsArea extends StatelessWidget {
                           }
                           state.notify();
                         },
-                  child: Text(l10n.selectAll),
                 ),
                 const SizedBox(width: 8),
-                FilledButton.icon(
+                AppButton(
+                  label: l10n.addToQueue,
+                  icon: Icons.download_for_offline,
                   onPressed: selectedCount > 0 ? onAddToQueue : null,
-                  icon: const Icon(Icons.download_for_offline, size: 18),
-                  label: Text(l10n.addToQueue),
                 ),
               ],
             ),

--- a/lib/screens/downloader/widgets/downloader_toolbar.dart
+++ b/lib/screens/downloader/widgets/downloader_toolbar.dart
@@ -50,8 +50,8 @@ class DownloaderToolbar extends StatelessWidget {
         controller: urlController,
         // Monospace: this is an address, not prose. Fixed widths make a typo in
         // a long path something you can see rather than something you re-read.
-        style: const TextStyle(fontSize: 13, fontFamily: 'monospace'),
-        decoration: _fieldDecoration(colorScheme, l10n.websiteUrl, Icons.link),
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontFamily: 'monospace'),
+        decoration: _fieldDecoration(context, colorScheme, l10n.websiteUrl, Icons.link),
       ),
     );
 
@@ -59,8 +59,8 @@ class DownloaderToolbar extends StatelessWidget {
       height: _controlHeight,
       child: TextField(
         controller: requirementController,
-        style: const TextStyle(fontSize: 13),
-        decoration: _fieldDecoration(colorScheme, l10n.whatToFind, Icons.search),
+        style: Theme.of(context).textTheme.bodyMedium,
+        decoration: _fieldDecoration(context, colorScheme, l10n.whatToFind, Icons.search),
         onSubmitted: (_) => isAnalyzing ? null : onAnalyze(),
       ),
     );
@@ -98,7 +98,7 @@ class DownloaderToolbar extends StatelessWidget {
         const SizedBox(width: 10),
         Text(
           l10n.imageDownloader,
-          style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 17),
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
         ),
       ],
     );
@@ -150,10 +150,11 @@ class DownloaderToolbar extends StatelessWidget {
 }
 
 /// The filled, unbordered field the app uses for search and address inputs.
-InputDecoration _fieldDecoration(ColorScheme colorScheme, String hint, IconData icon) {
+InputDecoration _fieldDecoration(
+    BuildContext context, ColorScheme colorScheme, String hint, IconData icon) {
   return InputDecoration(
     hintText: hint,
-    hintStyle: TextStyle(fontSize: 13, color: colorScheme.outline),
+    hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.outline),
     prefixIcon: Icon(icon, size: 18, color: colorScheme.outline),
     isDense: true,
     contentPadding: EdgeInsets.zero,
@@ -216,8 +217,10 @@ class DownloaderOptionsStrip extends StatelessWidget {
             ),
           ),
           Text(l10n.manualHtmlMode,
-              style: TextStyle(
-                  fontSize: 12, color: colorScheme.onSurfaceVariant)),
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: colorScheme.onSurfaceVariant)),
           if (state.isManualHtml) ...[
             const SizedBox(width: 4),
             AppButton(
@@ -237,8 +240,7 @@ class DownloaderOptionsStrip extends StatelessWidget {
                 ),
                 child: Text(
                   '${(state.manualHtml.length / 1024).toStringAsFixed(1)} KB',
-                  style: TextStyle(
-                      fontSize: 10,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
                       fontFamily: 'monospace',
                       color: colorScheme.onSurfaceVariant),
                 ),
@@ -282,8 +284,7 @@ class DownloaderOptionsStrip extends StatelessWidget {
                 l10n.downloaderFoundSelected(discoveredCount, selectedCount),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: 12.5,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   fontWeight: FontWeight.w600,
                   color: colorScheme.onSurface,
                 ),

--- a/lib/screens/downloader/widgets/downloader_toolbar.dart
+++ b/lib/screens/downloader/widgets/downloader_toolbar.dart
@@ -76,20 +76,11 @@ class DownloaderToolbar extends StatelessWidget {
 
     final findButton = SizedBox(
       height: _controlHeight,
-      child: FilledButton.icon(
-        onPressed: isAnalyzing ? null : onAnalyze,
-        icon: isAnalyzing
-            ? const SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              )
-            : const Icon(Icons.image_search, size: 18),
-        label: Text(isAnalyzing ? l10n.analyzing : l10n.findImages),
-        style: FilledButton.styleFrom(
-          minimumSize: const Size(0, _controlHeight),
-          padding: const EdgeInsets.symmetric(horizontal: 18),
-        ),
+      child: AppButton(
+        label: isAnalyzing ? l10n.analyzing : l10n.findImages,
+        icon: Icons.image_search,
+        loading: isAnalyzing,
+        onPressed: onAnalyze,
       ),
     );
 
@@ -229,13 +220,12 @@ class DownloaderOptionsStrip extends StatelessWidget {
                   fontSize: 12, color: colorScheme.onSurfaceVariant)),
           if (state.isManualHtml) ...[
             const SizedBox(width: 4),
-            TextButton.icon(
+            AppButton(
+              label: l10n.pasteFromClipboard,
+              icon: Icons.paste,
+              variant: AppButtonVariant.text,
+              size: AppButtonSize.compact,
               onPressed: onPasteHtml,
-              icon: const Icon(Icons.paste, size: 14),
-              label: Text(l10n.pasteFromClipboard,
-                  style: const TextStyle(fontSize: 12)),
-              style: TextButton.styleFrom(
-                  visualDensity: VisualDensity.compact),
             ),
             if (state.manualHtml.isNotEmpty) ...[
               Container(
@@ -265,15 +255,12 @@ class DownloaderOptionsStrip extends StatelessWidget {
           const SizedBox(width: 8),
           Container(width: 1, height: 18, color: colorScheme.outlineVariant),
           const SizedBox(width: 4),
-          TextButton.icon(
+          AppButton(
+            label: l10n.saveOriginHtml,
+            icon: Icons.html,
+            variant: AppButtonVariant.text,
+            size: AppButtonSize.compact,
             onPressed: isAnalyzing ? null : onSaveHtml,
-            icon: const Icon(Icons.html, size: 16),
-            label:
-                Text(l10n.saveOriginHtml, style: const TextStyle(fontSize: 12)),
-            style: TextButton.styleFrom(
-              visualDensity: VisualDensity.compact,
-              foregroundColor: colorScheme.onSurfaceVariant,
-            ),
           ),
           const SizedBox(width: 4),
           // Always drawn, disabled until there is something to read. Appearing
@@ -348,24 +335,24 @@ Future<void> showDownloaderAdvancedDialog(
         const SizedBox(height: 8),
         Row(
           children: [
-            TextButton.icon(
+            AppButton(
+              label: l10n.importCookieFile,
+              icon: Icons.upload_file,
+              variant: AppButtonVariant.text,
               onPressed: () {
                 Navigator.pop(context);
                 onImportCookie();
               },
-              icon: const Icon(Icons.upload_file, size: 16),
-              label: Text(l10n.importCookieFile,
-                  style: const TextStyle(fontSize: 12)),
             ),
             if (state.cookieHistory.isNotEmpty)
-              TextButton.icon(
+              AppButton(
+                label: l10n.cookieHistory,
+                icon: Icons.history,
+                variant: AppButtonVariant.text,
                 onPressed: () {
                   Navigator.pop(context);
                   _showCookieHistory(context, state, cookieController);
                 },
-                icon: const Icon(Icons.history, size: 16),
-                label: Text(l10n.cookieHistory,
-                    style: const TextStyle(fontSize: 12)),
               ),
           ],
         ),

--- a/lib/screens/metrics/token_usage_screen.dart
+++ b/lib/screens/metrics/token_usage_screen.dart
@@ -120,8 +120,7 @@ class _TokenUsageScreenState extends State<TokenUsageScreen> {
                       const SizedBox(width: 8),
                       Text(
                         label,
-                        style: TextStyle(
-                          fontSize: 15,
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
                           fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
                           color: color,
                         ),

--- a/lib/screens/metrics/widgets/usage_group_costs.dart
+++ b/lib/screens/metrics/widgets/usage_group_costs.dart
@@ -47,7 +47,7 @@ class UsageGroupCosts extends StatelessWidget {
       children: [
         Text(
           l10n.usageByGroup,
-          style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 14),
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
         ),
         const SizedBox(height: 10),
         LayoutBuilder(
@@ -79,6 +79,7 @@ class UsageGroupCosts extends StatelessWidget {
 
   Widget _buildCard(BuildContext context, PricingGroup group, double cost) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final accent = feeGroupAccent(group.id);
     final share = stats.totalCost > 0 ? (cost / stats.totalCost).clamp(0.0, 1.0) : 0.0;
 
@@ -94,7 +95,7 @@ class UsageGroupCosts extends StatelessWidget {
                 Expanded(
                   child: Text(
                     group.name,
-                    style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 13),
+                    style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -102,8 +103,7 @@ class UsageGroupCosts extends StatelessWidget {
                 const SizedBox(width: 8),
                 Text(
                   '\$${cost.toStringAsFixed(4)}',
-                  style: TextStyle(
-                    fontSize: 14,
+                  style: textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w700,
                     fontFamily: 'monospace',
                     color: colorScheme.onSurface,

--- a/lib/screens/metrics/widgets/usage_list.dart
+++ b/lib/screens/metrics/widgets/usage_list.dart
@@ -62,7 +62,7 @@ class UsageList extends StatelessWidget {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (!compact) _buildColumnHeader(l10n, colorScheme),
+            if (!compact) _buildColumnHeader(context, l10n, colorScheme),
             for (var i = 0; i < days.length; i++) ...[
               _buildDayHeader(
                 context,
@@ -92,12 +92,13 @@ class UsageList extends StatelessWidget {
 
   // --- Header -------------------------------------------------------------
 
-  Widget _buildColumnHeader(AppLocalizations l10n, ColorScheme colorScheme) {
-    final style = TextStyle(
-      fontSize: 11,
-      fontWeight: FontWeight.w600,
-      color: colorScheme.onSurfaceVariant,
-    );
+  Widget _buildColumnHeader(BuildContext context, AppLocalizations l10n, ColorScheme colorScheme) {
+    // Same slot as the rows beneath it — left at a bare 11 the header would
+    // have ended up the smaller of the two, which is backwards.
+    final style = Theme.of(context).textTheme.labelMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+          color: colorScheme.onSurfaceVariant,
+        );
 
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
@@ -136,6 +137,7 @@ class UsageList extends StatelessWidget {
     required List<Map<String, dynamic>> rows,
     required bool partial,
   }) {
+    final textTheme = Theme.of(context).textTheme;
     final total = rows.fold<double>(0, (sum, row) => sum + calculateRowCost(row));
     final name = _dayName(l10n, day);
     final date = DateFormat('MM-dd').format(day);
@@ -155,7 +157,7 @@ class UsageList extends StatelessWidget {
                   Flexible(
                     child: Text(
                       name,
-                      style: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w700),
+                      style: textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w700),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -164,8 +166,9 @@ class UsageList extends StatelessWidget {
                 ],
                 Text(
                   date,
-                  style: TextStyle(
-                    fontSize: name == null ? 12.5 : 11,
+                  // Two sizes, so two slots: standing in for the day's name the
+                  // date takes the larger one, beside it the smaller.
+                  style: (name == null ? textTheme.bodySmall : textTheme.labelMedium)?.copyWith(
                     fontWeight: name == null ? FontWeight.w700 : FontWeight.w400,
                     fontFamily: 'monospace',
                     color: name == null ? colorScheme.onSurface : colorScheme.onSurfaceVariant,
@@ -176,7 +179,7 @@ class UsageList extends StatelessWidget {
                   Flexible(
                     child: Text(
                       '· ${l10n.usageRecordCount(rows.length)}',
-                      style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+                      style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -189,8 +192,7 @@ class UsageList extends StatelessWidget {
           if (!partial)
             Text(
               '\$${total.toStringAsFixed(4)}',
-              style: const TextStyle(
-                fontSize: 12,
+              style: textTheme.bodySmall?.copyWith(
                 fontWeight: FontWeight.w700,
                 fontFamily: 'monospace',
                 color: usageCostAccent,
@@ -340,8 +342,7 @@ class _UsageRowState extends State<_UsageRow> {
           child: Text(
             DateFormat('HH:mm').format(time),
             textAlign: TextAlign.end,
-            style: TextStyle(
-              fontSize: 11.5,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
               fontFamily: 'monospace',
               color: colorScheme.onSurfaceVariant,
             ),
@@ -368,8 +369,7 @@ class _UsageRowState extends State<_UsageRow> {
                 children: [
                   Text(
                     DateFormat('HH:mm').format(time),
-                    style: TextStyle(
-                      fontSize: 11,
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
                       fontFamily: 'monospace',
                       color: colorScheme.onSurfaceVariant,
                     ),
@@ -395,6 +395,7 @@ class _UsageRowState extends State<_UsageRow> {
   /// it pushed every real model name to a different x and made the column
   /// unscannable; as a badge it stays readable and the names line up.
   Widget _buildModel(ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
     final modelId = widget.row['model_id'] as String;
     final match = RegExp(r'^\[([^\]]+)\]\s*').firstMatch(modelId);
     final name = match == null ? modelId : modelId.substring(match.end);
@@ -415,8 +416,7 @@ class _UsageRowState extends State<_UsageRow> {
               ),
               child: Text(
                 match.group(1)!,
-                style: TextStyle(
-                  fontSize: 10,
+                style: textTheme.labelSmall?.copyWith(
                   fontWeight: FontWeight.w700,
                   color: colorScheme.primary,
                 ),
@@ -429,8 +429,7 @@ class _UsageRowState extends State<_UsageRow> {
           Flexible(
             child: Text(
               name,
-              style: const TextStyle(
-                fontSize: 12.5,
+              style: textTheme.bodySmall?.copyWith(
                 fontWeight: FontWeight.w500,
                 fontFamily: 'monospace',
               ),
@@ -452,7 +451,7 @@ class _UsageRowState extends State<_UsageRow> {
     if (billingMode != 'token') {
       return Text(
         l10n.usageItemCount(row['request_count'] as int? ?? 1),
-        style: TextStyle(fontSize: 11.5, color: colorScheme.onSurfaceVariant),
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       );
@@ -498,7 +497,7 @@ class _UsageRowState extends State<_UsageRow> {
         const SizedBox(width: 3),
         Text(
           _abbreviate((tokens as int?) ?? 0),
-          style: const TextStyle(fontSize: 11, fontFamily: 'monospace'),
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(fontFamily: 'monospace'),
         ),
       ],
     );
@@ -510,8 +509,7 @@ class _UsageRowState extends State<_UsageRow> {
     return Text(
       '\$${cost.toStringAsFixed(4)}',
       textAlign: TextAlign.end,
-      style: TextStyle(
-        fontSize: 12.5,
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(
         fontWeight: FontWeight.w700,
         fontFamily: 'monospace',
         color: cost > 0 ? colorScheme.onSurface : colorScheme.outline,

--- a/lib/screens/metrics/widgets/usage_list.dart
+++ b/lib/screens/metrics/widgets/usage_list.dart
@@ -206,9 +206,12 @@ class UsageList extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 16),
       child: Center(
-        child: isLoadingMore
-            ? const SizedBox(width: 22, height: 22, child: CircularProgressIndicator(strokeWidth: 2))
-            : OutlinedButton(onPressed: onLoadMore, child: Text(l10n.loadMore)),
+        child: AppButton(
+          label: l10n.loadMore,
+          variant: AppButtonVariant.secondary,
+          loading: isLoadingMore,
+          onPressed: onLoadMore,
+        ),
       ),
     );
   }

--- a/lib/screens/metrics/widgets/usage_summary.dart
+++ b/lib/screens/metrics/widgets/usage_summary.dart
@@ -98,6 +98,7 @@ class UsageSummary extends StatelessWidget {
   /// would be less legible, not more emphatic, and the token counts beside it
   /// need their own accents to stay distinguishable from each other.
   Widget _buildCostCard(BuildContext context, AppLocalizations l10n, ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
     return _card(
       context,
       DecoratedBox(
@@ -125,8 +126,7 @@ class UsageSummary extends StatelessWidget {
                   Expanded(
                     child: Text(
                       l10n.estimatedCost,
-                      style: TextStyle(
-                        fontSize: 12,
+                      style: textTheme.bodySmall?.copyWith(
                         fontWeight: FontWeight.w600,
                         color: colorScheme.onSurfaceVariant,
                       ),
@@ -141,8 +141,7 @@ class UsageSummary extends StatelessWidget {
                 alignment: Alignment.centerLeft,
                 child: Text(
                   '\$${stats.totalCost.toStringAsFixed(4)}',
-                  style: TextStyle(
-                    fontSize: 32,
+                  style: textTheme.headlineLarge?.copyWith(
                     fontWeight: FontWeight.w700,
                     color: colorScheme.onSurface,
                     fontFamily: 'monospace',
@@ -162,6 +161,7 @@ class UsageSummary extends StatelessWidget {
   /// What the cost is a cost *of*: a count of requests, and the period both
   /// numbers cover.
   Widget _buildCostFooter(BuildContext context, AppLocalizations l10n, ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
     return Row(
       children: [
         Container(
@@ -172,8 +172,7 @@ class UsageSummary extends StatelessWidget {
           ),
           child: Text(
             '${_fmt(stats.totalRequestCount)} ${l10n.requests}',
-            style: const TextStyle(
-              fontSize: 11,
+            style: textTheme.labelMedium?.copyWith(
               fontWeight: FontWeight.w700,
               color: usageRequestAccent,
             ),
@@ -183,7 +182,7 @@ class UsageSummary extends StatelessWidget {
         Flexible(
           child: Text(
             rangeLabel,
-            style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+            style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
             overflow: TextOverflow.ellipsis,
           ),
         ),
@@ -223,6 +222,7 @@ class UsageSummary extends StatelessWidget {
   /// and three icons in a row read as a toolbar, not as figures.
   Widget _tokenStat(BuildContext context, Color accent, String label, int value) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return Expanded(
       child: Column(
@@ -231,8 +231,7 @@ class UsageSummary extends StatelessWidget {
         children: [
           Text(
             label,
-            style: TextStyle(
-              fontSize: 12,
+            style: textTheme.bodySmall?.copyWith(
               fontWeight: FontWeight.w600,
               color: colorScheme.onSurfaceVariant,
             ),
@@ -244,8 +243,7 @@ class UsageSummary extends StatelessWidget {
             alignment: Alignment.centerLeft,
             child: Text(
               _fmt(value),
-              style: TextStyle(
-                fontSize: 26,
+              style: textTheme.headlineMedium?.copyWith(
                 fontWeight: FontWeight.w700,
                 color: accent,
                 fontFamily: 'monospace',
@@ -262,6 +260,7 @@ class UsageSummary extends StatelessWidget {
   /// of the two numbers directly above it, and a bar says "of the whole" in a
   /// way a bare percentage does not.
   Widget _buildHitRateMeter(BuildContext context, AppLocalizations l10n, ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
     final rate = stats.cacheHitRate;
 
     return Tooltip(
@@ -274,8 +273,7 @@ class UsageSummary extends StatelessWidget {
               Expanded(
                 child: Text(
                   l10n.cacheHitRate,
-                  style: TextStyle(
-                    fontSize: 12,
+                  style: textTheme.bodySmall?.copyWith(
                     fontWeight: FontWeight.w600,
                     color: colorScheme.onSurfaceVariant,
                   ),
@@ -287,8 +285,7 @@ class UsageSummary extends StatelessWidget {
                 // An em dash, not "0.0%": with no prompt tokens in range the
                 // cache was never asked, which is not the same as never hit.
                 rate == null ? '—' : '${(rate * 100).toStringAsFixed(1)}%',
-                style: TextStyle(
-                  fontSize: 13,
+                style: textTheme.titleSmall?.copyWith(
                   fontWeight: FontWeight.w700,
                   fontFamily: 'monospace',
                   color: rate == null ? colorScheme.outline : usageCacheAccent,

--- a/lib/screens/metrics/widgets/usage_view_desktop.dart
+++ b/lib/screens/metrics/widgets/usage_view_desktop.dart
@@ -202,8 +202,7 @@ class _UsageViewDesktopState extends State<UsageViewDesktop> {
           padding: const EdgeInsets.only(left: 2),
           child: Text(
             '${fmt.format(_dateRange.start)} ~ ${fmt.format(_dateRange.end)}',
-            style: TextStyle(
-              fontSize: 12,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
               fontWeight: FontWeight.w500,
               color: colorScheme.onSurfaceVariant,
               fontFamily: 'monospace',

--- a/lib/screens/metrics/widgets/usage_view_mobile.dart
+++ b/lib/screens/metrics/widgets/usage_view_mobile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../core/app_theme.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/database_service.dart';
 import '../../../state/app_state.dart';
@@ -212,7 +213,7 @@ class _UsageViewMobileState extends State<UsageViewMobile> {
   /// that says which range every number below them covers.
   Widget _buildPresetChip(String preset, String label) {
     return ChoiceChip(
-      label: Text(label, style: const TextStyle(fontSize: 11)),
+      label: Text(label, style: Theme.of(context).textTheme.labelMedium?.metricsOnly),
       selected: _activePreset == preset,
       onSelected: (_) => _updateRange(preset),
       padding: EdgeInsets.zero,

--- a/lib/screens/models/models_screen.dart
+++ b/lib/screens/models/models_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../core/app_theme.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/llm_channel.dart';
@@ -157,6 +158,7 @@ class _ModelsScreenState extends State<ModelsScreen> {
 
   Widget _buildChannelsPanel(AppLocalizations l10n, AppState appState, List<LLMChannel> channels) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final modelCount = appState.allModels.length;
 
     // Screen header lives inside the top of the card; its bottom border
@@ -178,13 +180,12 @@ class _ModelsScreenState extends State<ModelsScreen> {
               children: [
                 Text(
                   l10n.modelManager,
-                  style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                   overflow: TextOverflow.ellipsis,
                 ),
                 Text(
                   l10n.modelsAndChannelsCount(modelCount, channels.length),
-                  style: TextStyle(
-                    fontSize: 11,
+                  style: textTheme.labelMedium?.copyWith(
                     fontWeight: FontWeight.w500,
                     color: colorScheme.onSurfaceVariant,
                     fontFamily: 'monospace',
@@ -231,15 +232,18 @@ class _ModelsScreenState extends State<ModelsScreen> {
                         leading: _buildChannelIcon(channel),
                         title: Text(
                           channel.displayName,
-                          style: TextStyle(
-                            fontSize: 13,
+                          style: textTheme.bodyMedium?.copyWith(
                             fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                            // ListTile tints a selected title with `primary`; the slot
+                            // carries `onSurface`, so that tint has to be re-stated or
+                            // the selected row loses it.
+                            color: isSelected ? colorScheme.primary : null,
                           ),
                           overflow: TextOverflow.ellipsis,
                         ),
                         subtitle: Text(
                           l10n.countModels(models.length),
-                          style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+                          style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
                         ),
                         onTap: () => setState(() => _selectedChannelId = channel.id),
                       ),
@@ -255,6 +259,7 @@ class _ModelsScreenState extends State<ModelsScreen> {
 
   Widget _buildDetailPanel(AppLocalizations l10n, AppState appState, LLMChannel channel) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final showActionLabels = Responsive.isDesktop(context);
 
     final header = Container(
@@ -274,13 +279,12 @@ class _ModelsScreenState extends State<ModelsScreen> {
               children: [
                 Text(
                   channel.displayName,
-                  style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                   overflow: TextOverflow.ellipsis,
                 ),
                 Text(
                   channel.endpoint,
-                  style: TextStyle(
-                    fontSize: 11,
+                  style: textTheme.labelMedium?.copyWith(
                     fontWeight: FontWeight.w500,
                     color: colorScheme.onSurfaceVariant,
                     fontFamily: 'monospace',
@@ -406,6 +410,7 @@ class _ModelsScreenState extends State<ModelsScreen> {
 
   Widget _buildModelCard(LLMModel model, AppLocalizations l10n, AppState appState) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final pricingGroup = appState.allPricingGroups.cast<dynamic>().firstWhere((g) => g.id == model.feeGroupId, orElse: () => null);
 
     return Card(
@@ -426,11 +431,11 @@ class _ModelsScreenState extends State<ModelsScreen> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(model.modelName, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15)),
+                    Text(model.modelName, style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
                     const SizedBox(height: 4),
                     Row(
                       children: [
-                        Flexible(child: Text(model.modelId, style: TextStyle(fontSize: 12, color: colorScheme.outline), overflow: TextOverflow.ellipsis)),
+                        Flexible(child: Text(model.modelId, style: textTheme.bodySmall?.copyWith(color: colorScheme.outline), overflow: TextOverflow.ellipsis)),
                         if (pricingGroup != null) ...[
                           const SizedBox(width: 8),
                           _buildFeeBadge(pricingGroup.name, colorScheme),
@@ -460,7 +465,13 @@ class _ModelsScreenState extends State<ModelsScreen> {
         color: colorScheme.secondaryContainer.withAlpha(150),
         borderRadius: BorderRadius.circular(4),
       ),
-      child: Text(name, style: TextStyle(fontSize: 10, color: colorScheme.onSecondaryContainer, fontWeight: FontWeight.w500)),
+      child: Text(
+        name,
+        style: Theme.of(context)
+            .textTheme
+            .labelSmall
+            ?.copyWith(color: colorScheme.onSecondaryContainer, fontWeight: FontWeight.w500),
+      ),
     );
   }
 
@@ -495,7 +506,8 @@ class _ModelsScreenState extends State<ModelsScreen> {
           child: ExpansionTile(
             leading: _buildChannelIcon(channel),
             title: Text(channel.displayName, style: const TextStyle(fontWeight: FontWeight.bold)),
-            subtitle: Text(l10n.countModels(models.length), style: const TextStyle(fontSize: 12)),
+            subtitle: Text(l10n.countModels(models.length),
+                style: Theme.of(context).textTheme.bodySmall?.metricsOnly),
             children: [
               if (models.isEmpty)
                 Padding(
@@ -505,7 +517,15 @@ class _ModelsScreenState extends State<ModelsScreen> {
               else
                 ...models.map((m) => ListTile(
                   title: Text(m.modelName),
-                  subtitle: Text(m.modelId, style: const TextStyle(fontSize: 11)),
+                  // ListTile's subtitle slot is `onSurfaceVariant`; the type slot
+                  // carries `onSurface`, so the muted tone is restated here.
+                  subtitle: Text(
+                    m.modelId,
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelMedium
+                        ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                  ),
                   trailing: _buildTagChip(m.tag),
                   onTap: () => _showModelDialog(l10n, appState, model: m),
                 )),
@@ -548,7 +568,15 @@ class _ModelsScreenState extends State<ModelsScreen> {
             child: ListTile(
               leading: _buildChannelIcon(channel, size: 32),
               title: Text(channel.displayName),
-              subtitle: Text(channel.endpoint, style: const TextStyle(fontSize: 12), maxLines: 1, overflow: TextOverflow.ellipsis),
+              subtitle: Text(
+                channel.endpoint,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
               trailing: const Icon(Icons.chevron_right),
               onTap: () => _showChannelDialog(l10n, appState, channel: channel),
             ),
@@ -609,7 +637,10 @@ class _ModelsScreenState extends State<ModelsScreen> {
       ),
       child: Text(
         tag.toUpperCase(),
-        style: TextStyle(fontSize: 9, color: color, fontWeight: FontWeight.bold),
+        style: Theme.of(context)
+            .textTheme
+            .labelSmall
+            ?.copyWith(color: color, fontWeight: FontWeight.bold),
       ),
     );
   }

--- a/lib/screens/models/models_screen.dart
+++ b/lib/screens/models/models_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../core/app_theme.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/llm_channel.dart';
@@ -294,11 +293,11 @@ class _ModelsScreenState extends State<ModelsScreen> {
           const SizedBox(width: 8),
           if (channel.enableDiscovery) ...[
             if (showActionLabels)
-              FilledButton.tonalIcon(
+              AppButton(
+                label: l10n.fetchModels,
+                icon: Icons.auto_awesome_outlined,
+                variant: AppButtonVariant.secondary,
                 onPressed: () => _showDiscoveryDialog(l10n, channel, appState),
-                icon: const Icon(Icons.auto_awesome_outlined, size: 18),
-                label: Text(l10n.fetchModels),
-                style: tonalButtonStyle(Theme.of(context).colorScheme),
               )
             else
               IconButton.filledTonal(
@@ -345,11 +344,12 @@ class _ModelsScreenState extends State<ModelsScreen> {
                               .titleMedium
                               ?.copyWith(fontWeight: FontWeight.bold),
                         ),
-                        TextButton.icon(
+                        AppButton(
+                          label: l10n.addModel,
+                          icon: Icons.add,
+                          variant: AppButtonVariant.text,
                           onPressed: () =>
                               _showModelDialog(l10n, appState, preChannelId: channel.id),
-                          icon: const Icon(Icons.add, size: 18),
-                          label: Text(l10n.addModel),
                         ),
                       ],
                     ),
@@ -515,14 +515,16 @@ class _ModelsScreenState extends State<ModelsScreen> {
                   alignment: MainAxisAlignment.end,
                   children: [
                     if (channel.enableDiscovery)
-                      TextButton.icon(
-                        icon: const Icon(Icons.refresh, size: 18),
-                        label: Text(l10n.fetchModels),
+                      AppButton(
+                        label: l10n.fetchModels,
+                        icon: Icons.refresh,
+                        variant: AppButtonVariant.text,
                         onPressed: () => _showDiscoveryDialog(l10n, channel, appState),
                       ),
-                    TextButton.icon(
-                      icon: const Icon(Icons.add, size: 18),
-                      label: Text(l10n.addModel),
+                    AppButton(
+                      label: l10n.addModel,
+                      icon: Icons.add,
+                      variant: AppButtonVariant.text,
                       onPressed: () => _showModelDialog(l10n, appState, preChannelId: channel.id),
                     ),
                   ],

--- a/lib/screens/prompts/prompts_screen.dart
+++ b/lib/screens/prompts/prompts_screen.dart
@@ -391,7 +391,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
           Expanded(
             child: Text(
               l10n.promptLibrary,
-              style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 14.5),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -458,7 +458,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
           const SizedBox(width: 10),
           Text(
             l10n.categoriesTab,
-            style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
           ),
           const Spacer(),
           AppButton(
@@ -684,8 +684,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
           if (index == 0) {
             final allSelected = _selectedFilterTagIds.isEmpty;
             return FilterChip(
-              label: Text(l10n.filterAll, style: TextStyle(
-                fontSize: 12,
+              label: Text(l10n.filterAll, style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: allSelected ? colorScheme.onPrimary : colorScheme.onSurfaceVariant,
                 fontWeight: allSelected ? FontWeight.bold : FontWeight.normal,
               )),
@@ -707,8 +706,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
           final color = Color(tag.color);
 
           return FilterChip(
-            label: Text(tag.name, style: TextStyle(
-              fontSize: 12,
+            label: Text(tag.name, style: Theme.of(context).textTheme.bodySmall?.copyWith(
               color: isSelected ? Colors.white : color,
               fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
             )),

--- a/lib/screens/prompts/prompts_screen.dart
+++ b/lib/screens/prompts/prompts_screen.dart
@@ -7,6 +7,7 @@ import '../../models/prompt.dart';
 import '../../models/tag.dart';
 import '../../services/database_service.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_button.dart';
 import '../../widgets/app_icon_button.dart';
 import '../../widgets/app_segmented_control.dart';
 import '../../widgets/panel_resizer.dart';
@@ -172,15 +173,17 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
                 onPressed: _handleBulkDelete,
               ),
             ] else ...[
-              TextButton.icon(
-                icon: const Icon(Icons.category_outlined),
-                label: Text(l10n.categorize),
+              AppButton(
+                label: l10n.categorize,
+                icon: Icons.category_outlined,
+                variant: AppButtonVariant.text,
                 onPressed: _handleBulkCategorize,
               ),
               const SizedBox(width: 8),
-              TextButton.icon(
-                icon: Icon(Icons.delete_outline, color: colorScheme.error),
-                label: Text(l10n.delete, style: TextStyle(color: colorScheme.error)),
+              AppButton(
+                label: l10n.delete,
+                icon: Icons.delete_outline,
+                variant: AppButtonVariant.destructiveText,
                 onPressed: _handleBulkDelete,
               ),
               const SizedBox(width: 8),
@@ -430,15 +433,17 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
             style: TextStyle(color: colorScheme.primary, fontWeight: FontWeight.w600),
           ),
           const Spacer(),
-          TextButton.icon(
-            icon: const Icon(Icons.category_outlined, size: 16),
-            label: Text(l10n.categorize),
+          AppButton(
+            label: l10n.categorize,
+            icon: Icons.category_outlined,
+            variant: AppButtonVariant.text,
             onPressed: _handleBulkCategorize,
           ),
           const SizedBox(width: 4),
-          TextButton.icon(
-            icon: Icon(Icons.delete_outline, size: 16, color: colorScheme.error),
-            label: Text(l10n.delete, style: TextStyle(color: colorScheme.error)),
+          AppButton(
+            label: l10n.delete,
+            icon: Icons.delete_outline,
+            variant: AppButtonVariant.destructiveText,
             onPressed: _handleBulkDelete,
           ),
         ],
@@ -456,10 +461,10 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
             style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
           ),
           const Spacer(),
-          FilledButton.icon(
+          AppButton(
+            label: l10n.addCategory,
+            icon: Icons.add,
             onPressed: _handleAddAction,
-            icon: const Icon(Icons.add, size: 18),
-            label: Text(l10n.addCategory),
           ),
         ],
       );
@@ -474,10 +479,10 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
         const SizedBox(width: 10),
         _buildImportExportActions(l10n),
         const SizedBox(width: 10),
-        FilledButton.icon(
+        AppButton(
+          label: _addLabel(l10n),
+          icon: Icons.add,
           onPressed: _handleAddAction,
-          icon: const Icon(Icons.add, size: 18),
-          label: Text(_addLabel(l10n)),
         ),
       ],
     );

--- a/lib/screens/prompts/widgets/prompt_dialogs.dart
+++ b/lib/screens/prompts/widgets/prompt_dialogs.dart
@@ -67,7 +67,7 @@ Future<bool> showPromptEditDialog(
                 ),
               ),
               const SizedBox(height: 16),
-              Text(l10n.tagCategory, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+              Text(l10n.tagCategory, style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
               const SizedBox(height: 8),
               _TagChips(tags: tags, selectedTagIds: selectedTagIds, setDialogState: setDialogState),
               const SizedBox(height: 16),
@@ -170,7 +170,7 @@ Future<bool> showSystemPromptEditDialog(
                 ],
               ),
               const SizedBox(height: 16),
-              Text(l10n.tagCategory, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+              Text(l10n.tagCategory, style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
               const SizedBox(height: 8),
               _TagChips(tags: tags, selectedTagIds: selectedTagIds, setDialogState: setDialogState),
               const SizedBox(height: 16),
@@ -455,7 +455,7 @@ class _TagChips extends StatelessWidget {
         final isSelected = selectedTagIds.contains(id);
         final color = Color(t.color);
         return FilterChip(
-          label: Text(t.name, style: TextStyle(fontSize: 12, color: isSelected ? Colors.white : color)),
+          label: Text(t.name, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: isSelected ? Colors.white : color)),
           selected: isSelected,
           onSelected: (val) {
             setDialogState(() {

--- a/lib/screens/prompts/widgets/prompts_sidebar.dart
+++ b/lib/screens/prompts/widgets/prompts_sidebar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../models/tag.dart';
+import '../../../widgets/app_button.dart';
 import '../../../widgets/app_segmented_control.dart';
 
 class PromptsSidebar extends StatelessWidget {
@@ -119,10 +120,11 @@ class PromptsSidebar extends StatelessWidget {
           if (selectedFilterTagIds.isNotEmpty)
             Padding(
               padding: const EdgeInsets.all(8.0),
-              child: TextButton.icon(
+              child: AppButton(
+                label: l10n.clear,
+                icon: Icons.clear_all,
+                variant: AppButtonVariant.text,
                 onPressed: onClear,
-                icon: const Icon(Icons.clear_all, size: 16),
-                label: Text(l10n.clear, style: const TextStyle(fontSize: 12)),
               ),
             ),
         ],

--- a/lib/screens/prompts/widgets/prompts_sidebar.dart
+++ b/lib/screens/prompts/widgets/prompts_sidebar.dart
@@ -51,10 +51,9 @@ class PromptsSidebar extends StatelessWidget {
             // panel's own title two rows above it.
             child: Text(
               l10n.categoriesTab,
-              style: TextStyle(
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 fontWeight: FontWeight.w700,
                 color: colorScheme.onSurfaceVariant,
-                fontSize: 12.5,
               ),
             ),
           ),
@@ -99,7 +98,7 @@ class PromptsSidebar extends StatelessWidget {
                 children: [
                   Text(
                     '${l10n.matchModeLabel}:',
-                    style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
                   ),
                   const SizedBox(width: 8),
                   Expanded(
@@ -171,8 +170,7 @@ class _SidebarTile extends StatelessWidget {
                 child: Text(
                   label,
                   overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 13,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
                     color: selected ? colorScheme.primary : colorScheme.onSurface,
                   ),
@@ -181,8 +179,7 @@ class _SidebarTile extends StatelessWidget {
               const SizedBox(width: 8),
               Text(
                 '$count',
-                style: TextStyle(
-                  fontSize: 11,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
                   color: selected ? colorScheme.primary : colorScheme.onSurfaceVariant,
                 ),
               ),

--- a/lib/screens/prompts/widgets/system_template_list.dart
+++ b/lib/screens/prompts/widgets/system_template_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/prompt.dart';
 import '../../../services/database_service.dart';
+import '../../../widgets/app_button.dart';
 import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/prompt_card.dart';
 
@@ -66,10 +67,10 @@ class _SystemTemplateListState extends State<SystemTemplateList> {
               style: TextStyle(color: Theme.of(context).colorScheme.outline),
             ),
             const SizedBox(height: 24),
-            ElevatedButton.icon(
+            AppButton(
+              label: l10n.newPrompt,
+              icon: Icons.add,
               onPressed: () => widget.onShowEditDialog(l10n),
-              icon: const Icon(Icons.add),
-              label: Text(l10n.newPrompt),
             ),
           ],
         ),

--- a/lib/screens/prompts/widgets/system_template_list.dart
+++ b/lib/screens/prompts/widgets/system_template_list.dart
@@ -58,7 +58,7 @@ class _SystemTemplateListState extends State<SystemTemplateList> {
             const SizedBox(height: 16),
             Text(
               l10n.noPromptsSaved,
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold) 
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)
             ),
             const SizedBox(height: 8),
             Text(

--- a/lib/screens/prompts/widgets/tag_management_list.dart
+++ b/lib/screens/prompts/widgets/tag_management_list.dart
@@ -85,8 +85,7 @@ class _TagManagementListState extends State<TagManagementList> {
                   ),
                   child: Text(
                     '$count',
-                    style: TextStyle(
-                      fontSize: 12,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       fontWeight: FontWeight.w600,
                       color: color.withAlpha(230),
                     ),

--- a/lib/screens/prompts/widgets/user_prompt_list.dart
+++ b/lib/screens/prompts/widgets/user_prompt_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/prompt.dart';
 import '../../../services/database_service.dart';
+import '../../../widgets/app_button.dart';
 import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/prompt_card.dart';
 
@@ -65,10 +66,10 @@ class _UserPromptListState extends State<UserPromptList> {
               style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
             const SizedBox(height: 24),
-            ElevatedButton.icon(
+            AppButton(
+              label: l10n.newPrompt,
+              icon: Icons.add,
               onPressed: () => widget.onShowEditDialog(l10n),
-              icon: const Icon(Icons.add),
-              label: Text(l10n.newPrompt),
             ),
           ],
         ),

--- a/lib/screens/prompts/widgets/user_prompt_list.dart
+++ b/lib/screens/prompts/widgets/user_prompt_list.dart
@@ -57,7 +57,7 @@ class _UserPromptListState extends State<UserPromptList> {
             const SizedBox(height: 16),
             Text(
               l10n.noPromptsSaved,
-              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)
             ),
             const SizedBox(height: 8),
             Text(

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -213,7 +213,7 @@ class _SettingsTwoPaneViewState extends State<_SettingsTwoPaneView> {
               const SizedBox(width: 10),
               Text(
                 widget.l10n.settings,
-                style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
               ),
             ],
           ),
@@ -252,8 +252,7 @@ class _SettingsTwoPaneViewState extends State<_SettingsTwoPaneView> {
         ),
         title: Text(
           _categoryLabel(category, widget.l10n),
-          style: TextStyle(
-            fontSize: 13,
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
             fontWeight: isSelected ? FontWeight.bold : FontWeight.w500,
             color: isSelected ? colorScheme.primary : null,
           ),
@@ -294,7 +293,7 @@ class _SettingsTwoPaneViewState extends State<_SettingsTwoPaneView> {
               const SizedBox(width: 10),
               Text(
                 _categoryLabel(_selected, widget.l10n),
-                style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
               ),
             ],
           ),

--- a/lib/screens/settings/widgets/about_section.dart
+++ b/lib/screens/settings/widgets/about_section.dart
@@ -33,6 +33,7 @@ class _AboutSectionState extends State<AboutSection> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return AppSection(
       title: l10n.about,
@@ -46,12 +47,12 @@ class _AboutSectionState extends State<AboutSection> {
             const SizedBox(height: 12),
             Text(
               l10n.appTitle,
-              style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 18),
+              style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: 4),
             Text(
               _version.isEmpty ? '' : l10n.aboutVersion(_version),
-              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 13),
+              style: textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant),
             ),
           ],
         ),
@@ -76,7 +77,7 @@ class _AboutSectionState extends State<AboutSection> {
           child: Text(
             l10n.aboutCopyright(DateTime.now().year, _copyrightHolder),
             textAlign: TextAlign.center,
-            style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
           ),
         ),
       ],

--- a/lib/screens/settings/widgets/application_section.dart
+++ b/lib/screens/settings/widgets/application_section.dart
@@ -84,10 +84,11 @@ class _ApplicationSectionState extends State<ApplicationSection> {
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Align(
                   alignment: Alignment.centerLeft,
-                  child: TextButton.icon(
+                  child: AppButton(
+                    label: l10n.openLogFolder,
+                    icon: Icons.folder_zip_outlined,
+                    variant: AppButtonVariant.text,
                     onPressed: () => LLMDebugLogger.openLogFolder(),
-                    icon: const Icon(Icons.folder_zip_outlined, size: 18),
-                    label: Text(l10n.openLogFolder),
                   ),
                 ),
               ),

--- a/lib/screens/settings/widgets/data_section.dart
+++ b/lib/screens/settings/widgets/data_section.dart
@@ -154,11 +154,11 @@ class DataSection extends StatelessWidget {
             children: [
               Text(l10n.exportOptions, style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold)),
               const SizedBox(height: 24),
-              _buildExportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, (v) => setState(() => d = v)),
+              _buildExportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, (v) => setState(() => d = v)),
               const Divider(height: 32),
-              _buildExportOption(l10n.includePrompts, l10n.includePromptsDesc, p, (v) => setState(() => p = v)),
+              _buildExportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, (v) => setState(() => p = v)),
               const Divider(height: 32),
-              _buildExportOption(l10n.includeUsage, l10n.includeUsageDesc, u, (v) => setState(() => u = v)),
+              _buildExportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, (v) => setState(() => u = v)),
               const SizedBox(height: 48),
               AppButton(
                 label: l10n.exportNow,
@@ -197,11 +197,11 @@ class DataSection extends StatelessWidget {
         builder: (context, setState) => Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            _buildExportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, (v) => setState(() => d = v)),
+            _buildExportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, (v) => setState(() => d = v)),
             const SizedBox(height: 12),
-            _buildExportOption(l10n.includePrompts, l10n.includePromptsDesc, p, (v) => setState(() => p = v)),
+            _buildExportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, (v) => setState(() => p = v)),
             const SizedBox(height: 12),
-            _buildExportOption(l10n.includeUsage, l10n.includeUsageDesc, u, (v) => setState(() => u = v)),
+            _buildExportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, (v) => setState(() => u = v)),
           ],
         ),
       ),
@@ -222,12 +222,14 @@ class DataSection extends StatelessWidget {
     );
   }
 
-  Widget _buildExportOption(String title, String desc, bool value, Function(bool) onChanged) {
+  Widget _buildExportOption(
+      BuildContext context, String title, String desc, bool value, Function(bool) onChanged) {
+    final textTheme = Theme.of(context).textTheme;
     return SwitchListTile(
       value: value,
       onChanged: onChanged,
-      title: Text(title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
-      subtitle: Text(desc, style: const TextStyle(fontSize: 12)),
+      title: Text(title, style: textTheme.titleMedium),
+      subtitle: Text(desc, style: textTheme.bodySmall),
       contentPadding: EdgeInsets.zero,
     );
   }
@@ -314,13 +316,13 @@ class DataSection extends StatelessWidget {
             children: [
               Text(l10n.importOptions, style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold)),
               const SizedBox(height: 8),
-              Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+              Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
               const SizedBox(height: 24),
-              _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
+              _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
               const Divider(height: 32),
-              _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
+              _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
               const Divider(height: 32),
-              _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
+              _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
               const SizedBox(height: 48),
               AppButton(
                 label: l10n.importNow,
@@ -365,13 +367,13 @@ class DataSection extends StatelessWidget {
         builder: (context, setState) => Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+            Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
             const SizedBox(height: 20),
-            _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
+            _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
             const SizedBox(height: 12),
-            _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
+            _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
             const SizedBox(height: 12),
-            _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
+            _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
           ],
         ),
       ),
@@ -393,18 +395,16 @@ class DataSection extends StatelessWidget {
     );
   }
 
-  Widget _buildImportOption(String title, String desc, bool value, bool enabled, AppLocalizations l10n, Function(bool) onChanged) {
+  Widget _buildImportOption(BuildContext context, String title, String desc, bool value, bool enabled,
+      AppLocalizations l10n, Function(bool) onChanged) {
+    final textTheme = Theme.of(context).textTheme;
     return SwitchListTile(
       value: value && enabled,
       onChanged: enabled ? onChanged : null,
-      title: Text(title, style: TextStyle(
-        fontWeight: FontWeight.bold, 
-        fontSize: 14,
-        color: enabled ? null : Colors.grey,
-      )),
+      title: Text(title, style: textTheme.titleMedium?.copyWith(color: enabled ? null : Colors.grey)),
       subtitle: Text(
-        enabled ? desc : l10n.notInBackup, 
-        style: TextStyle(fontSize: 12, color: enabled ? null : Colors.grey[400]),
+        enabled ? desc : l10n.notInBackup,
+        style: textTheme.bodySmall?.copyWith(color: enabled ? null : Colors.grey[400]),
       ),
       contentPadding: EdgeInsets.zero,
     );

--- a/lib/screens/settings/widgets/data_section.dart
+++ b/lib/screens/settings/widgets/data_section.dart
@@ -70,21 +70,16 @@ class DataSection extends StatelessWidget {
   }
 
   Widget _buildActionBtn(BuildContext context, dynamic action, bool fullWidth) {
-    final colorScheme = Theme.of(context).colorScheme;
     final bool isError = action.color != null;
 
     return SizedBox(
       width: fullWidth ? double.infinity : 220,
       height: 50,
-      child: OutlinedButton.icon(
+      child: AppButton(
+        label: action.label,
+        icon: action.icon,
+        variant: isError ? AppButtonVariant.destructiveOutline : AppButtonVariant.secondary,
         onPressed: action.onPressed,
-        icon: Icon(action.icon, size: 18),
-        label: Text(action.label, style: const TextStyle(fontSize: 12)),
-        style: OutlinedButton.styleFrom(
-          foregroundColor: action.color,
-          side: isError ? BorderSide(color: colorScheme.error.withAlpha(100)) : null,
-          backgroundColor: isError ? colorScheme.errorContainer.withAlpha(20) : null,
-        ),
       ),
     );
   }
@@ -165,19 +160,22 @@ class DataSection extends StatelessWidget {
               const Divider(height: 32),
               _buildExportOption(l10n.includeUsage, l10n.includeUsageDesc, u, (v) => setState(() => u = v)),
               const SizedBox(height: 48),
-              FilledButton(
+              AppButton(
+                label: l10n.exportNow,
+                size: AppButtonSize.large,
+                fullWidth: true,
                 onPressed: () {
                   onUpdate(d, p, u);
                   Navigator.pop(context, true);
                 },
-                style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(56), shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16))),
-                child: Text(l10n.exportNow),
               ),
               const SizedBox(height: 12),
-              TextButton(
+              AppButton(
+                label: l10n.cancel,
+                variant: AppButtonVariant.text,
+                size: AppButtonSize.large,
+                fullWidth: true,
                 onPressed: () => Navigator.pop(context, false),
-                style: TextButton.styleFrom(minimumSize: const Size.fromHeight(56)),
-                child: Text(l10n.cancel),
               ),
             ],
           ),
@@ -324,24 +322,23 @@ class DataSection extends StatelessWidget {
               const Divider(height: 32),
               _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
               const SizedBox(height: 48),
-              FilledButton(
+              AppButton(
+                label: l10n.importNow,
+                variant: AppButtonVariant.destructive,
+                size: AppButtonSize.large,
+                fullWidth: true,
                 onPressed: () {
                   onUpdate(d, p, u);
                   Navigator.pop(context, true);
                 },
-                style: FilledButton.styleFrom(
-                  backgroundColor: Colors.red,
-                  foregroundColor: Colors.white,
-                  minimumSize: const Size.fromHeight(56), 
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16))
-                ),
-                child: Text(l10n.importNow),
               ),
               const SizedBox(height: 12),
-              TextButton(
+              AppButton(
+                label: l10n.cancel,
+                variant: AppButtonVariant.text,
+                size: AppButtonSize.large,
+                fullWidth: true,
                 onPressed: () => Navigator.pop(context, false),
-                style: TextButton.styleFrom(minimumSize: const Size.fromHeight(56)),
-                child: Text(l10n.cancel),
               ),
             ],
           ),

--- a/lib/screens/wizard/setup_wizard.dart
+++ b/lib/screens/wizard/setup_wizard.dart
@@ -166,9 +166,10 @@ class _SetupWizardState extends State<SetupWizard> {
         title: Text(l10n.setupWizardTitle),
         automaticallyImplyLeading: false,
         actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(), 
-            child: Text(l10n.skip)
+          AppButton(
+            label: l10n.skip,
+            variant: AppButtonVariant.text,
+            onPressed: () => Navigator.of(context).pop(),
           ),
         ],
       ),
@@ -195,7 +196,9 @@ class _SetupWizardState extends State<SetupWizard> {
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   if (_currentStep > 0 && _currentStep != 4)
-                    TextButton(
+                    AppButton(
+                      label: l10n.back,
+                      variant: AppButtonVariant.text,
                       onPressed: () {
                         int prev = _currentStep - 1;
                         if (_currentStep == 4 && _createdChannelId == null) {
@@ -204,14 +207,13 @@ class _SetupWizardState extends State<SetupWizard> {
                         _pageController.animateToPage(prev, duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
                         setState(() => _currentStep = prev);
                       },
-                      child: Text(l10n.back),
                     ),
                   const SizedBox(width: 16),
-                  FilledButton(
-                    onPressed: _currentStep == 1 && _outputDirController.text.isEmpty 
-                        ? null 
+                  AppButton(
+                    label: _currentStep == _totalSteps - 1 ? l10n.getStarted : (_currentStep == 2 && _apiKeyController.text.isEmpty ? l10n.skip : l10n.next),
+                    onPressed: _currentStep == 1 && _outputDirController.text.isEmpty
+                        ? null
                         : _nextStep,
-                    child: Text(_currentStep == _totalSteps - 1 ? l10n.getStarted : (_currentStep == 2 && _apiKeyController.text.isEmpty ? l10n.skip : l10n.next)),
                   ),
                 ],
               ),
@@ -402,12 +404,12 @@ class _SetupWizardState extends State<SetupWizard> {
                 ),
               ),
               const SizedBox(width: 8),
-              OutlinedButton.icon(
-                onPressed: _isFetchingModels ? null : _fetchModels,
-                icon: _isFetchingModels 
-                  ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
-                  : const Icon(Icons.refresh),
-                label: Text(l10n.fetchModels),
+              AppButton(
+                label: l10n.fetchModels,
+                icon: Icons.refresh,
+                variant: AppButtonVariant.secondary,
+                loading: _isFetchingModels,
+                onPressed: _fetchModels,
               ),
             ],
           ),

--- a/lib/screens/wizard/wizard_import.dart
+++ b/lib/screens/wizard/wizard_import.dart
@@ -94,13 +94,13 @@ Future<bool?> _showMobileImportOptions(
           children: [
             Text(l10n.importOptions, style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
-            Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+            Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
             const SizedBox(height: 24),
-            _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
+            _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
             const Divider(height: 32),
-            _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
+            _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
             const Divider(height: 32),
-            _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
+            _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
             const SizedBox(height: 48),
             SizedBox(
               width: double.infinity,
@@ -147,13 +147,13 @@ Future<bool?> _showDesktopImportOptions(
       builder: (context, setState) => Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(l10n.importSettingsConfirm, style: const TextStyle(fontSize: 13, color: Colors.grey)),
+          Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
           const SizedBox(height: 20),
-          _buildImportOption(l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
+          _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
           const SizedBox(height: 12),
-          _buildImportOption(l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
+          _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
           const SizedBox(height: 12),
-          _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
+          _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
         ],
       ),
     ),
@@ -175,18 +175,16 @@ Future<bool?> _showDesktopImportOptions(
   );
 }
 
-Widget _buildImportOption(String title, String desc, bool value, bool enabled, AppLocalizations l10n, Function(bool) onChanged) {
+Widget _buildImportOption(BuildContext context, String title, String desc, bool value, bool enabled,
+    AppLocalizations l10n, Function(bool) onChanged) {
+  final textTheme = Theme.of(context).textTheme;
   return SwitchListTile(
     value: value && enabled,
     onChanged: enabled ? onChanged : null,
-    title: Text(title, style: TextStyle(
-      fontWeight: FontWeight.bold,
-      fontSize: 14,
-      color: enabled ? null : Colors.grey,
-    )),
+    title: Text(title, style: textTheme.titleMedium?.copyWith(color: enabled ? null : Colors.grey)),
     subtitle: Text(
       enabled ? desc : l10n.notInBackup,
-      style: TextStyle(fontSize: 12, color: enabled ? null : Colors.grey[400]),
+      style: textTheme.bodySmall?.copyWith(color: enabled ? null : Colors.grey[400]),
     ),
     contentPadding: EdgeInsets.zero,
   );

--- a/lib/screens/wizard/wizard_import.dart
+++ b/lib/screens/wizard/wizard_import.dart
@@ -102,24 +102,25 @@ Future<bool?> _showMobileImportOptions(
             const Divider(height: 32),
             _buildImportOption(l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
             const SizedBox(height: 48),
-            FilledButton(
-              onPressed: () {
-                onUpdate(d, p, u);
-                Navigator.pop(context, true);
-              },
-              style: FilledButton.styleFrom(
-                backgroundColor: Colors.red,
-                foregroundColor: Colors.white,
-                minimumSize: const Size.fromHeight(56),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16))
+            SizedBox(
+              width: double.infinity,
+              child: AppButton(
+                label: l10n.importNow,
+                variant: AppButtonVariant.destructive,
+                onPressed: () {
+                  onUpdate(d, p, u);
+                  Navigator.pop(context, true);
+                },
               ),
-              child: Text(l10n.importNow),
             ),
             const SizedBox(height: 12),
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              style: TextButton.styleFrom(minimumSize: const Size.fromHeight(56)),
-              child: Text(l10n.cancel),
+            SizedBox(
+              width: double.infinity,
+              child: AppButton(
+                label: l10n.cancel,
+                variant: AppButtonVariant.text,
+                onPressed: () => Navigator.pop(context, false),
+              ),
             ),
           ],
         ),

--- a/lib/screens/workbench/directory_tree_item.dart
+++ b/lib/screens/workbench/directory_tree_item.dart
@@ -221,8 +221,7 @@ class _DirectoryTreeItemState extends State<DirectoryTreeItem> {
           ),
           title: Text(
             folderName,
-            style: TextStyle(
-              fontSize: 13,
+            style: theme.textTheme.titleSmall?.copyWith(
               fontWeight: highlight ? FontWeight.bold : FontWeight.w500,
               color: highlight ? theme.colorScheme.primary : (isUnreachable ? theme.colorScheme.error : null),
             ),

--- a/lib/screens/workbench/folder_list.dart
+++ b/lib/screens/workbench/folder_list.dart
@@ -74,7 +74,7 @@ class FolderList extends StatelessWidget {
                     const SizedBox(height: 8),
                     Text(
                       Platform.isIOS ? l10n.iosSandboxDesc : l10n.mobileSandboxDesc,
-                      style: TextStyle(fontSize: 12, color: colorScheme.onPrimaryContainer),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onPrimaryContainer),
                       textAlign: TextAlign.center,
                     ),
                   ],
@@ -110,7 +110,7 @@ class FolderList extends StatelessWidget {
                 children: [
                   Text(
                     l10n.directories,
-                    style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                   ),
                   const SizedBox(width: 8),
                   Container(
@@ -121,8 +121,7 @@ class FolderList extends StatelessWidget {
                     ),
                     child: Text(
                       '${sourceDirectories.length}',
-                      style: TextStyle(
-                        fontSize: 11,
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
                         fontWeight: FontWeight.w700,
                         fontFamily: 'monospace',
                         color: colorScheme.onSurfaceVariant,
@@ -151,7 +150,7 @@ class FolderList extends StatelessWidget {
             Divider(height: 1, color: colorScheme.outlineVariant.withAlpha(90)),
             Expanded(
               child: sourceDirectories.isEmpty
-                  ? _buildEmptyState(colorScheme, l10n)
+                  ? _buildEmptyState(context, colorScheme, l10n)
                   : ListView.builder(
                       itemCount: sourceDirectories.length,
                       itemBuilder: (context, index) {
@@ -189,7 +188,7 @@ class FolderList extends StatelessWidget {
       children: [
         // SOURCES — the aggregate "All Sources" view is the head of the group,
         // with the browsable source-folder tree nested beneath it.
-        _buildSectionHeader(colorScheme, l10n.sectionSources, count: sourceDirectories.length),
+        _buildSectionHeader(context, colorScheme, l10n.sectionSources, count: sourceDirectories.length),
         _buildFixedNode(
           context,
           icon: Icons.photo_library_outlined,
@@ -200,7 +199,7 @@ class FolderList extends StatelessWidget {
           count: galleryState.galleryImages.length,
         ),
         if (sourceDirectories.isEmpty)
-          _buildInlineHint(colorScheme, l10n.noFolders)
+          _buildInlineHint(context, colorScheme, l10n.noFolders)
         else
           ...sourceDirectories.map((path) => DirectoryTreeItem(
                 key: ValueKey(path),
@@ -213,7 +212,7 @@ class FolderList extends StatelessWidget {
         const Divider(height: 16),
 
         // RESULTS — the result cache is also a real folder tree, now browsable.
-        _buildSectionHeader(colorScheme, l10n.sectionResults, count: resultRoots.length),
+        _buildSectionHeader(context, colorScheme, l10n.sectionResults, count: resultRoots.length),
         _buildFixedNode(
           context,
           icon: Icons.auto_awesome_motion,
@@ -224,14 +223,14 @@ class FolderList extends StatelessWidget {
           count: galleryState.processedImages.length,
         ),
         if (resultRoots.isEmpty)
-          _buildInlineHint(colorScheme, l10n.noResultsYet)
+          _buildInlineHint(context, colorScheme, l10n.noResultsYet)
         else
           ...resultRoots.map((path) => ResultTreeItem(key: ValueKey(path), path: path, isRoot: true)),
 
         const Divider(height: 16),
 
         // WORKSPACE — transient drop zone.
-        _buildSectionHeader(colorScheme, l10n.sectionWorkspace),
+        _buildSectionHeader(context, colorScheme, l10n.sectionWorkspace),
         _buildFixedNode(
           context,
           icon: Icons.workspaces_outline,
@@ -245,32 +244,33 @@ class FolderList extends StatelessWidget {
     );
   }
 
-  Widget _buildSectionHeader(ColorScheme colorScheme, String label, {int? count}) {
+  Widget _buildSectionHeader(BuildContext context, ColorScheme colorScheme, String label, {int? count}) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 18, 16, 6),
       child: Row(
         children: [
           Text(
             label.toUpperCase(),
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.bold,
-              color: colorScheme.onSurfaceVariant,
-              letterSpacing: 1.2,
-            ),
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurfaceVariant,
+                  letterSpacing: 1.2,
+                ),
           ),
           const Spacer(),
           if (count != null)
-            Text('$count', style: TextStyle(fontSize: 11, color: colorScheme.outline)),
+            Text('$count',
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline)),
         ],
       ),
     );
   }
 
-  Widget _buildInlineHint(ColorScheme colorScheme, String text) {
+  Widget _buildInlineHint(BuildContext context, ColorScheme colorScheme, String text) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 6, 16, 10),
-      child: Text(text, style: TextStyle(fontSize: 12, color: colorScheme.outline)),
+      child: Text(text,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.outline)),
     );
   }
 
@@ -287,8 +287,7 @@ class FolderList extends StatelessWidget {
       leading: Icon(icon, color: isSelected ? colorScheme.primary : colorScheme.onSurfaceVariant, size: 20),
       title: Text(
         label,
-        style: TextStyle(
-          fontSize: 13,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
           fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
           color: isSelected ? colorScheme.primary : colorScheme.onSurface,
         ),
@@ -296,8 +295,7 @@ class FolderList extends StatelessWidget {
       trailing: count != null
           ? Text(
               '$count',
-              style: TextStyle(
-                fontSize: 11,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
                 color: isSelected ? colorScheme.primary : colorScheme.outline,
               ),
             )
@@ -338,7 +336,7 @@ class FolderList extends StatelessWidget {
     );
   }
 
-  Widget _buildEmptyState(ColorScheme colorScheme, AppLocalizations l10n) {
+  Widget _buildEmptyState(BuildContext context, ColorScheme colorScheme, AppLocalizations l10n) {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24.0),
@@ -349,13 +347,13 @@ class FolderList extends StatelessWidget {
             const SizedBox(height: 16),
             Text(
               l10n.noFolders,
-              style: TextStyle(color: colorScheme.onSurface, fontSize: 14),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(color: colorScheme.onSurface),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
               l10n.clickAddFolder,
-              style: TextStyle(color: colorScheme.outline, fontSize: 12),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.outline),
               textAlign: TextAlign.center,
             ),
           ],

--- a/lib/screens/workbench/gallery.dart
+++ b/lib/screens/workbench/gallery.dart
@@ -59,8 +59,7 @@ class _GalleryState extends State<Gallery> {
                     const SizedBox(height: 16),
                     Text(
                       l10n.dropFilesHere,
-                      style: TextStyle(
-                        fontSize: 20,
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
                         fontWeight: FontWeight.bold,
                         color: Theme.of(context).colorScheme.primary
                       ),
@@ -135,7 +134,7 @@ class _GalleryState extends State<Gallery> {
               const SizedBox(height: 16),
               Text(
                 isTemp ? l10n.dropFilesHere : (isResult ? l10n.noResultsYet : l10n.noImagesFound),
-                style: TextStyle(color: Colors.grey[600], fontSize: 16),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Colors.grey[600]),
               ),
             ],
           ),
@@ -175,8 +174,7 @@ class _GalleryState extends State<Gallery> {
                           Expanded(
                             child: Text(
                               path,
-                              style: TextStyle(
-                                fontSize: 12,
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
                                 fontWeight: FontWeight.bold,
                                 color: colorScheme.secondary,
                                 letterSpacing: 0.5,
@@ -185,7 +183,7 @@ class _GalleryState extends State<Gallery> {
                           ),
                           Text(
                             "(${grouped[path]!.length})",
-                            style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
                           ),
                         ],
                       ),

--- a/lib/screens/workbench/model_selection_section.dart
+++ b/lib/screens/workbench/model_selection_section.dart
@@ -59,9 +59,9 @@ class ModelSelectionSection extends StatelessWidget {
         initiallyExpanded: isExpanded,
         onExpansionChanged: (_) => onToggleExpansion(),
         leading: Icon(Icons.tune_outlined, size: 20, color: colorScheme.primary),
-        title: Text(l10n.modelSelection, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+        title: Text(l10n.modelSelection, style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
         subtitle: collapsedModelName != null
-            ? Text(collapsedModelName, style: TextStyle(fontSize: 11, color: colorScheme.outline))
+            ? Text(collapsedModelName, style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline))
             : null,
         children: [
           const SizedBox(height: 8),
@@ -71,8 +71,8 @@ class ModelSelectionSection extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(l10n.channel, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 11)),
-                    _buildChannelDropdown(colorScheme),
+                    Text(l10n.channel, style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold)),
+                    _buildChannelDropdown(context, colorScheme),
                   ],
                 ),
               ),
@@ -81,14 +81,14 @@ class ModelSelectionSection extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(l10n.modelSelection, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 11)),
+                    Text(l10n.modelSelection, style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold)),
                     DropdownButton<int>(
                       isExpanded: true,
                       value: (filteredModels.any((m) => m['id'] == selectedModelDbId))
                           ? selectedModelDbId
                           : null,
                       hint: Text(l10n.selectAModel),
-                      style: TextStyle(fontSize: 12, color: colorScheme.onSurface),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
                       underline: Container(height: 1, color: colorScheme.outlineVariant),
                       items: filteredModels.map((m) => DropdownMenuItem(
                         value: m['id'] as int,
@@ -116,13 +116,13 @@ class ModelSelectionSection extends StatelessWidget {
     );
   }
 
-  Widget _buildChannelDropdown(ColorScheme colorScheme) {
+  Widget _buildChannelDropdown(BuildContext context, ColorScheme colorScheme) {
     return DropdownButton<int>(
       isExpanded: true,
       // Guard: the selected id must exist in the (filtered) channel list,
       // otherwise DropdownButton throws an assertion error.
       value: channels.any((c) => c['id'] == selectedChannelId) ? selectedChannelId : null,
-      style: TextStyle(fontSize: 12, color: colorScheme.onSurface),
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
       underline: Container(height: 1, color: colorScheme.outlineVariant),
       items: channels.map((c) => DropdownMenuItem<int>(
         value: c['id'] as int,
@@ -138,11 +138,10 @@ class ModelSelectionSection extends StatelessWidget {
                 ),
                 child: Text(
                   c['tag'],
-                  style: TextStyle(
-                    fontSize: 9,
-                    color: Color(c['tag_color'] ?? 0xFF607D8B),
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: Color(c['tag_color'] ?? 0xFF607D8B),
+                        fontWeight: FontWeight.bold,
+                      ),
                 ),
               ),
             Expanded(child: Text(c['display_name'], overflow: TextOverflow.ellipsis)),
@@ -181,7 +180,7 @@ class ModelSelectionSection extends StatelessWidget {
         control = DropdownButton<String>(
           isExpanded: true,
           value: current,
-          style: TextStyle(fontSize: 12, color: colorScheme.onSurface),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
           underline: Container(height: 1, color: colorScheme.outlineVariant),
           items: spec.options
               .map((o) => DropdownMenuItem(
@@ -216,7 +215,7 @@ class ModelSelectionSection extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
             minimumSize: const Size(0, 30),
             visualDensity: VisualDensity.compact,
-            textStyle: const TextStyle(fontSize: 12),
+            textStyle: Theme.of(context).textTheme.bodySmall,
             alignment: Alignment.centerLeft,
           ),
           onPressed: () async {
@@ -251,7 +250,7 @@ class ModelSelectionSection extends StatelessWidget {
         SizedBox(
           width: 80,
           child: Text(_paramLabel(l10n, spec.labelKey),
-              style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)),
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold)),
         ),
         Expanded(child: control),
       ],

--- a/lib/screens/workbench/widgets/comparator_view.dart
+++ b/lib/screens/workbench/widgets/comparator_view.dart
@@ -53,12 +53,12 @@ class _ComparatorViewState extends State<ComparatorView> {
             const SizedBox(height: 16),
             Text(
               l10n.sendToComparator,
-              style: TextStyle(fontSize: 16, color: colorScheme.onSurfaceVariant),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: colorScheme.onSurfaceVariant),
             ),
             const SizedBox(height: 8),
             Text(
               l10n.selectFromLibrary,
-              style: TextStyle(fontSize: 14, color: colorScheme.outline),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(color: colorScheme.outline),
             ),
             const SizedBox(height: 20),
             Row(
@@ -98,7 +98,7 @@ class _ComparatorViewState extends State<ComparatorView> {
               Expanded(
                 child: Text(
                   workbenchUIState.comparatorRawPath?.split(Platform.pathSeparator).last ?? '—',
-                  style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 10),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.onSurfaceVariant),
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
@@ -108,7 +108,7 @@ class _ComparatorViewState extends State<ComparatorView> {
               Expanded(
                 child: Text(
                   workbenchUIState.comparatorAfterPath?.split(Platform.pathSeparator).last ?? '—',
-                  style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 10),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.onSurfaceVariant),
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
@@ -259,7 +259,7 @@ class _ComparatorViewState extends State<ComparatorView> {
         children: [
           Icon(icon, size: 24, color: fg),
           const SizedBox(height: 6),
-          Text(label, style: TextStyle(fontSize: 11, fontWeight: FontWeight.bold, color: fg)),
+          Text(label, style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold, color: fg)),
         ],
       ),
     );
@@ -272,7 +272,7 @@ class _ComparatorViewState extends State<ComparatorView> {
         color: color.withAlpha(40),
         borderRadius: BorderRadius.circular(3),
       ),
-      child: Text(label, style: TextStyle(fontSize: 9, fontWeight: FontWeight.bold, color: color)),
+      child: Text(label, style: Theme.of(context).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.bold, color: color)),
     );
   }
 
@@ -285,14 +285,17 @@ class _ComparatorViewState extends State<ComparatorView> {
       ),
       child: Text(
         label,
-        style: const TextStyle(color: Colors.white, fontSize: 10, fontWeight: FontWeight.bold),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(color: Colors.white, fontWeight: FontWeight.bold),
       ),
     );
   }
 
   Widget _buildViewer(String? path, String label, TransformationController controller, {bool showLabel = true, Color? borderColor}) {
     if (path == null) {
-      return const Center(child: Text('No image', textAlign: TextAlign.center, style: TextStyle(color: Colors.white54, fontSize: 12)));
+      return Center(
+          child: Text('No image',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white54)));
     }
     return Stack(
       fit: StackFit.expand,
@@ -314,7 +317,7 @@ class _ComparatorViewState extends State<ComparatorView> {
                 color: borderColor ?? Colors.black54, 
                 borderRadius: BorderRadius.circular(4)
               ),
-              child: Text(label, style: const TextStyle(color: Colors.white, fontSize: 9, fontWeight: FontWeight.bold)),
+              child: Text(label, style: Theme.of(context).textTheme.labelSmall?.copyWith(color: Colors.white, fontWeight: FontWeight.bold)),
             ),
           ),
       ],

--- a/lib/screens/workbench/widgets/config_section_header.dart
+++ b/lib/screens/workbench/widgets/config_section_header.dart
@@ -25,8 +25,7 @@ class ConfigSectionHeader extends StatelessWidget {
           Expanded(
             child: Text(
               label.toUpperCase(),
-              style: TextStyle(
-                fontSize: 11,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
                 fontWeight: FontWeight.bold,
                 letterSpacing: 1.0,
                 color: colorScheme.primary,

--- a/lib/screens/workbench/widgets/crop_resize_toolbar.dart
+++ b/lib/screens/workbench/widgets/crop_resize_toolbar.dart
@@ -436,7 +436,7 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
   /// 8 the track's — see [AppSegmentedControl]. Measured at the selected
   /// weight, which is the wider of the two.
   double _ratioGroupWidth(AppLocalizations l10n, bool allRatios) {
-    const style = TextStyle(fontSize: 11.5, fontWeight: FontWeight.w700);
+    final style = Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w700);
     final labels = <String>[
       l10n.cropResizeFreeRatio,
       '1:1',
@@ -632,7 +632,9 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
         mainAxisSize: MainAxisSize.min,
         children: [
           _buildRatioField(_ratioXController),
-          const Padding(padding: EdgeInsets.symmetric(horizontal: 2), child: Text(":", style: TextStyle(fontSize: 12))),
+          Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2),
+              child: Text(":", style: Theme.of(context).textTheme.bodySmall)),
           _buildRatioField(_ratioYController),
         ],
       ),
@@ -645,7 +647,7 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
       child: TextField(
         controller: ctrl,
         decoration: const InputDecoration(isDense: true, border: InputBorder.none, contentPadding: EdgeInsets.zero),
-        style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold),
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold),
         keyboardType: TextInputType.number,
         textAlign: TextAlign.center,
       ),
@@ -824,7 +826,7 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
           children: [
             Icon(icon, color: fg, size: 24),
             const SizedBox(height: 4),
-            Text(label, style: TextStyle(fontSize: 10, color: fg, fontWeight: FontWeight.w500)),
+            Text(label, style: Theme.of(context).textTheme.labelSmall?.copyWith(color: fg, fontWeight: FontWeight.w500)),
           ],
         ),
       ),
@@ -872,7 +874,7 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
   Widget _buildRatioChip(String label, double? ratio, double? current) {
     final selected = ratio == current;
     return ChoiceChip(
-      label: Text(label, style: const TextStyle(fontSize: 11)),
+      label: Text(label, style: Theme.of(context).textTheme.labelMedium?.metricsOnly),
       selected: selected,
       onSelected: (v) {
         _updateAspectRatio(ratio);
@@ -901,7 +903,7 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
             ),
             const SizedBox(height: 12),
             SwitchListTile(
-              title: Text(l10n.maintainAspectRatio, style: const TextStyle(fontSize: 13)),
+              title: Text(l10n.maintainAspectRatio, style: Theme.of(context).textTheme.bodyMedium),
               value: uiState.maintainAspectRatio,
               onChanged: (v) {
                 uiState.setMaintainAspectRatio(v);

--- a/lib/screens/workbench/widgets/crop_resize_view.dart
+++ b/lib/screens/workbench/widgets/crop_resize_view.dart
@@ -290,7 +290,7 @@ class _CropBadge extends StatelessWidget {
           ),
           child: Text(
             ratio == null ? '$w × $h' : '$w × $h · $ratio',
-            style: const TextStyle(color: Colors.white, fontSize: 11, fontWeight: FontWeight.w600),
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: Colors.white, fontWeight: FontWeight.w600),
           ),
         ),
       ),
@@ -324,9 +324,8 @@ class _CanvasLabel extends StatelessWidget {
     return IgnorePointer(
       child: Text(
         l10n.cropResizeCanvasLabel(name),
-        style: TextStyle(
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
           color: Colors.white.withValues(alpha: 0.7),
-          fontSize: 12,
           fontFamily: 'monospace',
           shadows: const [Shadow(color: Colors.black54, blurRadius: 4)],
         ),
@@ -372,7 +371,7 @@ class _ZoomPill extends StatelessWidget {
             child: Text(
               '${percent.round()}%',
               textAlign: TextAlign.center,
-              style: const TextStyle(color: Colors.white, fontSize: 11.5, fontWeight: FontWeight.w600),
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(color: Colors.white, fontWeight: FontWeight.w600),
             ),
           ),
           _pillIcon(Icons.add, onZoomIn),
@@ -382,7 +381,7 @@ class _ZoomPill extends StatelessWidget {
             borderRadius: BorderRadius.circular(14),
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: Text(l10n.fitToWindow, style: const TextStyle(color: Colors.white, fontSize: 11)),
+              child: Text(l10n.fitToWindow, style: Theme.of(context).textTheme.labelMedium?.copyWith(color: Colors.white)),
             ),
           ),
         ],

--- a/lib/screens/workbench/widgets/gallery_toolbar.dart
+++ b/lib/screens/workbench/widgets/gallery_toolbar.dart
@@ -10,6 +10,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../models/app_image.dart';
 import '../../../state/app_state.dart';
 import '../../../state/gallery_state.dart';
+import '../../../widgets/app_button.dart';
 import '../../../widgets/dialogs/thumbnail_size_dialog.dart';
 
 class GalleryToolbar extends StatelessWidget {
@@ -75,11 +76,11 @@ class GalleryToolbar extends StatelessWidget {
           ),
           if (!isDesktop && galleryState.droppedImages.isNotEmpty) ...[
             _divider(colorScheme),
-            TextButton.icon(
+            AppButton(
+              label: l10n.clearTempWorkspace,
+              icon: Icons.delete_sweep_outlined,
+              variant: AppButtonVariant.destructiveText,
               onPressed: () => galleryState.clearDroppedImages(),
-              icon: const Icon(Icons.delete_sweep_outlined, size: 18),
-              label: Text(l10n.clearTempWorkspace),
-              style: TextButton.styleFrom(foregroundColor: colorScheme.error),
             ),
           ],
           _divider(colorScheme),
@@ -136,10 +137,11 @@ class GalleryToolbar extends StatelessWidget {
             ),
 
           if (canInline)
-            TextButton.icon(
+            AppButton(
+              label: l10n.importFromGallery,
+              icon: Icons.photo_library_outlined,
+              variant: AppButtonVariant.text,
               onPressed: () => _pickFromGallery(galleryState),
-              icon: const Icon(Icons.photo_library_outlined, size: 18),
-              label: Text(l10n.importFromGallery),
             )
           else
             _buildOverflowMenu(context, galleryState, l10n, selectedCount, thumbnailSize, isDesktop),

--- a/lib/screens/workbench/widgets/gallery_toolbar.dart
+++ b/lib/screens/workbench/widgets/gallery_toolbar.dart
@@ -292,7 +292,7 @@ class GalleryToolbar extends StatelessWidget {
   /// button, inside a padded track. Measured at the selected weight, which is
   /// the wider of the two the label can take.
   double _toggleNaturalWidth(BuildContext context, AppLocalizations l10n) {
-    const label = TextStyle(fontSize: 12, fontWeight: FontWeight.w600);
+    final label = Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600);
     return _measureText(context, l10n.allSources, label) +
         _measureText(context, l10n.allResults, label) +
         _kToggleChrome;
@@ -439,12 +439,14 @@ class GalleryToolbar extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           _buildToggleButton(
+            context: context,
             label: l10n.allSources,
             selected: isSource,
             colorScheme: colorScheme,
             onTap: () => gs.setViewMode(GalleryViewMode.all),
           ),
           _buildToggleButton(
+            context: context,
             label: l10n.allResults,
             selected: isResult,
             colorScheme: colorScheme,
@@ -456,6 +458,7 @@ class GalleryToolbar extends StatelessWidget {
   }
 
   Widget _buildToggleButton({
+    required BuildContext context,
     required String label,
     required bool selected,
     required ColorScheme colorScheme,
@@ -480,11 +483,10 @@ class GalleryToolbar extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 6),
             child: Text(
               label,
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-                color: selected ? colorScheme.onSurface : colorScheme.onSurfaceVariant,
-              ),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    color: selected ? colorScheme.onSurface : colorScheme.onSurfaceVariant,
+                  ),
             ),
           ),
         ),

--- a/lib/screens/workbench/widgets/image_card.dart
+++ b/lib/screens/workbench/widgets/image_card.dart
@@ -147,6 +147,8 @@ class _ImageCardState extends State<ImageCard> {
                   children: [
                     Icon(Icons.videocam, size: 10, color: _overlayInk),
                     SizedBox(width: 2),
+                    // Left off the type scale on purpose: its smallest slot is
+                    // labelSmall at 10, and +25% does not fit this badge.
                     Text(
                       "VIDEO",
                       style: TextStyle(color: _overlayInk, fontSize: 8, fontWeight: FontWeight.bold),
@@ -281,7 +283,7 @@ class _ImageCardState extends State<ImageCard> {
           color: _overlayScrim,
           child: Text(
             _dimensions,
-            style: const TextStyle(color: _overlayInk, fontSize: 9, height: 1.3),
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(color: _overlayInk, height: 1.3),
           ),
         ),
       ),
@@ -305,9 +307,8 @@ class _ImageCardState extends State<ImageCard> {
       ),
       child: Text(
         '${widget.selectionNumber}',
-        style: TextStyle(
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
           color: colorScheme.onPrimary,
-          fontSize: 11,
           fontWeight: FontWeight.w700,
           height: 1,
         ),

--- a/lib/screens/workbench/widgets/mask_editor_toolbar.dart
+++ b/lib/screens/workbench/widgets/mask_editor_toolbar.dart
@@ -189,31 +189,20 @@ class MaskEditorToolbar extends StatelessWidget {
           const VerticalDivider(width: 16, indent: 12, endIndent: 12),
           
           if (!isNarrow) ...[
-            OutlinedButton(
+            AppButton(
+              label: l10n.saveToTemp,
+              variant: AppButtonVariant.secondary,
               onPressed: onSave,
-              style: OutlinedButton.styleFrom(
-                visualDensity: VisualDensity.compact,
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-              ),
-              child: Text(l10n.saveToTemp, style: const TextStyle(fontSize: 12)),
             ),
             const SizedBox(width: 8),
-            FilledButton(
+            AppButton(
+              label: l10n.saveMaskToTemp,
               onPressed: onSaveMask,
-              style: FilledButton.styleFrom(
-                visualDensity: VisualDensity.compact,
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-              ),
-              child: Text(l10n.saveMaskToTemp, style: const TextStyle(fontSize: 12)),
             ),
           ] else
-            FilledButton(
+            AppButton(
+              label: l10n.saveMaskToTemp,
               onPressed: onSaveMask,
-              style: FilledButton.styleFrom(
-                visualDensity: VisualDensity.compact,
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-              ),
-              child: Text(l10n.saveMaskToTemp, style: const TextStyle(fontSize: 12)),
             ),
         ],
       ),

--- a/lib/screens/workbench/widgets/mask_editor_view.dart
+++ b/lib/screens/workbench/widgets/mask_editor_view.dart
@@ -130,7 +130,7 @@ class _MaskEditorViewState extends State<MaskEditorView> {
                 Expanded(
                   child: Text(
                     l10n.binaryModeActive,
-                    style: TextStyle(fontSize: 12, color: colorScheme.onTertiaryContainer),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onTertiaryContainer),
                   ),
                 ),
               ],

--- a/lib/screens/workbench/widgets/metadata_inspector.dart
+++ b/lib/screens/workbench/widgets/metadata_inspector.dart
@@ -123,9 +123,8 @@ class _MetadataInspectorState extends State<MetadataInspector> {
       padding: const EdgeInsets.only(bottom: 12),
       child: Text(
         title,
-        style: TextStyle(
-          fontWeight: FontWeight.bold, 
-          fontSize: 11, 
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+          fontWeight: FontWeight.bold,
           letterSpacing: 1.2,
           color: colorScheme.primary,
         ),
@@ -141,11 +140,11 @@ class _MetadataInspectorState extends State<MetadataInspector> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(entry.key, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12)),
+              Text(entry.key, style: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold)),
               const SizedBox(height: 4),
               SelectableText(
                 entry.value,
-                style: const TextStyle(fontSize: 13, fontFamily: 'monospace'),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontFamily: 'monospace'),
               ),
               const Divider(height: 16),
             ],

--- a/lib/screens/workbench/widgets/optimizer_config_panel.dart
+++ b/lib/screens/workbench/widgets/optimizer_config_panel.dart
@@ -527,7 +527,7 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
                 children: [
                   CircleAvatar(backgroundColor: Color(t.color), radius: 6),
                   const SizedBox(width: 8),
-                  Expanded(child: Text(t.name, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 13))),
+                  Expanded(child: Text(t.name, overflow: TextOverflow.ellipsis, style: Theme.of(context).textTheme.bodyMedium)),
                 ],
               ),
             )),
@@ -552,7 +552,7 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
           onChanged: widget.onSysPromptChanged,
           items: widget.filteredSysPrompts.map((p) => DropdownMenuItem(
             value: p.content,
-            child: Text(p.title, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 13)),
+            child: Text(p.title, overflow: TextOverflow.ellipsis, style: Theme.of(context).textTheme.bodyMedium),
           )).toList(),
         ),
       ),
@@ -567,12 +567,12 @@ class _OptimizerConfigPanelState extends State<OptimizerConfigPanel> {
       onChanged: widget.onSysPromptChanged,
       decoration: InputDecoration(
         hintText: l10n.customSysPromptHint,
-        hintStyle: TextStyle(fontSize: 13, color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6)),
+        hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6)),
         border: const OutlineInputBorder(),
         contentPadding: const EdgeInsets.all(12),
         isDense: true,
       ),
-      style: const TextStyle(fontSize: 13),
+      style: Theme.of(context).textTheme.bodyMedium,
     );
   }
 }
@@ -644,8 +644,7 @@ class _Chip extends StatelessWidget {
         ),
         child: Text(
           label,
-          style: TextStyle(
-            fontSize: 11,
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
             fontWeight: selected ? FontWeight.bold : FontWeight.normal,
             color: selected ? colorScheme.onPrimaryContainer : colorScheme.onSurfaceVariant,
           ),

--- a/lib/screens/workbench/widgets/optimizer_reference_panel.dart
+++ b/lib/screens/workbench/widgets/optimizer_reference_panel.dart
@@ -25,7 +25,7 @@ class OptimizerReferencePanel extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(16, 16, 12, 8),
           trailing: images.isEmpty
               ? null
-              : Text('${images.length}', style: TextStyle(fontSize: 11, color: colorScheme.outline)),
+              : Text('${images.length}', style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline)),
         ),
         if (images.isEmpty)
           Expanded(
@@ -37,7 +37,7 @@ class OptimizerReferencePanel extends StatelessWidget {
                   const SizedBox(height: 12),
                   Text(
                     l10n.noImagesSelected,
-                    style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
                   ),
                   const SizedBox(height: 8),
                   Padding(
@@ -45,7 +45,7 @@ class OptimizerReferencePanel extends StatelessWidget {
                     child: Text(
                       l10n.optEmptyImagesHint,
                       textAlign: TextAlign.center,
-                      style: TextStyle(color: colorScheme.outline, fontSize: 11),
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
                     ),
                   ),
                 ],
@@ -192,7 +192,7 @@ class _Badge extends StatelessWidget {
       child: text != null
           ? Text(
               text!,
-              style: TextStyle(fontSize: 10, fontWeight: FontWeight.bold, color: foreground),
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.bold, color: foreground),
             )
           : Icon(icon, size: 12, color: foreground),
     );

--- a/lib/screens/workbench/widgets/preview/media_preview_dialog.dart
+++ b/lib/screens/workbench/widgets/preview/media_preview_dialog.dart
@@ -194,12 +194,12 @@ class _MediaPreviewDialogState extends State<MediaPreviewDialog> {
                                 children: [
                                   Text(
                                     activeFile.name,
-                                    style: const TextStyle(color: Colors.white, fontSize: 14, fontWeight: FontWeight.bold),
+                                    style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.white, fontWeight: FontWeight.bold),
                                     overflow: TextOverflow.ellipsis,
                                   ),
                                   Text(
                                     '${activeIndex + 1} / ${images.length}',
-                                    style: const TextStyle(color: Colors.white70, fontSize: 11),
+                                    style: Theme.of(context).textTheme.labelMedium?.copyWith(color: Colors.white70),
                                   ),
                                 ],
                               ),

--- a/lib/screens/workbench/widgets/preview/video_preview_handler.dart
+++ b/lib/screens/workbench/widgets/preview/video_preview_handler.dart
@@ -421,7 +421,7 @@ class _VideoControlBarState extends State<_VideoControlBar> {
                     const SizedBox(width: 8),
                     Text(
                       '${_formatDuration(value.position)} / ${_formatDuration(value.duration)}',
-                      style: const TextStyle(color: Colors.white, fontSize: 12),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white),
                     ),
                     const Spacer(),
                     IconButton(

--- a/lib/screens/workbench/widgets/prompt_optimizer_view.dart
+++ b/lib/screens/workbench/widgets/prompt_optimizer_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:provider/provider.dart';
 
-import '../../../core/app_theme.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/prompt_optimizer_agent.dart';
 import '../../../state/workbench_ui_state.dart';
@@ -486,11 +485,11 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
               if (isLast && !widget.isBusy)
                 Padding(
                   padding: const EdgeInsets.only(top: 6),
-                  child: OutlinedButton.icon(
+                  child: AppButton(
+                    label: l10n.optRetry,
+                    icon: Icons.refresh,
+                    variant: AppButtonVariant.secondary,
                     onPressed: widget.onRetry,
-                    icon: const Icon(Icons.refresh, size: 15),
-                    label: Text(l10n.optRetry, style: const TextStyle(fontSize: 12)),
-                    style: OutlinedButton.styleFrom(visualDensity: VisualDensity.compact),
                   ),
                 ),
             ],
@@ -646,17 +645,19 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                 ? Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      TextButton(
+                      AppButton(
+                        label: l10n.kbEditReject,
+                        variant: AppButtonVariant.text,
+                        size: AppButtonSize.compact,
                         onPressed: () => widget.onRejectKbEdit(editId),
-                        child: Text(l10n.kbEditReject, style: const TextStyle(fontSize: 12)),
                       ),
                       const SizedBox(width: 6),
-                      FilledButton.tonalIcon(
+                      AppButton(
+                        label: l10n.kbEditApply,
+                        icon: Icons.save_outlined,
+                        variant: AppButtonVariant.secondary,
+                        size: AppButtonSize.compact,
                         onPressed: () => widget.onApplyKbEdit(editId),
-                        icon: const Icon(Icons.save_outlined, size: 15),
-                        label: Text(l10n.kbEditApply, style: const TextStyle(fontSize: 12)),
-                        style: tonalButtonStyle(colorScheme)
-                            .copyWith(visualDensity: VisualDensity.compact),
                       ),
                     ],
                   )
@@ -737,12 +738,11 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                     AppSnackBar.success(context, l10n.optPromptCopied);
                   },
                 ),
-                FilledButton.tonalIcon(
+                AppButton(
+                  label: l10n.apply,
+                  icon: Icons.check,
+                  variant: AppButtonVariant.secondary,
                   onPressed: () => widget.onApplyPrompt(entry.text),
-                  icon: const Icon(Icons.check, size: 15),
-                  label: Text(l10n.apply, style: textTheme.labelMedium),
-                  style: tonalButtonStyle(Theme.of(context).colorScheme)
-                      .copyWith(visualDensity: VisualDensity.compact),
                 ),
               ],
             ),
@@ -1059,14 +1059,13 @@ class _AskUserCardState extends State<_AskUserCard> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                FilledButton.tonalIcon(
+                AppButton(
+                  label: l10n.optAskUserConfirm,
+                  icon: Icons.send_rounded,
+                  variant: AppButtonVariant.secondary,
                   onPressed: widget.enabled && _allAnswered
                       ? () => widget.onSubmit(_collectAnswers())
                       : null,
-                  icon: const Icon(Icons.send_rounded, size: 15),
-                  label: Text(l10n.optAskUserConfirm, style: const TextStyle(fontSize: 12)),
-                  style: tonalButtonStyle(colorScheme)
-                      .copyWith(visualDensity: VisualDensity.compact),
                 ),
               ],
             ),

--- a/lib/screens/workbench/widgets/prompt_optimizer_view.dart
+++ b/lib/screens/workbench/widgets/prompt_optimizer_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:provider/provider.dart';
 
+import '../../../core/app_theme.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/prompt_optimizer_agent.dart';
 import '../../../state/workbench_ui_state.dart';
@@ -183,7 +184,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
               Text(
                 l10n.optEmptyChat,
                 textAlign: TextAlign.center,
-                style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 13, height: 1.5),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant, height: 1.5),
               ),
             ],
           ),
@@ -385,7 +386,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
             ),
             child: SelectableText(
               entry.text,
-              style: TextStyle(color: colorScheme.onPrimaryContainer, fontSize: 13, height: 1.4),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.onPrimaryContainer, height: 1.4),
             ),
           ),
         );
@@ -404,7 +405,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
               data: entry.text,
               selectable: true,
               styleSheet: MarkdownStyleSheet(
-                p: TextStyle(color: colorScheme.onSurface, fontSize: 13, height: 1.4),
+                p: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.onSurface, height: 1.4),
               ),
             ),
           ),
@@ -452,7 +453,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                 Flexible(
                   child: Text(
                     noticeText,
-                    style: TextStyle(fontSize: 11, color: colorScheme.outline, fontStyle: FontStyle.italic),
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline, fontStyle: FontStyle.italic),
                   ),
                 ),
               ],
@@ -476,7 +477,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                 ),
                 child: SelectableText(
                   entry.text,
-                  style: TextStyle(color: colorScheme.onErrorContainer, fontSize: 12, height: 1.4),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onErrorContainer, height: 1.4),
                 ),
               ),
               // The failed turn's context (user message, tool results) is
@@ -539,8 +540,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                 const SizedBox(width: 6),
                 Text(
                   isCreate ? l10n.kbEditProposedCreate : l10n.kbEditProposedUpdate,
-                  style: TextStyle(
-                    fontSize: 11,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                     color: colorScheme.primary,
                   ),
@@ -550,8 +550,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                   child: Text(
                     entry.targetPath ?? '',
                     overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 12,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       fontFamily: 'monospace',
                       color: colorScheme.onSurface,
                     ),
@@ -565,8 +564,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
               padding: const EdgeInsets.fromLTRB(14, 6, 14, 0),
               child: Text(
                 entry.note!,
-                style: TextStyle(
-                  fontSize: 11,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
                   fontStyle: FontStyle.italic,
                   color: colorScheme.onSurfaceVariant,
                 ),
@@ -582,7 +580,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                   Expanded(
                     child: Text(
                       l10n.kbEditShrinkWarning(entry.oldContent!.length, content.length),
-                      style: TextStyle(fontSize: 11, color: colorScheme.error),
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.error),
                     ),
                   ),
                 ],
@@ -606,7 +604,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                     label: Text(
                       expanded ? l10n.kbEditHide : l10n.kbEditShow(content.length),
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(fontSize: 11),
+                      style: Theme.of(context).textTheme.labelMedium?.metricsOnly,
                     ),
                     style: TextButton.styleFrom(
                       visualDensity: VisualDensity.compact,
@@ -630,8 +628,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
               child: SingleChildScrollView(
                 child: SelectableText(
                   content,
-                  style: TextStyle(
-                    fontSize: 11,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     height: 1.45,
                     fontFamily: 'monospace',
                     color: colorScheme.onSurface,
@@ -683,8 +680,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                             _ => l10n.kbEditFailedShort,
                           },
                           overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            fontSize: 11,
+                          style: Theme.of(context).textTheme.labelMedium?.copyWith(
                             color: state == KbEditState.failed
                                 ? colorScheme.error
                                 : colorScheme.outline,
@@ -761,7 +757,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                   data: entry.text,
                   selectable: true,
                   styleSheet: MarkdownStyleSheet(
-                    p: TextStyle(color: colorScheme.onSurface, fontSize: 13, height: 1.45),
+                    p: textTheme.bodyMedium?.copyWith(color: colorScheme.onSurface, height: 1.45),
                   ),
                 ),
               ),
@@ -783,8 +779,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
               padding: const EdgeInsets.fromLTRB(14, 0, 14, 10),
               child: Text(
                 entry.note!,
-                style: TextStyle(
-                  fontSize: 11,
+                style: textTheme.labelMedium?.copyWith(
                   fontStyle: FontStyle.italic,
                   color: colorScheme.onSurfaceVariant,
                 ),
@@ -805,7 +800,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
           const SizedBox(width: 8),
           Text(
             l10n.optAgentWorking,
-            style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
           ),
         ],
       ),
@@ -1043,8 +1038,7 @@ class _AskUserCardState extends State<_AskUserCard> {
                 Expanded(
                   child: Text(
                     l10n.optAskUserTitle,
-                    style: TextStyle(
-                      fontSize: 11,
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: colorScheme.primary,
                     ),
@@ -1089,8 +1083,7 @@ class _AskUserCardState extends State<_AskUserCard> {
                 child: Text(
                   question.header,
                   overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 11,
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                     color: colorScheme.onSurfaceVariant,
                   ),
@@ -1100,7 +1093,7 @@ class _AskUserCardState extends State<_AskUserCard> {
                 const SizedBox(width: 6),
                 Text(
                   l10n.optAskUserMultiHint,
-                  style: TextStyle(fontSize: 10, color: colorScheme.outline),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.outline),
                 ),
               ],
             ],
@@ -1108,7 +1101,7 @@ class _AskUserCardState extends State<_AskUserCard> {
           const SizedBox(height: 4),
           SelectableText(
             question.question,
-            style: TextStyle(fontSize: 13, height: 1.4, color: colorScheme.onSurface),
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(height: 1.4, color: colorScheme.onSurface),
           ),
           const SizedBox(height: 8),
           Wrap(
@@ -1121,7 +1114,7 @@ class _AskUserCardState extends State<_AskUserCard> {
                   child: FilterChip(
                     label: Text(
                       question.options[o].label,
-                      style: const TextStyle(fontSize: 12),
+                      style: Theme.of(context).textTheme.bodySmall?.metricsOnly,
                     ),
                     selected: selected.contains(o),
                     showCheckmark: question.multiSelect,
@@ -1139,13 +1132,12 @@ class _AskUserCardState extends State<_AskUserCard> {
             enabled: widget.enabled,
             minLines: 1,
             maxLines: 3,
-            style: const TextStyle(fontSize: 12, height: 1.4),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(height: 1.4),
             // setState so the confirm button re-evaluates _allAnswered.
             onChanged: (_) => setState(() {}),
             decoration: InputDecoration(
               hintText: l10n.optAskUserOtherHint,
-              hintStyle: TextStyle(
-                fontSize: 12,
+              hintStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
               ),
               isDense: true,
@@ -1193,7 +1185,7 @@ class _AskUserCardState extends State<_AskUserCard> {
                       ? l10n.optAskUserAnswered
                       : l10n.optAskUserDismissed,
                   overflow: TextOverflow.ellipsis,
-                  style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                  style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
                 ),
               ),
             ],
@@ -1204,7 +1196,7 @@ class _AskUserCardState extends State<_AskUserCard> {
               child: Text(
                 '${answer.header}: '
                 '${[...answer.selected, if (answer.otherText != null) answer.otherText!].join(', ')}',
-                style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
               ),
             ),
         ],

--- a/lib/screens/workbench/widgets/queue_settings_dialog.dart
+++ b/lib/screens/workbench/widgets/queue_settings_dialog.dart
@@ -55,8 +55,10 @@ Future<void> showQueueSettingsDialog(BuildContext context) {
               const Divider(),
               const SizedBox(height: 8),
               Text(l10n.filenamePrefix,
-                  style: const TextStyle(
-                      fontWeight: FontWeight.bold, fontSize: 13)),
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold)),
               const SizedBox(height: 8),
               TextField(
                 controller: prefixController,

--- a/lib/screens/workbench/widgets/result_tree_item.dart
+++ b/lib/screens/workbench/widgets/result_tree_item.dart
@@ -107,8 +107,7 @@ class _ResultTreeItemState extends State<ResultTreeItem> {
           ),
           title: Text(
             folderName,
-            style: TextStyle(
-              fontSize: 13,
+            style: theme.textTheme.titleSmall?.copyWith(
               fontWeight: isViewing ? FontWeight.bold : FontWeight.w500,
               color: isViewing ? theme.colorScheme.primary : null,
             ),

--- a/lib/screens/workbench/widgets/safety_settings_section.dart
+++ b/lib/screens/workbench/widgets/safety_settings_section.dart
@@ -55,11 +55,11 @@ class SafetySettingsSection extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(l10n.safetySettings,
-            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
         const SizedBox(height: 2),
         Text(
           l10n.safetySettingsDesc,
-          style: TextStyle(fontSize: 11, color: colorScheme.outline),
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
         ),
         for (final category in SafetySettings.categories) ...[
           const SizedBox(height: 8),
@@ -67,13 +67,12 @@ class SafetySettingsSection extends StatelessWidget {
             children: [
               Expanded(
                 child: Text(_categoryLabel(l10n, category),
-                    style: const TextStyle(fontSize: 12)),
+                    style: Theme.of(context).textTheme.bodySmall),
               ),
               Text(
                 _thresholdLabel(
                     l10n, thresholds[category] ?? SafetySettings.defaultThreshold),
-                style: TextStyle(
-                  fontSize: 11,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
                   fontWeight: FontWeight.bold,
                   color: colorScheme.primary,
                 ),

--- a/lib/screens/workbench/widgets/video_config_panel.dart
+++ b/lib/screens/workbench/widgets/video_config_panel.dart
@@ -12,6 +12,7 @@ import '../../../models/prompt_history_entry.dart';
 import '../../../services/llm/model_capabilities.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_button.dart';
 import '../../../widgets/app_segmented_control.dart';
 import '../../../widgets/app_snackbar.dart';
 import '../../../widgets/collapsible_card.dart';
@@ -205,14 +206,12 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
     final generateButton = Row(
       children: [
         Expanded(
-          child: FilledButton.icon(
+          child: AppButton(
+            label: l10n.generateVideo,
+            icon: Icons.movie_outlined,
+            size: AppButtonSize.large,
+            fullWidth: true,
             onPressed: _promptController.text.isEmpty ? null : _handleSubmit,
-            icon: const Icon(Icons.movie_outlined),
-            label: Text(l10n.generateVideo, style: const TextStyle(fontWeight: FontWeight.bold)),
-            style: FilledButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-            ),
           ),
         ),
         const SizedBox(width: 10),

--- a/lib/screens/workbench/widgets/video_config_panel.dart
+++ b/lib/screens/workbench/widgets/video_config_panel.dart
@@ -143,8 +143,11 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
           expand: false,
         ),
         SwitchListTile(
-          title: Text(l10n.compressReferenceImages, style: const TextStyle(fontSize: 13, fontWeight: FontWeight.bold)),
-          subtitle: Text(l10n.compressReferenceImagesDesc, style: const TextStyle(fontSize: 11)),
+          title: Text(l10n.compressReferenceImages, style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
+          // Carries the colour the ListTile's own subtitle style supplied, which
+          // the slot would otherwise replace with plain onSurface.
+          subtitle: Text(l10n.compressReferenceImagesDesc,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant)),
           value: appState.compressReferenceImages,
           onChanged: (v) => appState.updateWorkbenchConfig(compressReferenceImages: v),
           secondary: const Icon(Icons.compress, size: 20),
@@ -413,7 +416,7 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
                 SizedBox(
                   width: 80,
                   child: Text(_videoParamLabel(l10n, spec.labelKey),
-                      style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold)),
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold)),
                 ),
                 Expanded(
                   child: _buildVideoParamControl(spec, model.modelId, appState, colorScheme, l10n),
@@ -439,7 +442,7 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
         return DropdownButton<String>(
           isExpanded: true,
           value: current,
-          style: TextStyle(fontSize: 12, color: colorScheme.onSurface),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
           underline: Container(height: 1, color: colorScheme.outlineVariant),
           items: spec.options
               .map((o) => DropdownMenuItem(
@@ -490,7 +493,7 @@ class _VideoConfigPanelState extends State<VideoConfigPanel> {
               child: Text(
                 '${value}s',
                 textAlign: TextAlign.end,
-                style: TextStyle(fontSize: 12, color: colorScheme.onSurface),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
               ),
             ),
           ],
@@ -557,7 +560,7 @@ class _FrameDropTarget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+        Text(label, style: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold)),
         const SizedBox(height: 4),
         DropTarget(
           onDragDone: (details) {
@@ -616,7 +619,7 @@ class _FrameDropTarget extends StatelessWidget {
                               Icon(emptyIcon, color: colorScheme.outline),
                               if (isMobile) ...[
                                 const SizedBox(height: 4),
-                                Text(l10n.tapToPick, style: TextStyle(color: colorScheme.outline, fontSize: 10)),
+                                Text(l10n.tapToPick, style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.outline)),
                               ],
                             ],
                           ),
@@ -682,7 +685,7 @@ class _ReferenceImagesTarget extends StatelessWidget {
                         Text(
                           dropHint,
                           textAlign: TextAlign.center,
-                          style: TextStyle(color: colorScheme.outline, fontSize: 11),
+                          style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
                         ),
                       ],
                     ),

--- a/lib/screens/workbench/widgets/video_workbench_view.dart
+++ b/lib/screens/workbench/widgets/video_workbench_view.dart
@@ -7,6 +7,7 @@ import 'package:video_player/video_player.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_button.dart';
 
 class VideoWorkbenchOverlay extends StatefulWidget {
   const VideoWorkbenchOverlay({super.key});
@@ -191,14 +192,10 @@ class _VideoWorkbenchOverlayState extends State<VideoWorkbenchOverlay> {
                     const SizedBox(height: 12),
                     SizedBox(
                       width: double.infinity,
-                      child: FilledButton.icon(
+                      child: AppButton(
+                        label: l10n.openInSystemPlayer,
+                        icon: Icons.open_in_new,
                         onPressed: () => _openInSystemPlayer(uiState.lastGeneratedVideoPath!),
-                        icon: const Icon(Icons.open_in_new, size: 16),
-                        label: Text(l10n.openInSystemPlayer, style: const TextStyle(fontSize: 12)),
-                        style: FilledButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(vertical: 8),
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                        ),
                       ),
                     ),
                   ],

--- a/lib/screens/workbench/widgets/video_workbench_view.dart
+++ b/lib/screens/workbench/widgets/video_workbench_view.dart
@@ -132,7 +132,7 @@ class _VideoWorkbenchOverlayState extends State<VideoWorkbenchOverlay> {
                         Expanded(
                           child: Text(
                             l10n.processResults,
-                            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                            style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                           ),
                         ),
                         IconButton(
@@ -154,7 +154,7 @@ class _VideoWorkbenchOverlayState extends State<VideoWorkbenchOverlay> {
                             Text(
                               _errorMessage ?? 'Failed to initialize video player',
                               textAlign: TextAlign.center,
-                              style: TextStyle(fontSize: 12, color: colorScheme.error),
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.error),
                             ),
                           ],
                         ),

--- a/lib/screens/workbench/widgets/workbench_bottom_console.dart
+++ b/lib/screens/workbench/widgets/workbench_bottom_console.dart
@@ -91,8 +91,7 @@ class _WorkbenchBottomConsoleState extends State<WorkbenchBottomConsole>
                     Flexible(
                       child: Text(
                         l10n.executionLogs,
-                        style: TextStyle(
-                          fontSize: 11,
+                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
                           fontWeight: FontWeight.w500,
                           letterSpacing: 0.4,
                           color: colorScheme.onSurfaceVariant,
@@ -122,8 +121,7 @@ class _WorkbenchBottomConsoleState extends State<WorkbenchBottomConsole>
                               alignment: Alignment.centerRight,
                               child: Text(
                                 lastLogMessage,
-                                style: TextStyle(
-                                  fontSize: 11,
+                                style: Theme.of(context).textTheme.labelMedium?.copyWith(
                                   fontFamily: 'monospace',
                                   color: colorScheme.onSurfaceVariant.withAlpha(160),
                                 ),
@@ -270,7 +268,7 @@ class _WorkbenchBottomConsoleState extends State<WorkbenchBottomConsole>
           if (runningCount > 0) ...[
             Text(
               l10n.runningCount(runningCount),
-              style: TextStyle(fontSize: 11.5, fontWeight: FontWeight.w600, color: colorScheme.primary),
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600, color: colorScheme.primary),
             ),
             const SizedBox(width: 7),
             // A bar rather than the 11px ring this replaced: at that size a
@@ -294,7 +292,7 @@ class _WorkbenchBottomConsoleState extends State<WorkbenchBottomConsole>
               const SizedBox(width: 7),
               Text(
                 '$pct%',
-                style: TextStyle(fontSize: 11.5, fontWeight: FontWeight.w700, color: colorScheme.primary),
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w700, color: colorScheme.primary),
               ),
             ],
           ],
@@ -304,7 +302,7 @@ class _WorkbenchBottomConsoleState extends State<WorkbenchBottomConsole>
             const SizedBox(width: 4),
             Text(
               l10n.plannedCount(pendingCount),
-              style: TextStyle(fontSize: 11.5, color: colorScheme.onSurfaceVariant),
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
             ),
           ],
         ],

--- a/lib/screens/workbench/widgets/workbench_top_bar.dart
+++ b/lib/screens/workbench/widgets/workbench_top_bar.dart
@@ -177,8 +177,8 @@ class WorkbenchTopBar extends StatelessWidget {
                         const SizedBox(width: 5),
                         Text(
                           channelName,
-                          style: TextStyle(fontFamily: 'monospace',
-                            fontSize: 11,
+                          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                            fontFamily: 'monospace',
                             fontWeight: FontWeight.w500,
                             color: colorScheme.onSurfaceVariant,
                           ),

--- a/lib/screens/workbench/workbench_config_panel.dart
+++ b/lib/screens/workbench/workbench_config_panel.dart
@@ -440,11 +440,11 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
             _updateConfig(prompt: content);
           },
         ),
-        TextButton.icon(
+        AppButton(
+          label: l10n.library,
+          icon: Icons.library_books_outlined,
+          variant: AppButtonVariant.text,
           onPressed: _allUserPrompts.isEmpty ? null : () => _showPromptPickerMenu(l10n),
-          icon: const Icon(Icons.library_books_outlined, size: 16),
-          label: Text(l10n.library, style: const TextStyle(fontSize: 12)),
-          style: TextButton.styleFrom(visualDensity: VisualDensity.compact),
         ),
       ],
     );
@@ -500,9 +500,10 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
               l10n.selectedCount(selectedImages.length),
               style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
             ),
-            TextButton(
+            AppButton(
+              label: l10n.clear,
+              variant: AppButtonVariant.text,
               onPressed: () => Provider.of<AppState>(context, listen: false).clearImageSelection(),
-              child: Text(l10n.clear, style: const TextStyle(fontSize: 12)),
             ),
           ],
         ),

--- a/lib/screens/workbench/workbench_config_panel.dart
+++ b/lib/screens/workbench/workbench_config_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../core/app_theme.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/app_image.dart';
 import '../../models/llm_channel.dart';
@@ -331,7 +332,7 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
                 selectedCount == 0
                     ? l10n.processPrompt
                     : l10n.processImages(selectedCount),
-                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+                style: Theme.of(context).textTheme.titleMedium?.metricsOnly.copyWith(fontWeight: FontWeight.bold),
               ),
               style: FilledButton.styleFrom(
                 padding: const EdgeInsets.symmetric(vertical: 16),
@@ -483,7 +484,7 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
             children: [
               Icon(Icons.collections_outlined, size: 48, color: colorScheme.outline),
               const SizedBox(height: 8),
-              Text(l10n.noImagesSelected, style: TextStyle(color: colorScheme.onSurface, fontSize: 12)),
+              Text(l10n.noImagesSelected, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface)),
             ],
           ),
         ),
@@ -498,7 +499,7 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
           children: [
             Text(
               l10n.selectedCount(selectedImages.length),
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
             ),
             AppButton(
               label: l10n.clear,
@@ -587,7 +588,7 @@ class _WorkbenchConfigPanelState extends State<WorkbenchConfigPanel> {
           Icon(Icons.info_outline, size: 16, color: colorScheme.onTertiaryContainer),
           const SizedBox(width: 8),
           Expanded(
-            child: Text(message, style: TextStyle(fontSize: 11, color: colorScheme.onTertiaryContainer)),
+            child: Text(message, style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.onTertiaryContainer)),
           ),
         ],
       ),

--- a/lib/screens/workbench/workbench_screen.dart
+++ b/lib/screens/workbench/workbench_screen.dart
@@ -12,6 +12,7 @@ import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../core/app_paths.dart';
+import '../../core/app_theme.dart';
 import '../../core/constants.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
@@ -342,7 +343,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
                 ),
                 subtitle: Text(
                   meta.updatedAt.toLocal().toString().substring(0, 16),
-                  style: const TextStyle(fontSize: 11),
+                  style: Theme.of(context).textTheme.labelMedium?.metricsOnly,
                 ),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -31,6 +31,33 @@ enum AppButtonVariant {
   /// reserved for the confirmation the user actually commits with (inside the
   /// dialog this button opens), not the toolbar button that only proposes it.
   destructiveOutline,
+
+  /// A destructive action at the lowest emphasis — the error colour on a
+  /// borderless button. For a toolbar or selection bar of otherwise
+  /// borderless controls, where [destructiveOutline]'s edge would be the
+  /// only one in the row and [destructive]'s fill would shout.
+  destructiveText,
+}
+
+/// How much room a button takes.
+///
+/// Buttons were pinned to one height until several call sites turned out to
+/// need otherwise, and each had hand-rolled its own `minimumSize` or
+/// `visualDensity` to get there — the same drift the component exists to
+/// stop. Three sizes cover every one of them.
+enum AppButtonSize {
+  /// ~30px and tight. For a button inside a popup, a slim toolbar strip or
+  /// a card footer, where [normal] would force the row taller than the
+  /// controls it sits among.
+  compact,
+
+  /// The default, matching [AppIconButton] and the segmented control.
+  normal,
+
+  /// 48px. For a sheet's committing action, or a panel's single main call
+  /// to action — where the button is what the screen is *for*, and is
+  /// usually also a touch target on a phone.
+  large,
 }
 
 /// A labelled action button in one of four roles ([AppButtonVariant]).
@@ -60,6 +87,12 @@ class AppButton extends StatelessWidget {
   /// site driving this from a `Future` doesn't need its own busy/idle switch.
   final bool loading;
 
+  final AppButtonSize size;
+
+  /// Stretches to the width offered. For the committing action at the foot
+  /// of a bottom sheet, which is expected to span it.
+  final bool fullWidth;
+
   const AppButton({
     super.key,
     required this.label,
@@ -68,6 +101,8 @@ class AppButton extends StatelessWidget {
     this.icon,
     this.variant = AppButtonVariant.primary,
     this.loading = false,
+    this.size = AppButtonSize.normal,
+    this.fullWidth = false,
   });
 
   /// The label, plus [secondaryLabel] trailing it when set.
@@ -91,11 +126,56 @@ class AppButton extends StatelessWidget {
     );
   }
 
+  /// Geometry *and type* for [size] and [fullWidth], layered under the
+  /// variant's own style so colour always wins over sizing.
+  ///
+  /// The label scales with the box. A compact button holding a full-size
+  /// label is not compact — it was still overflowing the card it had been
+  /// shrunk to fit, and the call sites that predate this had each hand-set a
+  /// `fontSize: 12` alongside their `visualDensity`, which is the pairing
+  /// this encodes once. Sizes come from the app's type scale rather than
+  /// literals, so a change there still reaches buttons.
+  ///
+  /// Returns null for the default, so an ordinary button keeps whatever the
+  /// theme says rather than having the same numbers restated over it.
+  ButtonStyle? _sizeStyle(TextTheme textTheme) {
+    if (size == AppButtonSize.normal && !fullWidth) return null;
+
+    final (height, density, padding, textStyle) = switch (size) {
+      AppButtonSize.compact => (
+          30.0,
+          VisualDensity.compact,
+          const EdgeInsets.symmetric(horizontal: 10),
+          textTheme.labelMedium,
+        ),
+      AppButtonSize.normal => (appButtonMinHeight, null, null, null),
+      // A screen's main action carries a little more weight than the buttons
+      // beside it; several of these had spelled that out as a bold label.
+      AppButtonSize.large => (
+          48.0,
+          null,
+          const EdgeInsets.symmetric(horizontal: 20),
+          textTheme.titleMedium,
+        ),
+    };
+
+    return ButtonStyle(
+      minimumSize: WidgetStatePropertyAll(Size(fullWidth ? double.infinity : 0, height)),
+      visualDensity: density,
+      padding: padding == null ? null : WidgetStatePropertyAll(padding),
+      textStyle: textStyle == null ? null : WidgetStatePropertyAll(textStyle),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final effectiveOnPressed = loading ? null : onPressed;
-    final style = _styleFor(context, colorScheme);
+    final sizeStyle = _sizeStyle(Theme.of(context).textTheme);
+    final variantStyle = _styleFor(context, colorScheme);
+    // Variant first: `merge` fills only what the receiver left null, so the
+    // variant's colours survive and the size style supplies the geometry.
+    final style = variantStyle?.merge(sizeStyle) ?? sizeStyle;
 
     if (loading) {
       final spinner = SizedBox(
@@ -120,6 +200,7 @@ class AppButton extends StatelessWidget {
       case AppButtonVariant.destructive:
         return FilledButton(style: style, onPressed: onPressed, child: child);
       case AppButtonVariant.text:
+      case AppButtonVariant.destructiveText:
         return TextButton(style: style, onPressed: onPressed, child: child);
       case AppButtonVariant.destructiveOutline:
         return OutlinedButton(style: style, onPressed: onPressed, child: child);
@@ -139,25 +220,32 @@ class AppButton extends StatelessWidget {
         return FilledButton.icon(
           style: style,
           onPressed: onPressed,
-          icon: Icon(icon, size: 18),
+          icon: Icon(icon, size: _iconSize),
           label: label,
         );
       case AppButtonVariant.text:
+      case AppButtonVariant.destructiveText:
         return TextButton.icon(
           style: style,
           onPressed: onPressed,
-          icon: Icon(icon, size: 18),
+          icon: Icon(icon, size: _iconSize),
           label: label,
         );
       case AppButtonVariant.destructiveOutline:
         return OutlinedButton.icon(
           style: style,
           onPressed: onPressed,
-          icon: Icon(icon, size: 18),
+          icon: Icon(icon, size: _iconSize),
           label: label,
         );
     }
   }
+
+  double get _iconSize => switch (size) {
+        AppButtonSize.compact => 15,
+        AppButtonSize.normal => 18,
+        AppButtonSize.large => 20,
+      };
 
   ButtonStyle? _styleFor(BuildContext context, ColorScheme colorScheme) {
     switch (variant) {
@@ -181,6 +269,11 @@ class AppButton extends StatelessWidget {
           side: BorderSide(color: colorScheme.error.withValues(alpha: 0.5)),
           disabledForegroundColor: colorScheme.onSurface.withValues(alpha: 0.38),
         );
+      case AppButtonVariant.destructiveText:
+        return TextButton.styleFrom(
+          foregroundColor: colorScheme.error,
+          disabledForegroundColor: colorScheme.onSurface.withValues(alpha: 0.38),
+        );
     }
   }
 
@@ -200,6 +293,7 @@ class AppButton extends StatelessWidget {
       case AppButtonVariant.destructive:
         return colorScheme.onError;
       case AppButtonVariant.destructiveOutline:
+      case AppButtonVariant.destructiveText:
         return colorScheme.error;
     }
   }

--- a/lib/widgets/app_section.dart
+++ b/lib/widgets/app_section.dart
@@ -24,8 +24,7 @@ class AppSection extends StatelessWidget {
             padding: const EdgeInsets.only(bottom: 16),
             child: Text(
               title,
-              style: TextStyle(
-                fontSize: 18,
+              style: theme.textTheme.titleLarge?.copyWith(
                 fontWeight: FontWeight.bold,
                 color: theme.colorScheme.primary,
               ),

--- a/lib/widgets/app_segmented_control.dart
+++ b/lib/widgets/app_segmented_control.dart
@@ -146,8 +146,10 @@ class AppSegmentedControl<T> extends StatelessWidget {
                 segment.label,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: compact ? 11.5 : 12.5,
+                style: (compact
+                        ? Theme.of(context).textTheme.labelMedium
+                        : Theme.of(context).textTheme.bodySmall)
+                    ?.copyWith(
                   fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
                   color: color,
                 ),

--- a/lib/widgets/chat_model_selector.dart
+++ b/lib/widgets/chat_model_selector.dart
@@ -100,11 +100,10 @@ class ChatModelSelector extends StatelessWidget {
                   ),
                   child: Text(
                     channel.tag!,
-                    style: TextStyle(
-                      fontSize: 9, 
-                      color: Color(channel.tagColor ?? 0xFF607D8B),
-                      fontWeight: FontWeight.bold,
-                    ),
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: Color(channel.tagColor ?? 0xFF607D8B),
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
                 ),
               Flexible(child: Text(m.modelName, overflow: TextOverflow.ellipsis)),

--- a/lib/widgets/collapsible_card.dart
+++ b/lib/widgets/collapsible_card.dart
@@ -94,14 +94,17 @@ class _CollapsibleCardState extends State<CollapsibleCard> with SingleTickerProv
                     children: [
                       Text(
                         widget.title,
-                        style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
                       ),
                       SizeTransition(
                         sizeFactor: _controller.drive(Tween(begin: 1.0, end: 0.0).chain(CurveTween(curve: Curves.easeInOut))),
                         child: widget.subtitle != null 
                           ? Text(
                               widget.subtitle!,
-                              style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelMedium
+                                  ?.copyWith(color: colorScheme.outline),
                             )
                           : const SizedBox.shrink(),
                       ),

--- a/lib/widgets/color_picker_widget.dart
+++ b/lib/widgets/color_picker_widget.dart
@@ -63,11 +63,14 @@ class ColorPickerWidget extends StatelessWidget {
         ],
 
         // Preset Colors Section
-        const Align(
+        Align(
           alignment: Alignment.centerLeft,
           child: Text(
             "Presets",
-            style: TextStyle(fontSize: 11, fontWeight: FontWeight.bold, color: Colors.grey),
+            style: Theme.of(context)
+                .textTheme
+                .labelMedium
+                ?.copyWith(fontWeight: FontWeight.bold, color: Colors.grey),
           ),
         ),
         const SizedBox(height: 8),

--- a/lib/widgets/dialogs/image_size_picker_dialog.dart
+++ b/lib/widgets/dialogs/image_size_picker_dialog.dart
@@ -202,7 +202,7 @@ class _ImageSizePickerDialogState extends State<_ImageSizePickerDialog> {
             const SizedBox(height: 6),
             Text(
               l10n.imageSizeSnapHint,
-              style: TextStyle(fontSize: 11, color: colorScheme.outline),
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
             ),
             if (rules.isNotEmpty) ...[
               const SizedBox(height: 14),
@@ -266,7 +266,10 @@ class _SectionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       label,
-      style: const TextStyle(fontSize: 11, fontWeight: FontWeight.bold, letterSpacing: 0.4),
+      style: Theme.of(context)
+          .textTheme
+          .labelMedium
+          ?.copyWith(fontWeight: FontWeight.bold, letterSpacing: 0.4),
     );
   }
 }
@@ -298,7 +301,7 @@ class _AutoCard extends StatelessWidget {
             Icon(Icons.auto_fix_high,
                 size: 18, color: selected ? colorScheme.primary : colorScheme.outline),
             const SizedBox(width: 10),
-            Expanded(child: Text(label, style: const TextStyle(fontSize: 12))),
+            Expanded(child: Text(label, style: Theme.of(context).textTheme.bodySmall)),
             if (selected) Icon(Icons.check, size: 16, color: colorScheme.primary),
           ],
         ),
@@ -325,10 +328,9 @@ class _RuleRow extends StatelessWidget {
           Expanded(
             child: Text(
               label,
-              style: TextStyle(
-                fontSize: 11,
-                color: passes ? colorScheme.onSurfaceVariant : colorScheme.error,
-              ),
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: passes ? colorScheme.onSurfaceVariant : colorScheme.error,
+                  ),
             ),
           ),
         ],
@@ -378,7 +380,7 @@ class _AspectPreview extends StatelessWidget {
           const SizedBox(height: 4),
           Text(
             '$width×$height',
-            style: const TextStyle(fontSize: 11, fontWeight: FontWeight.w600),
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600),
           ),
         ],
       ),

--- a/lib/widgets/dialogs/library_dialog.dart
+++ b/lib/widgets/dialogs/library_dialog.dart
@@ -100,7 +100,7 @@ class _PromptLibrarySheetState extends State<PromptLibrarySheet> {
           Expanded(
             child: Text(
               l10n.promptLibrary,
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
             ),
           ),
           SizedBox(
@@ -110,7 +110,12 @@ class _PromptLibrarySheetState extends State<PromptLibrarySheet> {
               controller: _searchCtrl,
               decoration: InputDecoration(
                 hintText: l10n.filterPrompts, 
-                hintStyle: const TextStyle(fontSize: 12),
+                // The muted tone the field supplied on its own before this
+                // style named a scale slot, which brings a colour with it.
+                hintStyle: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: colorScheme.onSurfaceVariant),
                 prefixIcon: const Icon(Icons.search, size: 16),
                 isDense: true,
                 filled: true,
@@ -150,8 +155,7 @@ class _PromptLibrarySheetState extends State<PromptLibrarySheet> {
           final color = Color(tag.color);
 
           return FilterChip(
-            label: Text(tag.name, style: TextStyle(
-              fontSize: 11, 
+            label: Text(tag.name, style: Theme.of(context).textTheme.labelMedium?.copyWith(
               color: isSelected ? Colors.white : color,
               fontWeight: isSelected ? FontWeight.bold : FontWeight.normal
             )),
@@ -234,7 +238,7 @@ class _CompactPromptCard extends StatelessWidget {
                 Expanded(
                   child: Text(
                     prompt.title,
-                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -248,7 +252,10 @@ class _CompactPromptCard extends StatelessWidget {
                     ),
                     child: Text(
                       prompt.tags.first.name,
-                      style: TextStyle(fontSize: 10, color: Color(prompt.tags.first.color), fontWeight: FontWeight.bold),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: Color(prompt.tags.first.color),
+                            fontWeight: FontWeight.bold,
+                          ),
                     ),
                   ),
               ],
@@ -256,7 +263,7 @@ class _CompactPromptCard extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               prompt.content,
-              style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
               maxLines: 3,
               overflow: TextOverflow.ellipsis,
             ),

--- a/lib/widgets/dialogs/library_dialog.dart
+++ b/lib/widgets/dialogs/library_dialog.dart
@@ -4,6 +4,7 @@ import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/prompt.dart';
 import '../../models/tag.dart';
+import '../app_button.dart';
 import '../app_side_panel.dart';
 
 class PromptLibrarySheet extends StatefulWidget {
@@ -263,21 +264,19 @@ class _CompactPromptCard extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                TextButton.icon(
+                AppButton(
+                  label: l10n.add,
+                  icon: Icons.add,
+                  variant: AppButtonVariant.text,
+                  size: AppButtonSize.compact,
                   onPressed: () => onApply(true),
-                  icon: const Icon(Icons.add, size: 16),
-                  label: Text(l10n.add, style: const TextStyle(fontSize: 12)),
-                  style: TextButton.styleFrom(visualDensity: VisualDensity.compact),
                 ),
                 const SizedBox(width: 8),
-                FilledButton.icon(
+                AppButton(
+                  label: l10n.apply,
+                  icon: Icons.check,
+                  size: AppButtonSize.compact,
                   onPressed: () => onApply(false),
-                  icon: const Icon(Icons.check, size: 16),
-                  label: Text(l10n.apply, style: const TextStyle(fontSize: 12)),
-                  style: FilledButton.styleFrom(
-                    visualDensity: VisualDensity.compact,
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                  ),
                 ),
               ],
             ),

--- a/lib/widgets/dialogs/prompt_history_dialog.dart
+++ b/lib/widgets/dialogs/prompt_history_dialog.dart
@@ -117,7 +117,7 @@ class _PromptHistorySheetState extends State<PromptHistorySheet> {
           Expanded(
             child: Text(
               l10n.promptHistory,
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
             ),
           ),
           if (widget.entries.isNotEmpty)
@@ -150,7 +150,7 @@ class _PromptHistorySheetState extends State<PromptHistorySheet> {
               Text(
                 l10n.noPromptHistoryDesc,
                 textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 12, color: colorScheme.outline),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.outline),
               ),
             ],
           ),
@@ -240,7 +240,10 @@ class _HistoryCard extends StatelessWidget {
                   Expanded(
                     child: Text(
                       formatRelativeTime(l10n, entry.usedAt),
-                      style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelMedium
+                          ?.copyWith(color: colorScheme.outline),
                     ),
                   ),
                   Icon(Icons.chevron_right, size: 16, color: colorScheme.outline),
@@ -249,7 +252,7 @@ class _HistoryCard extends StatelessWidget {
               const SizedBox(height: 8),
               Text(
                 entry.content,
-                style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -280,7 +283,7 @@ class _PromptPreviewDialog extends StatelessWidget {
         children: [
           Text(
             formatRelativeTime(l10n, entry.usedAt),
-            style: TextStyle(fontSize: 11, color: colorScheme.outline),
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
           ),
           const SizedBox(height: 12),
           // Caps the prompt body only — the warning line below it has to stay
@@ -297,7 +300,7 @@ class _PromptPreviewDialog extends StatelessWidget {
               child: SingleChildScrollView(
                 child: SelectableText(
                   entry.content,
-                  style: const TextStyle(fontSize: 13),
+                  style: Theme.of(context).textTheme.bodyMedium,
                 ),
               ),
             ),
@@ -305,7 +308,7 @@ class _PromptPreviewDialog extends StatelessWidget {
           const SizedBox(height: 10),
           Text(
             l10n.applyPromptWarning,
-            style: TextStyle(fontSize: 11, color: colorScheme.outline),
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
           ),
         ],
       ),

--- a/lib/widgets/dialogs/task_log_dialog.dart
+++ b/lib/widgets/dialogs/task_log_dialog.dart
@@ -181,13 +181,12 @@ class _TaskLogDialogState extends State<TaskLogDialog> {
       padding: const EdgeInsets.symmetric(vertical: 1),
       child: Text(
         line,
-        style: TextStyle(
-          fontFamily: 'monospace',
-          fontSize: 11,
-          height: 1.45,
-          color: color,
-          fontWeight: isError ? FontWeight.w600 : FontWeight.normal,
-        ),
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              fontFamily: 'monospace',
+              height: 1.45,
+              color: color,
+              fontWeight: isError ? FontWeight.w600 : FontWeight.normal,
+            ),
       ),
     );
   }
@@ -207,13 +206,16 @@ class _TaskLogDialogState extends State<TaskLogDialog> {
           const SizedBox(height: 10),
           Text(
             l10n.noTaskLog,
-            style: TextStyle(fontSize: 13, color: colorScheme.onSurfaceVariant),
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 4),
           Text(
             l10n.noTaskLogHint,
-            style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant.withAlpha(170)),
+            style: Theme.of(context)
+                .textTheme
+                .labelMedium
+                ?.copyWith(color: colorScheme.onSurfaceVariant.withAlpha(170)),
             textAlign: TextAlign.center,
           ),
         ],

--- a/lib/widgets/log_console.dart
+++ b/lib/widgets/log_console.dart
@@ -105,10 +105,11 @@ class _LogConsoleWidgetState extends State<LogConsoleWidget> {
                 child: TextField(
                   controller: _searchController,
                   autofocus: true,
-                  style: TextStyle(color: colorScheme.onSurface, fontSize: 12),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
                   decoration: InputDecoration(
                     hintText: 'Filter logs...',
-                    hintStyle: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
+                    hintStyle:
+                        Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
                     prefixIcon: Icon(Icons.search, size: 14, color: colorScheme.onSurfaceVariant),
                     suffixIcon: IconButton(
                       icon: Icon(Icons.close, size: 14, color: colorScheme.onSurfaceVariant),
@@ -170,7 +171,11 @@ class _LogConsoleWidgetState extends State<LogConsoleWidget> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 2),
       child: ActionChip(
-        label: Text(label, style: TextStyle(fontSize: 9, fontWeight: FontWeight.bold, color: color)),
+        label: Text(label,
+            style: Theme.of(context)
+                .textTheme
+                .labelSmall
+                ?.copyWith(fontWeight: FontWeight.bold, color: color)),
         backgroundColor: isSelected ? color.withAlpha(100) : Colors.transparent,
         side: BorderSide(color: color.withAlpha(isSelected ? 255 : 100)),
         padding: EdgeInsets.zero,
@@ -197,7 +202,10 @@ class _LogLine extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 1),
       child: RichText(
         text: TextSpan(
-          style: const TextStyle(fontFamily: 'monospace', fontSize: 11, height: 1.4),
+          style: Theme.of(context)
+              .textTheme
+              .labelMedium
+              ?.copyWith(fontFamily: 'monospace', height: 1.4),
           children: [
             TextSpan(
               text: '[${log.timestamp.toIso8601String().split('T').last.substring(0, 8)}] ',

--- a/lib/widgets/markdown_editor.dart
+++ b/lib/widgets/markdown_editor.dart
@@ -212,14 +212,14 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
                   }
                 },
               ),
-              const Text(
+              Text(
                 "Markdown",
-                style: TextStyle(fontSize: 12),
+                style: Theme.of(context).textTheme.bodySmall,
               ),
             ] else
               Text(
                 widget.label,
-                style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
               ),
           ],
         ),
@@ -317,7 +317,7 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
                       Expanded(
                         child: Text(
                           widget.label,
-                          style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),
@@ -423,7 +423,7 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
             fillColor: widget.isRefined ? Colors.grey.withValues(alpha: 0.05) : null,
             filled: widget.isRefined,
           ),
-          style: const TextStyle(fontSize: 13),
+          style: Theme.of(context).textTheme.bodyMedium,
           strutStyle: const StrutStyle(
             fontSize: 13,
             height: 1.5,

--- a/lib/widgets/models/channel_edit_dialog.dart
+++ b/lib/widgets/models/channel_edit_dialog.dart
@@ -245,12 +245,12 @@ class _ChannelEditDialogState extends State<ChannelEditDialog> {
           ),
           // The style applies to the popup menu items too — it must carry an
           // explicit color or the items render with the wrong default.
-          style: TextStyle(fontSize: 14, color: colorScheme.onSurface),
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(color: colorScheme.onSurface),
         ),
         const SizedBox(height: 12),
         TextField(
           controller: epCtrl,
-          style: const TextStyle(fontSize: 14),
+          style: Theme.of(context).textTheme.titleMedium,
           decoration: InputDecoration(
             labelText: l10n.endpointUrl,
             isDense: true,
@@ -258,7 +258,7 @@ class _ChannelEditDialogState extends State<ChannelEditDialog> {
             prefixIcon: const Icon(Icons.link, size: 20),
             helperText: endpointHint,
             helperMaxLines: 3,
-            helperStyle: TextStyle(color: colorScheme.outline, fontSize: 11),
+            helperStyle: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.outline),
           ),
         ),
         const SizedBox(height: 12),
@@ -269,10 +269,10 @@ class _ChannelEditDialogState extends State<ChannelEditDialog> {
         ),
         const SizedBox(height: 4),
         SwitchListTile(
-          title: Text(l10n.enableDiscovery, style: const TextStyle(fontSize: 14)),
+          title: Text(l10n.enableDiscovery, style: Theme.of(context).textTheme.titleMedium),
           subtitle: Text(
             l10n.enableDiscoveryDesc,
-            style: TextStyle(fontSize: 12, color: colorScheme.outline),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.outline),
           ),
           value: discovery,
           onChanged: (v) => setState(() => discovery = v),

--- a/lib/widgets/models/channel_edit_dialog.dart
+++ b/lib/widgets/models/channel_edit_dialog.dart
@@ -99,10 +99,10 @@ class _ChannelEditDialogState extends State<ChannelEditDialog> {
             onPressed: () => Navigator.pop(context),
           ),
           actions: [
-            TextButton(
+            AppButton(
+              label: l10n.save,
+              variant: AppButtonVariant.text,
               onPressed: _save,
-              child: Text(l10n.save,
-                  style: const TextStyle(fontWeight: FontWeight.bold)),
             ),
           ],
         ),

--- a/lib/widgets/models/channel_form_sections.dart
+++ b/lib/widgets/models/channel_form_sections.dart
@@ -16,11 +16,10 @@ class ChannelSectionLabel extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 10),
       child: Text(
         text,
-        style: TextStyle(
-          fontSize: 12,
-          fontWeight: FontWeight.bold,
-          color: Theme.of(context).colorScheme.primary,
-        ),
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.primary,
+            ),
       ),
     );
   }
@@ -74,11 +73,10 @@ class ChannelAppearanceSection extends StatelessWidget {
         const SizedBox(height: 14),
         Text(
           l10n.tagColor,
-          style: TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.bold,
-            color: colorScheme.outline,
-          ),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: colorScheme.outline,
+              ),
         ),
         const SizedBox(height: 8),
         CompactColorPicker(
@@ -181,8 +179,10 @@ class _CompactColorPickerState extends State<CompactColorPicker> {
                   ),
                   const SizedBox(width: 6),
                   Text(_hex,
-                      style: TextStyle(
-                          fontSize: 12, color: colorScheme.onSurfaceVariant)),
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(color: colorScheme.onSurfaceVariant)),
                 ],
               ),
             ),
@@ -192,8 +192,13 @@ class _CompactColorPickerState extends State<CompactColorPicker> {
               label: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  // The button's own foreground colour, carried explicitly: it
+                  // used to arrive by inheritance, which a scale slot replaces.
                   Text(widget.l10n.moreColors,
-                      style: const TextStyle(fontSize: 12)),
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(color: colorScheme.onSurfaceVariant)),
                   Icon(
                     _expanded ? Icons.expand_less : Icons.expand_more,
                     size: 16,

--- a/lib/widgets/models/channel_wizard_dialog.dart
+++ b/lib/widgets/models/channel_wizard_dialog.dart
@@ -433,11 +433,10 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
       padding: const EdgeInsets.only(bottom: 8),
       child: Text(
         text,
-        style: TextStyle(
-          fontSize: 12,
-          fontWeight: FontWeight.bold,
-          color: Theme.of(context).colorScheme.outline,
-        ),
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.outline,
+            ),
       ),
     );
   }
@@ -467,6 +466,7 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
 
   Widget _buildProviderCard(AppLocalizations l10n, _ProviderPreset preset) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final isSelected = _selectedProviderId == preset.id;
 
     return InkWell(
@@ -503,15 +503,15 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
                     _providerTitle(l10n, preset.id),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                        fontWeight: FontWeight.bold, fontSize: 13),
+                    style: textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.bold),
                   ),
                   Text(
                     _providerSubtitle(l10n, preset),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style:
-                        TextStyle(fontSize: 11, color: colorScheme.outline),
+                    style: textTheme.labelMedium
+                        ?.copyWith(color: colorScheme.outline),
                   ),
                 ],
               ),
@@ -530,6 +530,7 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
 
   Widget _buildConnectionStep(AppLocalizations l10n) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final preset = _preset;
     final isNewApi = preset.endpointSuffix.isNotEmpty;
     final isCustom = preset.id == 'custom';
@@ -552,8 +553,7 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
               const SizedBox(width: 8),
               Text(
                 _providerTitle(l10n, preset.id),
-                style:
-                    const TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
+                style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
               ),
               const Spacer(),
               if (preset.fixedEndpoint != null)
@@ -562,8 +562,8 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
                     preset.fixedEndpoint!,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style:
-                        TextStyle(fontSize: 11, color: colorScheme.outline),
+                    style: textTheme.labelMedium
+                        ?.copyWith(color: colorScheme.outline),
                   ),
                 ),
             ],
@@ -573,8 +573,7 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
 
         if (isCustom) ...[
           Text(l10n.channelType,
-              style:
-                  const TextStyle(fontSize: 13, fontWeight: FontWeight.bold)),
+              style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
           AppSegmentedControl<String>(
             segments: [
@@ -620,14 +619,14 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
         const SizedBox(height: 8),
         Text(
           l10n.apiKeyStorageNotice,
-          style: TextStyle(fontSize: 12, color: colorScheme.outline),
+          style: textTheme.bodySmall?.copyWith(color: colorScheme.outline),
         ),
         const SizedBox(height: 8),
         SwitchListTile(
-          title: Text(l10n.enableDiscovery, style: const TextStyle(fontSize: 14)),
+          title: Text(l10n.enableDiscovery, style: textTheme.titleMedium),
           subtitle: Text(
             l10n.enableDiscoveryDesc,
-            style: TextStyle(fontSize: 12, color: colorScheme.outline),
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.outline),
           ),
           value: _enableDiscovery,
           onChanged: (v) => setState(() => _enableDiscovery = v),
@@ -686,13 +685,14 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
 
   Widget _buildSummaryRow(String label, String value) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 3),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(label,
-              style: TextStyle(fontSize: 12, color: colorScheme.outline)),
+              style: textTheme.bodySmall?.copyWith(color: colorScheme.outline)),
           const SizedBox(width: 16),
           Expanded(
             child: Text(
@@ -700,8 +700,7 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
               textAlign: TextAlign.right,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style:
-                  const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+              style: textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
             ),
           ),
         ],

--- a/lib/widgets/models/channel_wizard_dialog.dart
+++ b/lib/widgets/models/channel_wizard_dialog.dart
@@ -318,14 +318,18 @@ class _ChannelWizardDialogState extends State<ChannelWizardDialog> {
                     _buildStepDots(),
                     const Spacer(),
                     if (_currentStep > 0) ...[
-                      OutlinedButton(onPressed: _back, child: Text(l10n.back)),
+                      AppButton(
+                        label: l10n.back,
+                        variant: AppButtonVariant.secondary,
+                        onPressed: _back,
+                      ),
                       const SizedBox(width: 12),
                     ],
-                    FilledButton(
-                      onPressed: _isNextEnabled() ? _next : null,
-                      child: Text(_currentStep == _totalSteps - 1
+                    AppButton(
+                      label: _currentStep == _totalSteps - 1
                           ? l10n.finish
-                          : l10n.next),
+                          : l10n.next,
+                      onPressed: _isNextEnabled() ? _next : null,
                     ),
                   ],
                 ),

--- a/lib/widgets/models/discovery_dialog.dart
+++ b/lib/widgets/models/discovery_dialog.dart
@@ -230,7 +230,8 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
             padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
             child: Row(
               children: [
-                Text(l10n.modelsDiscovered(_filtered.length), style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+                Text(l10n.modelsDiscovered(_filtered.length),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold)),
                 const Spacer(),
                 if (available.isNotEmpty)
                   AppButton(
@@ -261,7 +262,9 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
 
   Widget _buildModelCard(DiscoveredModel m, bool isAdded, bool isSelected) {
     final colorScheme = Theme.of(context).colorScheme;
-    
+    final textTheme = Theme.of(context).textTheme;
+
+
     return Card(
       elevation: 0,
       margin: const EdgeInsets.only(bottom: 8),
@@ -313,13 +316,15 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(m.displayName, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14)),
-                    Text(m.modelId, style: TextStyle(fontSize: 11, color: colorScheme.outline)),
+                    Text(m.displayName, style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
+                    Text(m.modelId, style: textTheme.labelMedium?.copyWith(color: colorScheme.outline)),
                   ],
                 ),
               ),
               if (isAdded)
-                Text(widget.l10n.alreadyAdded, style: TextStyle(color: colorScheme.outline, fontSize: 10, fontWeight: FontWeight.bold))
+                Text(widget.l10n.alreadyAdded,
+                    style: textTheme.labelSmall
+                        ?.copyWith(color: colorScheme.outline, fontWeight: FontWeight.bold))
               else
                 _buildTagChip(_inferTag(m)),
             ],
@@ -344,7 +349,11 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
         color: color.withAlpha(30),
         borderRadius: BorderRadius.circular(6),
       ),
-      child: Text(tag.toUpperCase(), style: TextStyle(fontSize: 9, color: color, fontWeight: FontWeight.bold)),
+      child: Text(tag.toUpperCase(),
+          style: Theme.of(context)
+              .textTheme
+              .labelSmall
+              ?.copyWith(color: color, fontWeight: FontWeight.bold)),
     );
   }
 
@@ -365,9 +374,14 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
           children: [
             Icon(icon, size: 64, color: color.withAlpha(150)),
             const SizedBox(height: 24),
-            Text(title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+            Text(title, style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
-            Text(subtitle, textAlign: TextAlign.center, style: TextStyle(color: Theme.of(context).colorScheme.outline, fontSize: 13)),
+            Text(subtitle,
+                textAlign: TextAlign.center,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: Theme.of(context).colorScheme.outline)),
             if (action != null) ...[
               const SizedBox(height: 24),
               action,

--- a/lib/widgets/models/discovery_dialog.dart
+++ b/lib/widgets/models/discovery_dialog.dart
@@ -203,10 +203,10 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
         color: Theme.of(context).colorScheme.error,
         title: "Connection Failed",
         subtitle: l10n.fetchFailed(_error!),
-        action: FilledButton(onPressed: () {
+        action: AppButton(label: "Retry", onPressed: () {
           setState(() { _isLoading = true; _error = null; });
           _fetch();
-        }, child: const Text("Retry")),
+        }),
       );
     }
 
@@ -233,10 +233,11 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
                 Text(l10n.modelsDiscovered(_filtered.length), style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
                 const Spacer(),
                 if (available.isNotEmpty)
-                  TextButton.icon(
+                  AppButton(
+                    label: _selectedIds.length == available.length ? l10n.deselectAll : l10n.selectAll,
+                    icon: _selectedIds.length == available.length ? Icons.deselect : Icons.select_all,
+                    variant: AppButtonVariant.text,
                     onPressed: _toggleSelectAll,
-                    icon: Icon(_selectedIds.length == available.length ? Icons.deselect : Icons.select_all, size: 16),
-                    label: Text(_selectedIds.length == available.length ? l10n.deselectAll : l10n.selectAll, style: const TextStyle(fontSize: 12)),
                   ),
               ],
             ),

--- a/lib/widgets/models/model_edit_dialog.dart
+++ b/lib/widgets/models/model_edit_dialog.dart
@@ -201,6 +201,7 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
   Widget _buildForm(ColorScheme colorScheme, {required bool twoColumn}) {
     final l10n = widget.l10n;
     final appState = widget.appState;
+    final textTheme = Theme.of(context).textTheme;
 
     final nameField = TextField(
       controller: nameCtrl,
@@ -267,8 +268,7 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
                 selected: tag == value,
                 onSelected: (_) => setState(() => tag = value),
                 label: Text(label),
-                labelStyle: TextStyle(
-                  fontSize: 12,
+                labelStyle: textTheme.bodySmall?.copyWith(
                   fontWeight: FontWeight.w600,
                   color: tag == value ? color : colorScheme.onSurfaceVariant,
                 ),
@@ -314,11 +314,12 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
               children: [
                 Icon(Icons.memory_outlined, size: 18, color: colorScheme.outline),
                 const SizedBox(width: 8),
-                Text(l10n.contextMax, style: const TextStyle(fontSize: 13)),
+                Text(l10n.contextMax, style: textTheme.bodyMedium),
                 const Spacer(),
                 Text(
                   l10n.contextTokens(_formatTokens(_contextSizes[contextSizeIdx.round()])),
-                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.bold, color: colorScheme.primary),
+                  style: textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold, color: colorScheme.primary),
                 ),
               ],
             ),
@@ -340,7 +341,7 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
               ContextWindowMode.specified => l10n.contextWindowHint,
               ContextWindowMode.unlimited => l10n.contextUnlimitedDesc,
             },
-            style: TextStyle(color: colorScheme.outline, fontSize: 11),
+            style: textTheme.labelMedium?.copyWith(color: colorScheme.outline),
           ),
         ),
 
@@ -348,16 +349,20 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
         _sectionHeader(l10n.capabilities),
         const SizedBox(height: 4),
         SwitchListTile(
-          title: Text(l10n.supportsStreaming, style: const TextStyle(fontSize: 13)),
-          subtitle: Text(l10n.supportsStreamingDesc, style: const TextStyle(fontSize: 11)),
+          title: Text(l10n.supportsStreaming, style: textTheme.bodyMedium),
+          // The muted tone is spelled out because it used to be inherited from
+          // ListTile's own subtitle style, which a scale slot overrides.
+          subtitle: Text(l10n.supportsStreamingDesc,
+              style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant)),
           value: supportsStream,
           onChanged: (v) => setState(() => supportsStream = v),
           secondary: const Icon(Icons.stream),
           contentPadding: EdgeInsets.zero,
         ),
         SwitchListTile(
-          title: Text(l10n.supportsStandardRequest, style: const TextStyle(fontSize: 13)),
-          subtitle: Text(l10n.supportsStandardRequestDesc, style: const TextStyle(fontSize: 11)),
+          title: Text(l10n.supportsStandardRequest, style: textTheme.bodyMedium),
+          subtitle: Text(l10n.supportsStandardRequestDesc,
+              style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant)),
           value: supportsStandard,
           onChanged: (v) => setState(() => supportsStandard = v),
           secondary: const Icon(Icons.http),
@@ -368,8 +373,9 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
         _sectionHeader(l10n.agentBehavior),
         const SizedBox(height: 4),
         SwitchListTile(
-          title: Text(l10n.forceViewAllImages, style: const TextStyle(fontSize: 13)),
-          subtitle: Text(l10n.forceViewAllImagesDesc, style: const TextStyle(fontSize: 11)),
+          title: Text(l10n.forceViewAllImages, style: textTheme.bodyMedium),
+          subtitle: Text(l10n.forceViewAllImagesDesc,
+              style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant)),
           value: forceViewAllImages,
           onChanged: (v) => setState(() => forceViewAllImages = v),
           secondary: const Icon(Icons.visibility_outlined),
@@ -432,12 +438,11 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
       children: [
         Text(
           title.toUpperCase(),
-          style: TextStyle(
-            fontSize: 11,
-            fontWeight: FontWeight.bold,
-            color: Theme.of(context).colorScheme.primary,
-            letterSpacing: 1.2,
-          ),
+          style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.primary,
+                letterSpacing: 1.2,
+              ),
         ),
         const SizedBox(height: 4),
         const Divider(height: 1),

--- a/lib/widgets/placeholders/permission_placeholder.dart
+++ b/lib/widgets/placeholders/permission_placeholder.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../services/file_permission_service.dart';
+import '../app_button.dart';
 
 class PermissionPlaceholder extends StatelessWidget {
   final VoidCallback onReAuthorize;
@@ -44,10 +45,10 @@ class PermissionPlaceholder extends StatelessWidget {
               style: const TextStyle(fontSize: 13, color: Colors.grey),
             ),
             const SizedBox(height: 24),
-            FilledButton.icon(
+            AppButton(
+              label: service.getReAuthorizeButtonLabel(),
+              icon: Icons.folder_open,
               onPressed: onReAuthorize,
-              icon: const Icon(Icons.folder_open),
-              label: Text(service.getReAuthorizeButtonLabel()),
             ),
           ],
         ),

--- a/lib/widgets/placeholders/permission_placeholder.dart
+++ b/lib/widgets/placeholders/permission_placeholder.dart
@@ -32,17 +32,16 @@ class PermissionPlaceholder extends StatelessWidget {
             const SizedBox(height: 16),
             Text(
               service.getPermissionErrorMessage(),
-              style: TextStyle(
-                color: colorScheme.error,
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: colorScheme.error,
+                    fontWeight: FontWeight.bold,
+                  ),
             ),
             const SizedBox(height: 12),
             Text(
               customMessage ?? service.getPermissionInstructions(),
               textAlign: TextAlign.center,
-              style: const TextStyle(fontSize: 13, color: Colors.grey),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey),
             ),
             const SizedBox(height: 24),
             AppButton(

--- a/lib/widgets/pricing_group_manager.dart
+++ b/lib/widgets/pricing_group_manager.dart
@@ -90,10 +90,10 @@ class PricingGroupManager extends StatelessWidget {
                       ],
                     ),
                     const Spacer(),
-                    FilledButton.icon(
+                    AppButton(
+                      label: l10n.addFeeGroup,
+                      icon: Icons.add,
                       onPressed: () => _showGroupEditor(context, appState, l10n),
-                      icon: const Icon(Icons.add),
-                      label: Text(l10n.addFeeGroup),
                     ),
                   ],
                 ),
@@ -136,10 +136,10 @@ class PricingGroupManager extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 12),
-            FilledButton.icon(
+            AppButton(
+              label: l10n.addFeeGroup,
+              icon: Icons.add,
               onPressed: () => _showGroupEditor(context, appState, l10n),
-              icon: const Icon(Icons.add, size: 18),
-              label: Text(l10n.addFeeGroup),
             ),
           ],
         ),
@@ -218,10 +218,10 @@ class PricingGroupManager extends StatelessWidget {
             const SizedBox(height: 8),
             Text(l10n.feeGroupDesc, textAlign: TextAlign.center, style: TextStyle(color: Theme.of(context).colorScheme.outline)),
             const SizedBox(height: 32),
-            FilledButton.icon(
+            AppButton(
+              label: l10n.addFeeGroup,
+              icon: Icons.add,
               onPressed: () => _showGroupEditor(context, appState, l10n),
-              icon: const Icon(Icons.add),
-              label: Text(l10n.addFeeGroup),
             ),
           ],
         ),
@@ -948,29 +948,32 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
         children: [
           if (widget.isMobile) ...[
             Expanded(
-              child: TextButton(
+              child: AppButton(
+                label: l10n.cancel,
+                variant: AppButtonVariant.text,
+                size: AppButtonSize.large,
+                fullWidth: true,
                 onPressed: () => Navigator.pop(context),
-                style: TextButton.styleFrom(minimumSize: const Size.fromHeight(48)),
-                child: Text(l10n.cancel),
               ),
             ),
             const SizedBox(width: 8),
             Expanded(
-              child: FilledButton.icon(
+              child: AppButton(
+                label: saveLabel,
+                icon: Icons.save,
+                size: AppButtonSize.large,
+                fullWidth: true,
                 onPressed: _save,
-                style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
-                icon: const Icon(Icons.save, size: 18),
-                label: Text(saveLabel),
               ),
             ),
           ] else ...[
-            TextButton(onPressed: () => Navigator.pop(context), child: Text(l10n.cancel)),
-            const SizedBox(width: 8),
-            FilledButton.icon(
-              onPressed: _save,
-              icon: const Icon(Icons.save, size: 18),
-              label: Text(saveLabel),
+            AppButton(
+              label: l10n.cancel,
+              variant: AppButtonVariant.text,
+              onPressed: () => Navigator.pop(context),
             ),
+            const SizedBox(width: 8),
+            AppButton(label: saveLabel, icon: Icons.save, onPressed: _save),
           ],
         ],
       ),

--- a/lib/widgets/pricing_group_manager.dart
+++ b/lib/widgets/pricing_group_manager.dart
@@ -85,7 +85,10 @@ class PricingGroupManager extends StatelessWidget {
                         ),
                         Text(
                           l10n.feeGroupDesc,
-                          style: TextStyle(color: Theme.of(context).colorScheme.outline, fontSize: 13),
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyMedium
+                              ?.copyWith(color: Theme.of(context).colorScheme.outline),
                         ),
                       ],
                     ),
@@ -125,12 +128,15 @@ class PricingGroupManager extends StatelessWidget {
                   // and it is what the button on the right adds to.
                   Text(
                     l10n.feeGroups,
-                    style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w700),
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
                   ),
                   const SizedBox(height: 3),
                   Text(
                     l10n.feeGroupDesc,
-                    style: TextStyle(color: Theme.of(context).colorScheme.outline, fontSize: 12),
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Theme.of(context).colorScheme.outline),
                   ),
                 ],
               ),
@@ -214,7 +220,8 @@ class PricingGroupManager extends StatelessWidget {
               child: Icon(Icons.monetization_on_outlined, size: 64, color: Theme.of(context).colorScheme.primary.withAlpha(150)),
             ),
             const SizedBox(height: 24),
-            Text(l10n.noFeeGroups, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            Text(l10n.noFeeGroups,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),
             const SizedBox(height: 8),
             Text(l10n.feeGroupDesc, textAlign: TextAlign.center, style: TextStyle(color: Theme.of(context).colorScheme.outline)),
             const SizedBox(height: 32),
@@ -359,6 +366,8 @@ class _GroupCardState extends State<_GroupCard> {
   }
 
   Widget _buildIdentity(ColorScheme colorScheme, AppLocalizations l10n, Color accent) {
+    final textTheme = Theme.of(context).textTheme;
+
     return Row(
       children: [
         Container(
@@ -378,7 +387,7 @@ class _GroupCardState extends State<_GroupCard> {
             children: [
               Text(
                 widget.group.name,
-                style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 14),
+                style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -390,7 +399,7 @@ class _GroupCardState extends State<_GroupCard> {
                   Flexible(
                     child: Text(
                       l10n.feeGroupModelCount(widget.models.length),
-                      style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+                      style: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
@@ -430,13 +439,18 @@ class _GroupCardState extends State<_GroupCard> {
       ),
       child: Text(
         _isToken ? l10n.tokenBilling : l10n.requestBilling,
-        style: TextStyle(fontSize: 10, fontWeight: FontWeight.w700, color: accent),
+        style: Theme.of(context)
+            .textTheme
+            .labelSmall
+            ?.copyWith(fontWeight: FontWeight.w700, color: accent),
       ),
     );
   }
 
   /// The models this group bills.
   Widget _buildConsumers(ColorScheme colorScheme, AppLocalizations l10n) {
+    final textTheme = Theme.of(context).textTheme;
+
     if (widget.models.isEmpty) {
       // Worth saying out loud: an orphaned group prices nothing, and nothing
       // else on this screen would ever tell you.
@@ -447,8 +461,7 @@ class _GroupCardState extends State<_GroupCard> {
           Flexible(
             child: Text(
               l10n.feeGroupUnused,
-              style: TextStyle(
-                fontSize: 11,
+              style: textTheme.labelMedium?.copyWith(
                 color: colorScheme.outline,
                 fontStyle: FontStyle.italic,
               ),
@@ -463,7 +476,7 @@ class _GroupCardState extends State<_GroupCard> {
       message: widget.models.join('\n'),
       child: Text(
         widget.models.join(', '),
-        style: TextStyle(fontSize: 11, fontFamily: 'monospace', color: colorScheme.outline),
+        style: textTheme.labelMedium?.copyWith(fontFamily: 'monospace', color: colorScheme.outline),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
@@ -478,7 +491,7 @@ class _GroupCardState extends State<_GroupCard> {
         children: [
           Text(
             l10n.priceLabelRequest,
-            style: TextStyle(fontSize: 11, color: colorScheme.onSurfaceVariant),
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
           ),
           const Spacer(),
           _priceValue(colorScheme, group.requestPrice, unit: 'Req', large: true),
@@ -519,7 +532,7 @@ class _GroupCardState extends State<_GroupCard> {
       children: [
         Text(
           label,
-          style: TextStyle(fontSize: 10.5, color: colorScheme.onSurfaceVariant),
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.onSurfaceVariant),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
@@ -538,6 +551,8 @@ class _GroupCardState extends State<_GroupCard> {
     bool large = false,
     bool inherited = false,
   }) {
+    final textTheme = Theme.of(context).textTheme;
+
     return FittedBox(
       fit: BoxFit.scaleDown,
       alignment: Alignment.centerLeft,
@@ -553,17 +568,19 @@ class _GroupCardState extends State<_GroupCard> {
             // number alone cannot say which it is.
             TextSpan(
               text: '/$unit',
-              style: TextStyle(
-                fontSize: large ? 10 : 9,
+              style: textTheme.labelSmall?.copyWith(
                 fontWeight: FontWeight.w600,
+                // Spelled out even though the Text's own style below sets it:
+                // a scale slot carries the app font, which would otherwise
+                // replace the monospace this span used to inherit.
+                fontFamily: 'monospace',
                 color: colorScheme.onSurfaceVariant,
               ),
             ),
           ],
         ),
         maxLines: 1,
-        style: TextStyle(
-          fontSize: large ? 16 : 12.5,
+        style: (large ? textTheme.titleLarge : textTheme.bodySmall)?.copyWith(
           fontWeight: FontWeight.w700,
           fontFamily: 'monospace',
           fontStyle: inherited ? FontStyle.italic : FontStyle.normal,
@@ -877,11 +894,12 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
     String? helperText,
   }) {
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     return TextField(
       controller: ctrl,
       keyboardType: const TextInputType.numberWithOptions(decimal: true),
-      style: const TextStyle(fontFamily: 'monospace', fontWeight: FontWeight.w700, fontSize: 17),
+      style: textTheme.titleLarge?.copyWith(fontFamily: 'monospace', fontWeight: FontWeight.w700),
       onChanged: (_) {
         if (_invalidFields.remove(ctrl)) setState(() {});
       },
@@ -894,26 +912,26 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
         border: _fieldBorder(colorScheme),
         enabledBorder: _fieldBorder(colorScheme),
         focusedBorder: _fieldBorder(colorScheme, color: accent, width: 2),
-        labelStyle: TextStyle(color: accent, fontWeight: FontWeight.w700, fontSize: 15),
-        floatingLabelStyle: TextStyle(color: accent, fontWeight: FontWeight.w700, fontSize: 15),
+        labelStyle: textTheme.titleMedium?.copyWith(color: accent, fontWeight: FontWeight.w700),
+        floatingLabelStyle: textTheme.titleMedium?.copyWith(color: accent, fontWeight: FontWeight.w700),
         prefixIcon: Icon(icon, size: 19, color: accent),
         prefixIconConstraints: const BoxConstraints(minWidth: 42, minHeight: 42),
         hintText: hintText,
-        hintStyle: TextStyle(
+        hintStyle: textTheme.titleMedium?.copyWith(
           fontFamily: 'monospace',
           fontStyle: FontStyle.italic,
           fontWeight: FontWeight.w400,
-          fontSize: 14,
           color: colorScheme.outline,
         ),
         helperText: helperText,
         helperMaxLines: 2,
-        helperStyle: TextStyle(fontSize: 11.5, color: colorScheme.onSurfaceVariant),
+        helperStyle: textTheme.labelMedium?.copyWith(color: colorScheme.onSurfaceVariant),
         errorText: _invalidFields.contains(ctrl)
             ? AppLocalizations.of(context)!.invalidPriceValue
             : null,
         suffixText: suffix,
-        suffixStyle: TextStyle(fontSize: 12, fontWeight: FontWeight.w700, color: colorScheme.onSurfaceVariant),
+        suffixStyle:
+            textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w700, color: colorScheme.onSurfaceVariant),
         contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 18),
       ),
     );
@@ -924,11 +942,10 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
   Widget _sectionHeader(String title) {
     return Text(
       title,
-      style: TextStyle(
-        fontSize: 13,
-        fontWeight: FontWeight.w700,
-        color: Theme.of(context).colorScheme.primary,
-      ),
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: Theme.of(context).colorScheme.primary,
+          ),
     );
   }
 

--- a/lib/widgets/prompt_card.dart
+++ b/lib/widgets/prompt_card.dart
@@ -67,7 +67,7 @@ class PromptCard extends StatelessWidget {
                 children: [
                   _buildHeader(context, colorScheme),
                   if (isExpanded) _buildExpandedContent(context, colorScheme)
-                  else _buildCollapsedContent(colorScheme),
+                  else _buildCollapsedContent(context, colorScheme),
                 ],
               ),
             ),
@@ -101,16 +101,15 @@ class PromptCard extends StatelessWidget {
             Expanded(
               child: Text(
                 prompt.title,
-                style: TextStyle(
-                  fontWeight: isExpanded ? FontWeight.bold : FontWeight.w600,
-                  fontSize: 14,
-                  color: isExpanded ? colorScheme.primary : colorScheme.onSurface,
-                ),
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: isExpanded ? FontWeight.bold : FontWeight.w600,
+                      color: isExpanded ? colorScheme.primary : colorScheme.onSurface,
+                    ),
                 overflow: TextOverflow.ellipsis,
               ),
             ),
             if (showCategory) ...[
-              _buildTagsList(),
+              _buildTagsList(context),
               const SizedBox(width: 8),
             ],
 
@@ -151,7 +150,7 @@ class PromptCard extends StatelessWidget {
     );
   }
 
-  Widget _buildTagsList() {
+  Widget _buildTagsList(BuildContext context) {
     final displayTags = prompt.tags.isEmpty 
         ? [null] 
         : prompt.tags;
@@ -161,6 +160,7 @@ class PromptCard extends StatelessWidget {
       runSpacing: 4,
       alignment: WrapAlignment.end,
       children: displayTags.map((t) => _buildCategoryTag(
+            context,
         t?.name ?? 'General',
         t?.color,
       )).toList(),
@@ -186,11 +186,10 @@ class PromptCard extends StatelessWidget {
                     child: MarkdownBody(
                       data: prompt.content,
                       styleSheet: MarkdownStyleSheet(
-                        p: TextStyle(
-                          fontSize: 13, 
-                          height: 1.6, 
-                          color: colorScheme.onSurface.withAlpha(230)
-                        ),
+                        p: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              height: 1.6,
+                              color: colorScheme.onSurface.withAlpha(230),
+                            ),
                         code: TextStyle(
                           backgroundColor: colorScheme.surfaceContainerHighest,
                           fontFamily: 'monospace',
@@ -201,11 +200,10 @@ class PromptCard extends StatelessWidget {
                 : SelectionArea(
                     child: Text(
                       prompt.content,
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: colorScheme.onSurfaceVariant,
-                        height: 1.5,
-                      ),
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                            height: 1.5,
+                          ),
                     ),
                   ),
           ),
@@ -214,22 +212,19 @@ class PromptCard extends StatelessWidget {
     );
   }
 
-  Widget _buildCollapsedContent(ColorScheme colorScheme) {
+  Widget _buildCollapsedContent(BuildContext context, ColorScheme colorScheme) {
     return Padding(
       padding: const EdgeInsets.only(left: 40.0, bottom: 12, right: 16),
       child: Text(
         prompt.content.toString().replaceAll('\n', ' '),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
-        style: TextStyle(
-          fontSize: 12,
-          color: colorScheme.outline,
-        ),
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.outline),
       ),
     );
   }
 
-  Widget _buildCategoryTag(String tag, int? tagColor) {
+  Widget _buildCategoryTag(BuildContext context, String tag, int? tagColor) {
     final color = tagColor != null ? Color(tagColor) : Colors.blueGrey;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
@@ -240,12 +235,11 @@ class PromptCard extends StatelessWidget {
       ),
       child: Text(
         tag,
-        style: TextStyle(
-          fontSize: 10, 
-          fontWeight: FontWeight.bold, 
-          color: color.withAlpha(220),
-          letterSpacing: 0.5,
-        ),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: color.withAlpha(220),
+              letterSpacing: 0.5,
+            ),
       ),
     );
   }

--- a/lib/widgets/settings_widgets.dart
+++ b/lib/widgets/settings_widgets.dart
@@ -24,7 +24,8 @@ class ThemeSelector extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(l10n.appearance, style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 14)),
+        Text(l10n.appearance,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w500)),
         const SizedBox(height: 12),
         ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 500),
@@ -62,7 +63,8 @@ class ThemeColorSelector extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text("Theme Color", style: TextStyle(fontWeight: FontWeight.w500, fontSize: 14)),
+        Text("Theme Color",
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w500)),
         const SizedBox(height: 12),
         Wrap(
           spacing: 12,
@@ -132,7 +134,7 @@ class LanguageSelector extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(l10n.language,
-            style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 14)),
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w500)),
         const SizedBox(height: 16),
         LayoutBuilder(
           builder: (context, constraints) {
@@ -201,7 +203,7 @@ class FontSelector extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(l10n.font,
-            style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 14)),
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w500)),
         const SizedBox(height: 16),
         LayoutBuilder(
           builder: (context, constraints) {
@@ -394,14 +396,13 @@ class _LanguageCard extends StatelessWidget {
             Expanded(
               child: Text(
                 label,
-                style: TextStyle(
-                  fontFamily: fontFamily,
-                  fontSize: 14,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
-                  color: isSelected
-                      ? colorScheme.onPrimaryContainer
-                      : colorScheme.onSurface,
-                ),
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontFamily: fontFamily,
+                      fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                      color: isSelected
+                          ? colorScheme.onPrimaryContainer
+                          : colorScheme.onSurface,
+                    ),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/lib/widgets/task_capsule_monitor.dart
+++ b/lib/widgets/task_capsule_monitor.dart
@@ -7,6 +7,7 @@ import '../core/responsive.dart';
 import '../l10n/app_localizations.dart';
 import '../services/task_queue_service.dart';
 import '../state/app_state.dart';
+import 'app_button.dart';
 
 class TaskCapsuleMonitor extends StatefulWidget {
   const TaskCapsuleMonitor({super.key});
@@ -185,16 +186,14 @@ class _TaskCapsuleMonitorState extends State<TaskCapsuleMonitor> {
                           ],
                         ),
                       )),
-                      TextButton(
+                      AppButton(
+                        label: l10n.viewAll,
+                        variant: AppButtonVariant.text,
+                        size: AppButtonSize.compact,
                         onPressed: () {
                           context.read<AppState>().navigateToScreen(2);
                           setState(() => _isExpanded = false);
                         },
-                        style: TextButton.styleFrom(
-                          visualDensity: VisualDensity.compact,
-                          padding: EdgeInsets.zero,
-                        ),
-                        child: Text(l10n.viewAll, style: const TextStyle(fontSize: 12)),
                       ),
                     ],
                   ],

--- a/lib/widgets/task_capsule_monitor.dart
+++ b/lib/widgets/task_capsule_monitor.dart
@@ -116,8 +116,7 @@ class _TaskCapsuleMonitorState extends State<TaskCapsuleMonitor> {
                                 runningCount > 0 
                                   ? l10n.runningCount(runningCount)
                                   : l10n.plannedCount(pendingCount),
-                                style: TextStyle(
-                                  fontSize: 13, 
+                                style: Theme.of(context).textTheme.titleSmall?.copyWith(
                                   fontWeight: FontWeight.bold,
                                   color: colorScheme.onSurfaceVariant
                                 ),
@@ -125,7 +124,10 @@ class _TaskCapsuleMonitorState extends State<TaskCapsuleMonitor> {
                               if (pendingCount > 0 && runningCount > 0)
                                 Text(
                                   l10n.plannedCount(pendingCount),
-                                  style: TextStyle(fontSize: 11, color: colorScheme.outline),
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .labelMedium
+                                      ?.copyWith(color: colorScheme.outline),
                                 ),
                             ],
                           ),
@@ -134,8 +136,7 @@ class _TaskCapsuleMonitorState extends State<TaskCapsuleMonitor> {
                         if (runningCount > 0)
                           Text(
                             "${(avgProgress * 100).toInt()}%",
-                            style: TextStyle(
-                              fontSize: 13, 
+                            style: Theme.of(context).textTheme.titleSmall?.copyWith(
                               fontWeight: FontWeight.w900,
                               color: colorScheme.primary
                             ),
@@ -173,7 +174,7 @@ class _TaskCapsuleMonitorState extends State<TaskCapsuleMonitor> {
                             Expanded(
                               child: Text(
                                 t.modelId,
-                                style: const TextStyle(fontSize: 11),
+                                style: Theme.of(context).textTheme.labelMedium,
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ),

--- a/test/app_button_test.dart
+++ b/test/app_button_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_button.dart';
@@ -71,5 +72,151 @@ void main() {
 
     expect(find.text('Save'), findsOneWidget);
     expect(find.byIcon(Icons.save), findsOneWidget);
+  });
+
+  /// The painted surface, not the button: a button pads itself out to a 48px
+  /// tap target that is never drawn, so its own size says nothing about what
+  /// the user sees.
+  Size paintedSize(WidgetTester tester) => tester.getSize(
+        find.descendant(of: find.byType(AppButton), matching: find.byType(Material)).first,
+      );
+
+  group('sizes', () {
+    // Every one of these existed as a hand-rolled `minimumSize` or
+    // `visualDensity` at some call site the migration could not bring across.
+    // The component owning them is the point.
+
+    testWidgets('compact is shorter than normal, large is taller', (tester) async {
+      await tester.pumpWidget(host(AppButton(label: 'X', onPressed: () {}, size: AppButtonSize.compact)));
+      final compact = paintedSize(tester).height;
+
+      await tester.pumpWidget(host(AppButton(label: 'X', onPressed: () {})));
+      final normal = paintedSize(tester).height;
+
+      await tester.pumpWidget(host(AppButton(label: 'X', onPressed: () {}, size: AppButtonSize.large)));
+      final large = paintedSize(tester).height;
+
+      expect(compact, lessThan(normal));
+      expect(normal, lessThan(large));
+      expect(normal, appButtonMinHeight, reason: 'the default drifted away from the shared floor');
+    });
+
+    testWidgets('a compact button carries a smaller icon', (tester) async {
+      // 18px inside a 30px button is most of its height.
+      await tester.pumpWidget(host(
+        AppButton(label: 'X', icon: Icons.close, onPressed: () {}, size: AppButtonSize.compact),
+      ));
+      final compact = tester.widget<Icon>(find.byIcon(Icons.close)).size;
+
+      await tester.pumpWidget(host(AppButton(label: 'X', icon: Icons.close, onPressed: () {})));
+      final normal = tester.widget<Icon>(find.byIcon(Icons.close)).size;
+
+      expect(compact, lessThan(normal!));
+    });
+
+    testWidgets('fullWidth spans what it is offered', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        theme: buildAppTheme(seedColor: seed, brightness: Brightness.light),
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            child: AppButton(label: 'Import now', onPressed: () {}, fullWidth: true),
+          ),
+        ),
+      ));
+
+      expect(paintedSize(tester).width, 400);
+    });
+
+    testWidgets('the label scales with the box', (tester) async {
+      // A compact button holding a full-size label is not compact. It was
+      // still overflowing the card it had been shrunk to fit, and every call
+      // site that predates this had hand-set a `fontSize: 12` beside its
+      // `visualDensity` — the pairing this encodes once.
+      // The rendered paragraph, not the Text widget or the DefaultTextStyle
+      // above it: the button resolves its own text style onto the label, and
+      // only what was actually laid out settles whether it shrank.
+      //
+      // Each read needs pumpAndSettle first. A button animates its label
+      // style, so reading straight after pumpWidget returns the *previous*
+      // button's size -- which made all three look identical and sent me
+      // hunting a bug in the widget that was not there.
+      double labelSize(WidgetTester tester) => tester
+          .renderObject<RenderParagraph>(
+            find.descendant(of: find.text('X'), matching: find.byType(RichText)),
+          )
+          .text
+          .style!
+          .fontSize!;
+
+      await tester.pumpWidget(host(AppButton(label: 'X', onPressed: () {}, size: AppButtonSize.compact)));
+      await tester.pumpAndSettle();
+      final compact = labelSize(tester);
+
+      await tester.pumpWidget(host(AppButton(label: 'X', onPressed: () {})));
+      await tester.pumpAndSettle();
+      final normal = labelSize(tester);
+
+      await tester.pumpWidget(host(AppButton(label: 'X', onPressed: () {}, size: AppButtonSize.large)));
+      await tester.pumpAndSettle();
+      final large = labelSize(tester);
+
+      expect(compact, lessThan(normal));
+      expect(normal, lessThan(large));
+    });
+
+    testWidgets('the label comes from the type scale, not a literal', (tester) async {
+      // So that a change to the scale still reaches buttons — the whole
+      // reason the scale exists.
+      final theme = buildAppTheme(seedColor: seed, brightness: Brightness.light);
+
+      await tester.pumpWidget(host(AppButton(label: 'X', onPressed: () {}, size: AppButtonSize.compact)));
+      final style = tester.widget<FilledButton>(find.byType(FilledButton)).style!;
+
+      expect(style.textStyle?.resolve(const {})?.fontSize, theme.textTheme.labelMedium?.fontSize);
+    });
+
+    testWidgets('the default size leaves the theme alone', (tester) async {
+      // Restating the theme's own numbers over it is the drift this replaced;
+      // a plain button must still resolve straight through the theme.
+      await tester.pumpWidget(host(AppButton(label: 'Go', onPressed: () {})));
+
+      expect(tester.widget<FilledButton>(find.byType(FilledButton)).style, isNull);
+    });
+
+    testWidgets('sizing never repaints the variant', (tester) async {
+      // Size and colour are merged from two styles; if the geometry were
+      // merged over the variant instead of under it, a large destructive
+      // button would come out the default fill.
+      await tester.pumpWidget(host(AppButton(
+        label: 'Delete',
+        onPressed: () {},
+        variant: AppButtonVariant.destructive,
+        size: AppButtonSize.large,
+      )));
+
+      final theme = buildAppTheme(seedColor: seed, brightness: Brightness.light);
+      final style = tester.widget<FilledButton>(find.byType(FilledButton)).style!;
+
+      expect(style.backgroundColor?.resolve(const {}), theme.colorScheme.error);
+      expect(paintedSize(tester).height, 48);
+    });
+  });
+
+  testWidgets('destructiveText is the error colour with no border', (tester) async {
+    // For a toolbar of borderless controls, where destructiveOutline's edge
+    // would be the only one in the row and destructive's fill would shout.
+    await tester.pumpWidget(host(AppButton(
+      label: 'Clear',
+      onPressed: () {},
+      variant: AppButtonVariant.destructiveText,
+    )));
+
+    final theme = buildAppTheme(seedColor: seed, brightness: Brightness.light);
+    final style = tester.widget<TextButton>(find.byType(TextButton)).style!;
+
+    expect(style.foregroundColor?.resolve(const {}), theme.colorScheme.error);
+    expect(style.side?.resolve(const {}), isNull);
+    expect(find.byType(OutlinedButton), findsNothing);
   });
 }

--- a/test/app_theme_test.dart
+++ b/test/app_theme_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
 
@@ -155,6 +156,8 @@ void main() {
     }
   });
 
+  group('metricsOnly', _metricsOnlyTests);
+
   test('tonal buttons keep their own colours despite the filled theme', () {
     // FilledButton.tonal reads the same FilledButtonTheme, and a theme's
     // background outranks the tonal variant's default — so every tonal button
@@ -171,3 +174,87 @@ void main() {
 }
 
 void _noop() {}
+
+/// Covers [AppTextScaleMetrics.metricsOnly].
+///
+/// It exists to stop a specific invisible-text bug: a Material 3 TextTheme
+/// slot arrives stamped with `onSurface`, and an explicit colour on a Text
+/// beats the ambient DefaultTextStyle -- so handing a raw slot to a filled
+/// button's label paints dark-on-dark, and to a chip's label freezes it on
+/// the unselected colour.
+void _metricsOnlyTests() {
+  const seed = Colors.indigo;
+  ThemeData light() => buildAppTheme(seedColor: seed, brightness: Brightness.light);
+
+  test('a scale slot really does carry a colour', () {
+    // The premise. If Material ever stops stamping one, metricsOnly is dead
+    // weight and this test says so.
+    for (final slot in [
+      light().textTheme.bodySmall,
+      light().textTheme.labelMedium,
+      light().textTheme.titleMedium,
+    ]) {
+      expect(slot?.color, isNotNull);
+    }
+  });
+
+  test('metricsOnly is marked inheriting, or the merge never happens', () {
+    // The subtle half. Text only merges its style over the ambient
+    // DefaultTextStyle when `inherit` is true; TextStyle.merge returns the
+    // incoming style wholesale otherwise. Copy a slot's own `inherit` through
+    // and the label comes out with no colour at all -- black on a filled
+    // button, which is worse than the bug this getter exists to fix. Caught
+    // by the end-to-end case below, not by reading the code.
+    expect(light().textTheme.labelMedium!.metricsOnly.inherit, isTrue);
+  });
+
+  test('metricsOnly drops the colour and keeps everything else', () {
+    final slot = light().textTheme.labelMedium!;
+    final bare = slot.metricsOnly;
+
+    expect(bare.color, isNull, reason: 'the colour survived, which is the whole bug');
+    expect(bare.fontSize, slot.fontSize);
+    expect(bare.fontWeight, slot.fontWeight);
+    expect(bare.letterSpacing, slot.letterSpacing);
+    expect(bare.height, slot.height);
+    expect(bare.fontFamily, slot.fontFamily);
+  });
+
+  test('copyWith cannot do this, which is why the extension exists', () {
+    // Documents the trap: null in copyWith means "leave it alone", so the
+    // obvious spelling silently keeps the colour.
+    final slot = light().textTheme.labelMedium!;
+
+    expect(slot.copyWith(color: null).color, slot.color);
+  });
+
+  testWidgets('a metricsOnly label takes the colour of the widget above it', (tester) async {
+    // The end to end claim: inside a filled button the label must come out
+    // the button's foreground, not the scale's onSurface.
+    await tester.pumpWidget(MaterialApp(
+      theme: light(),
+      home: Scaffold(
+        body: Center(
+          child: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () {},
+              child: Text('Go', style: Theme.of(context).textTheme.bodySmall?.metricsOnly),
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    final rendered = tester
+        .renderObject<RenderParagraph>(
+          find.descendant(of: find.text('Go'), matching: find.byType(RichText)),
+        )
+        .text
+        .style!;
+
+    expect(rendered.color, isNot(light().colorScheme.onSurface));
+    expect(rendered.color, buttonFillScheme(seed).onPrimary);
+    expect(rendered.fontSize, light().textTheme.bodySmall?.fontSize);
+  });
+}


### PR DESCRIPTION
The last two of the four component-library debts from #63, following #68.
Both are migrations, and in both the call sites turned out to be saying
things the shared abstraction could not — so the abstraction grew rather
than the call sites being flattened to fit it.

| | before | after |
|---|---|---|
| Raw Material buttons | 81 | 20 |
| Hardcoded `fontSize:` | 390 | 4 |

`flutter analyze` clean · 394 tests pass (389 before; the new ones pin the
new API).

---

## Buttons — 61 of 81 sites

The migration ran in two passes because the first kept stopping. Three
independent workers each hit the same wall and each declined to migrate
rather than drop styling to fit the API — so **the declines were the
useful output**. Sorted, they named three missing things:

- **`AppButtonSize { compact, normal, large }` + `fullWidth`.** Call sites
  had been hand-rolling `minimumSize: Size.fromHeight(48|56)` for sheet
  CTAs and `visualDensity: compact` for slim strips — the same drift the
  component exists to stop, just spelled per-site.
- **`AppButtonVariant.destructiveText`.** A red *borderless* delete, for a
  selection bar where `destructiveOutline`'s edge would be the only one in
  the row and `destructive`'s fill would shout.
- **The size has to carry the type, not just the geometry.** This came out
  of a failure: migrating the knowledge-base edit card overflowed it by
  34px on mobile, and compact *geometry* alone only got that to 6.7px. The
  cause was the label — every one of those call sites had paired its
  `visualDensity` with a `fontSize: 12`, and only half the pairing had been
  encoded. Sizes now take `labelMedium` / default / `titleMedium` from the
  scale. The card fits with room to spare.

### Left raw on purpose (20)

- `task_queue_screen`'s header pair — the shared style encodes per-action
  colour (neutral for "cancel pending", error for "clear completed") plus a
  tinted fill that appears only while there is something to clear.
  Flattening loses the "this one destroys something" signal.
- Two labels that are a `Row`, one needing `TextOverflow.ellipsis`.
  `AppButton` takes a `String` — that is the boundary, not a gap.
- The optimizer's apply button, whose *disabled state changes its shape*
  (outline, not a grey slab). No variant switches geometry on state.
- Four bespoke shapes: a radius-22 capsule pill, a radius-16 mobile CTA, a
  200×50 centred wizard button, a 30px dense-list retry.

Growing the API to reach these would turn `AppButton` into a parameterised
`ButtonStyle`, which is where this started.

---

## Type — 386 of 390 sites

### The plan's premise was wrong, and the scope is bigger than it said

The original note claimed hardcoded sizes blocked font switching. **They
never did** — `Text` merges its style over the ambient `DefaultTextStyle`,
so `TextStyle(fontSize: 12)` was already carrying the app font and the
theme colour. A probe test established this before any of the work
started. The real payoff is consistency, which is a weaker case than the
plan assumed, and worth stating plainly.

And a slot carries **line height and letter spacing**, not just a size, so
this moves the app's whole typographic rhythm. Concretely: a `fontSize: 12`
inheriting height 1.43 (a 17.2px line box) becomes `bodySmall` at 1.33
(16.0px). Lines tighten throughout, and a few strings track out slightly —
the monospace URL field picks up `bodyMedium`'s 0.25 letter spacing.
Nothing overflows and every layout test passes, but *"only the number
changed"* would be a lie.

Sizes with no slot were reviewed, not rounded blindly: the nine 9px sites
were all badges (`labelSmall` is the badge slot); the eleven 15px sites
were all bold section headers → `titleMedium`; 16 and 32 hit `bodyLarge`
and `headlineLarge` exactly, both Material defaults never overridden here.

### The hazard this could have shipped

A slot arrives stamped with `onSurface`, and an explicit colour on a `Text`
beats the ambient `DefaultTextStyle`. So a raw slot handed to a label whose
colour belongs to the widget *around* it — a filled button's foreground, a
chip's selected tint, a `ListTile` under `selected: true`, an
`ExpansionTile`'s animated tween — paints `onSurface` over that choice.
Dark on dark.

Eight sites hit this. `copyWith(color: null)` cannot express "keep the
metrics, drop the colour" (null there means *leave unchanged*), so
`TextStyle.metricsOnly` does, next to the scale it belongs to.

It has a second edge **only a rendering test finds**: the result must be
marked `inherit: true`, because `TextStyle.merge` returns the incoming
style *wholesale* when that is false. My first version copied each slot's
own `inherit` through and produced a label with **no colour at all** —
black on a teal button, worse than the bug being fixed. The widget tree
looked correct; the test that caught it asserts the rendered span.

### Still literal (4)

Computed sizes (`size * 0.5`, `(style?.fontSize ?? 13) + 2`), a
`StrutStyle` the scale has no slot for, and the 8px VIDEO micro-badge on
image cards — the smallest slot is 10 and +25% does not fit it.

---

## Reviewer notes

- **This is the widest-reaching diff of the four.** 105 files. The type
  change in particular touches nearly every screen, and its effect is a
  small global shift in line spacing rather than anything a test can
  assert. Worth a look on a real run before trusting the green tick.
- Two near-misses fixed while sweeping: three popup-menu labels were
  heading for `bodyMedium` (w400) when their ambient style was `labelLarge`
  (w500) — the mapping table reads "13 + no weight" as w400, but *no
  weight* means inherited, not w400; and `usage_list`'s column header would
  have been left the only 11px thing under rows that had moved to 11.5.
- One known cosmetic regression, carried over: the downloader's "Save
  origin HTML" had `foregroundColor: onSurfaceVariant` to sit quieter than
  its neighbour, and now takes the accent like any text button.
  `AppToolButton` is the app's muted toolbar action but is pinned to 38px
  and that strip is 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
