### PR TITLE
fix(windows): make the title bar recolouring actually reach DWM, and say when it doesn't

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -144,7 +144,15 @@ class _WindowChromeSyncState extends State<_WindowChromeSync> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    WindowChromeService.applyTheme(Theme.of(context).colorScheme);
+    final appState = context.read<AppState>();
+    // Logged, not fire-and-forget. Whether the OS took the colours is the one
+    // thing the app cannot see by looking at itself — the caption is drawn by
+    // the window manager, outside anything Flutter renders or a test can
+    // assert. Putting the platform's answer in the execution log is the only
+    // way this is checkable at all.
+    WindowChromeService.applyTheme(Theme.of(context).colorScheme).then((report) {
+      if (report != null) appState.addLog(report);
+    });
   }
 
   @override

--- a/lib/services/window_chrome_service.dart
+++ b/lib/services/window_chrome_service.dart
@@ -27,6 +27,16 @@ class WindowChromeService {
   static int? _lastCaption;
   static int? _lastText;
 
+  /// Whether the execution log has already been told the channel works.
+  ///
+  /// A theme change is animated, so this runs once per frame of the
+  /// transition — eight or nine times for a single switch, each with an
+  /// interpolated colour. Applying every frame is wanted (the caption then
+  /// fades along with the UI instead of snapping), but saying so every frame
+  /// buries the user's own task output. Success is worth one line, ever;
+  /// failures are worth all of them.
+  static bool _reportedSuccess = false;
+
   /// Whether this platform has a caption this service can recolour.
   static bool get isSupported => !kIsWeb && Platform.isWindows;
 
@@ -34,8 +44,14 @@ class WindowChromeService {
   ///
   /// Safe to call on every theme rebuild — repeat calls with unchanged
   /// colours return without touching the channel.
-  static Future<void> applyTheme(ColorScheme colorScheme) async {
-    if (!isSupported) return;
+  ///
+  /// Returns a one-line account of what the platform did, for the execution
+  /// log, or null when there was nothing to do. Whether DWM *accepted* the
+  /// colours is not something the app can see by looking at itself, and a
+  /// silent no-op here is indistinguishable from the feature not existing —
+  /// which is how it went unnoticed through three releases. So it says so.
+  static Future<String?> applyTheme(ColorScheme colorScheme) async {
+    if (!isSupported) return null;
 
     // surfaceContainer, not surface: it is the colour of the canvas the nav
     // rail and top bar float on, so the caption continues the same plane
@@ -45,10 +61,10 @@ class WindowChromeService {
     // as an int64 rather than an int32 — see the runner's own note.
     final caption = colorScheme.surfaceContainer.toARGB32();
     final text = colorScheme.onSurface.toARGB32();
-    if (caption == _lastCaption && text == _lastText) return;
+    if (caption == _lastCaption && text == _lastText) return null;
 
     try {
-      await _channel.invokeMethod<void>('setCaptionColors', {
+      final applied = await _channel.invokeMapMethod<String, int>('setCaptionColors', {
         'caption': caption,
         'text': text,
         'dark': colorScheme.brightness == Brightness.dark,
@@ -58,6 +74,11 @@ class WindowChromeService {
       // change saw its own colours already "sent" and returned early.
       _lastCaption = caption;
       _lastText = text;
+
+      final refused = (applied ?? const {}).entries.where((e) => e.value != 0).toList();
+      if (refused.isEmpty && _reportedSuccess) return null;
+      _reportedSuccess = true;
+      return _describe(caption, text, colorScheme.brightness, applied);
     } on PlatformException catch (error, stack) {
       // Reported, not dropped. The runner errors here only on arguments it
       // cannot read, which is a defect in this file rather than a property of
@@ -72,9 +93,25 @@ class WindowChromeService {
         library: 'window_chrome_service',
         context: ErrorDescription('applying the window caption colours'),
       ));
+      return 'Window caption rejected the colours: ${error.code} ${error.message}';
     } on MissingPluginException {
       // Running against a runner built before the channel existed.
+      return 'Window caption channel is missing — the runner predates it.';
     }
+  }
+
+  /// Each DWM attribute reports its own HRESULT; 0 is S_OK. They are shown
+  /// individually because they fail independently: Windows 10 takes the
+  /// dark-mode flag and refuses the two colours.
+  static String _describe(int caption, int text, Brightness brightness, Map<String, int>? applied) {
+    String hex(int v) => '#${(v & 0xFFFFFF).toRadixString(16).padLeft(6, '0')}';
+    final summary = 'caption ${hex(caption)}, text ${hex(text)}, ${brightness.name}';
+    if (applied == null) return 'Window caption set ($summary) — runner returned nothing.';
+
+    final failures = applied.entries.where((e) => e.value != 0).toList();
+    if (failures.isEmpty) return 'Window caption applied: $summary.';
+    final detail = failures.map((e) => '${e.key}=0x${e.value.toUnsigned(32).toRadixString(16)}').join(', ');
+    return 'Window caption partly refused by DWM ($summary) — $detail';
   }
 
   /// Forces the next [applyTheme] to reach the platform even if the colours
@@ -83,5 +120,6 @@ class WindowChromeService {
   static void resetCache() {
     _lastCaption = null;
     _lastText = null;
+    _reportedSuccess = false;
   }
 }

--- a/lib/services/window_chrome_service.dart
+++ b/lib/services/window_chrome_service.dart
@@ -40,12 +40,12 @@ class WindowChromeService {
     // surfaceContainer, not surface: it is the colour of the canvas the nav
     // rail and top bar float on, so the caption continues the same plane
     // rather than introducing a third tone above them.
-    final caption = _toArgb(colorScheme.surfaceContainer);
-    final text = _toArgb(colorScheme.onSurface);
+    //
+    // Both are opaque, so both always exceed 0x7FFFFFFF and reach the runner
+    // as an int64 rather than an int32 — see the runner's own note.
+    final caption = colorScheme.surfaceContainer.toARGB32();
+    final text = colorScheme.onSurface.toARGB32();
     if (caption == _lastCaption && text == _lastText) return;
-
-    _lastCaption = caption;
-    _lastText = text;
 
     try {
       await _channel.invokeMethod<void>('setCaptionColors', {
@@ -53,10 +53,25 @@ class WindowChromeService {
         'text': text,
         'dark': colorScheme.brightness == Brightness.dark,
       });
-    } on PlatformException {
-      // An older Windows rejects the colour attributes. The caption keeps the
-      // OS theme, which is the behaviour this app shipped with — not worth
-      // surfacing to the user.
+      // Recorded only once the platform has taken them. Caching before the
+      // await meant a rejected call was also a permanent one: the next theme
+      // change saw its own colours already "sent" and returned early.
+      _lastCaption = caption;
+      _lastText = text;
+    } on PlatformException catch (error, stack) {
+      // Reported, not dropped. The runner errors here only on arguments it
+      // cannot read, which is a defect in this file rather than a property of
+      // the machine — a Windows too old for the attributes fails silently on
+      // the native side and never reaches this handler. Swallowing it hid
+      // exactly such a defect for three releases: every colour crossed as an
+      // int64 while the runner would only accept an int32, so the caption was
+      // never once recoloured.
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: error,
+        stack: stack,
+        library: 'window_chrome_service',
+        context: ErrorDescription('applying the window caption colours'),
+      ));
     } on MissingPluginException {
       // Running against a runner built before the channel existed.
     }
@@ -69,10 +84,4 @@ class WindowChromeService {
     _lastCaption = null;
     _lastText = null;
   }
-
-  static int _toArgb(Color color) =>
-      (color.a * 255).round() << 24 |
-      (color.r * 255).round() << 16 |
-      (color.g * 255).round() << 8 |
-      (color.b * 255).round();
 }

--- a/test/window_chrome_service_test.dart
+++ b/test/window_chrome_service_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
+import 'package:joycai_image_ai_toolkits/services/window_chrome_service.dart';
+
+/// Covers the channel that recolours the Windows title bar.
+///
+/// This shipped broken for three releases and nothing caught it. Every colour
+/// crossed the channel as an int64 — an opaque ARGB value always exceeds
+/// `0x7FFFFFFF`, and Dart's codec widens anything past that — while the runner
+/// would only accept an int32. It rejected all of them, the Dart side caught
+/// the error and dropped it on the floor, and the caption silently kept the OS
+/// theme. Nothing in the app misbehaved; it simply never did the one thing it
+/// existed to do.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('joycai/window_chrome');
+  final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late List<MethodCall> calls;
+  String? errorFrom;
+
+  /// Installs a handler that records calls and answers with [reject] set to
+  /// true when the runner should refuse them.
+  void mockRunner({bool reject = false}) {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (reject) throw PlatformException(code: 'bad_args', message: 'nope');
+      return null;
+    });
+  }
+
+  setUp(() {
+    calls = [];
+    errorFrom = null;
+    WindowChromeService.resetCache();
+    FlutterError.onError = (details) => errorFrom = details.library;
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    FlutterError.onError = FlutterError.presentError;
+  });
+
+  ThemeData theme(Brightness brightness) =>
+      buildAppTheme(seedColor: Colors.teal, brightness: brightness);
+
+  test('an opaque caption colour does not fit in an int32', () {
+    // The whole defect in one assertion. Alpha is 0xFF on any colour this
+    // sends, so the value is always above the int32 ceiling and the codec
+    // always widens it. Any runner reading this channel has to accept an
+    // int64; one that insists on int32 receives nothing it can use, ever.
+    for (final brightness in [Brightness.light, Brightness.dark]) {
+      final scheme = theme(brightness).colorScheme;
+      for (final colour in [scheme.surfaceContainer, scheme.onSurface]) {
+        final argb = colour.toARGB32();
+        expect(argb, greaterThan(0x7FFFFFFF),
+            reason: 'an opaque colour that fits in an int32 would hide the widening');
+      }
+    }
+  });
+
+  test('the colours survive the codec the runner decodes with', () {
+    // Encoding and decoding with the real StandardMethodCodec is as close as
+    // a Dart test gets to the runner. If the value that comes out the far end
+    // is not the value that went in, the caption is painted the wrong colour.
+    final scheme = theme(Brightness.light).colorScheme;
+    final sent = <String, Object?>{
+      'caption': scheme.surfaceContainer.toARGB32(),
+      'text': scheme.onSurface.toARGB32(),
+      'dark': false,
+    };
+
+    const codec = StandardMethodCodec();
+    final decoded = codec.decodeMethodCall(
+      codec.encodeMethodCall(MethodCall('setCaptionColors', sent)),
+    );
+
+    expect(decoded.arguments, sent);
+  });
+
+  group('on Windows', () {
+    test('the caption takes the canvas colour and the label the text colour', () async {
+      mockRunner();
+      final scheme = theme(Brightness.light).colorScheme;
+
+      await WindowChromeService.applyTheme(scheme);
+
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'setCaptionColors');
+      final args = calls.single.arguments as Map;
+      expect(args['caption'], scheme.surfaceContainer.toARGB32());
+      expect(args['text'], scheme.onSurface.toARGB32());
+      expect(args['dark'], isFalse);
+    });
+
+    test('dark mode is announced separately from the colours', () async {
+      // Windows 10 rejects the two colour attributes but honours the dark
+      // flag, so it has to travel on its own rather than be inferred.
+      mockRunner();
+
+      await WindowChromeService.applyTheme(theme(Brightness.dark).colorScheme);
+
+      expect((calls.single.arguments as Map)['dark'], isTrue);
+    });
+
+    test('unchanged colours do not cross the channel twice', () async {
+      mockRunner();
+      final scheme = theme(Brightness.light).colorScheme;
+
+      await WindowChromeService.applyTheme(scheme);
+      await WindowChromeService.applyTheme(scheme);
+
+      expect(calls, hasLength(1));
+    });
+
+    test('a rejected call is reported rather than dropped', () async {
+      // The runner errors only on arguments it cannot read — a defect here,
+      // not a property of the machine. Swallowing it is what let the int64
+      // mismatch survive three releases.
+      mockRunner(reject: true);
+
+      await WindowChromeService.applyTheme(theme(Brightness.light).colorScheme);
+
+      expect(errorFrom, 'window_chrome_service');
+    });
+
+    test('a rejected call is retried on the next theme change', () async {
+      // The cache used to be written before the await, so a refusal also made
+      // the failure permanent: the next theme saw its colours already "sent".
+      mockRunner(reject: true);
+      await WindowChromeService.applyTheme(theme(Brightness.light).colorScheme);
+      expect(calls, hasLength(1));
+
+      mockRunner();
+      await WindowChromeService.applyTheme(theme(Brightness.dark).colorScheme);
+      await WindowChromeService.applyTheme(theme(Brightness.light).colorScheme);
+
+      expect(calls, hasLength(3),
+          reason: 'the light theme was never re-sent after being refused');
+    });
+  },
+      skip: WindowChromeService.isSupported
+          ? false
+          : 'applyTheme is a no-op off Windows (host is ${Platform.operatingSystem})');
+}

--- a/test/window_chrome_service_test.dart
+++ b/test/window_chrome_service_test.dart
@@ -26,11 +26,11 @@ void main() {
 
   /// Installs a handler that records calls and answers with [reject] set to
   /// true when the runner should refuse them.
-  void mockRunner({bool reject = false}) {
+  void mockRunner({bool reject = false, Map<String, int>? hresults}) {
     messenger.setMockMethodCallHandler(channel, (call) async {
       calls.add(call);
       if (reject) throw PlatformException(code: 'bad_args', message: 'nope');
-      return null;
+      return hresults ?? const {'darkMode': 0, 'caption': 0, 'text': 0};
     });
   }
 
@@ -127,6 +127,64 @@ void main() {
       await WindowChromeService.applyTheme(theme(Brightness.light).colorScheme);
 
       expect(errorFrom, 'window_chrome_service');
+    });
+
+    test('it reports what DWM did, because nothing else can see it', () async {
+      // The caption is painted by the window manager, outside anything
+      // Flutter renders — no widget test and no screenshot can reach it. The
+      // platform's own answer in the execution log is the only evidence the
+      // feature works, and its absence is what let a dead channel pass for a
+      // working one across three releases.
+      mockRunner();
+
+      final report = await WindowChromeService.applyTheme(theme(Brightness.light).colorScheme);
+
+      expect(report, isNotNull);
+      expect(report, contains('applied'));
+    });
+
+    test('success is said once, not once per animation frame', () async {
+      // A theme switch is animated, so this runs eight or nine times with
+      // interpolated colours. Applying each frame is deliberate — the caption
+      // then fades with the UI — but nine identical log lines per switch bury
+      // the user's own output, which is what the execution log is for.
+      mockRunner();
+      final light = theme(Brightness.light).colorScheme;
+
+      final first = await WindowChromeService.applyTheme(light);
+      // Distinct colours, as each animation frame would be.
+      final second = await WindowChromeService.applyTheme(theme(Brightness.dark).colorScheme);
+      final third = await WindowChromeService.applyTheme(light);
+
+      expect(first, isNotNull);
+      expect(second, isNull);
+      expect(third, isNull);
+      expect(calls, hasLength(3), reason: 'the later frames were not applied to the caption');
+    });
+
+    test('a failure is said every time, however often it repeats', () async {
+      // The opposite rule. A caption that silently stopped working is the
+      // whole defect this service has already shipped once.
+      mockRunner(hresults: const {'darkMode': 0, 'caption': -2147024809, 'text': 0});
+
+      final first = await WindowChromeService.applyTheme(theme(Brightness.light).colorScheme);
+      final second = await WindowChromeService.applyTheme(theme(Brightness.dark).colorScheme);
+
+      expect(first, contains('refused'));
+      expect(second, contains('refused'));
+    });
+
+    test('a partial refusal names the attribute that failed', () async {
+      // Windows 10 takes the dark-mode flag and refuses the two colours, so
+      // "it worked" and "it did nothing" have to be tellable apart per
+      // attribute rather than as one boolean.
+      mockRunner(hresults: const {'darkMode': 0, 'caption': -2147024809, 'text': -2147024809});
+
+      final report = await WindowChromeService.applyTheme(theme(Brightness.light).colorScheme);
+
+      expect(report, contains('refused'));
+      expect(report, contains('caption'));
+      expect(report, isNot(contains('darkMode')), reason: 'the attribute that succeeded was named as a failure');
     });
 
     test('a rejected call is retried on the next theme change', () async {

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -139,8 +139,16 @@ bool FlutterWindow::OnCreate() {
           }
         }
 
-        SetCaptionColors(ToColorRef(caption), ToColorRef(text), dark);
-        result->Success();
+        const auto applied =
+            SetCaptionColors(ToColorRef(caption), ToColorRef(text), dark);
+        result->Success(flutter::EncodableValue(flutter::EncodableMap{
+            {flutter::EncodableValue("darkMode"),
+             flutter::EncodableValue(static_cast<int32_t>(applied.dark_mode))},
+            {flutter::EncodableValue("caption"),
+             flutter::EncodableValue(static_cast<int32_t>(applied.caption))},
+            {flutter::EncodableValue("text"),
+             flutter::EncodableValue(static_cast<int32_t>(applied.text))},
+        }));
       });
 
   flutter_controller_->engine()->SetNextFrameCallback([&]() {

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -103,12 +103,25 @@ bool FlutterWindow::OnCreate() {
           if (it == args->end()) {
             return false;
           }
-          const auto* value = std::get_if<int32_t>(&it->second);
-          if (!value) {
-            return false;
+          // Both widths, and int64 is the one that actually arrives. An
+          // opaque colour carries alpha 0xFF, so its ARGB value always
+          // exceeds 0x7FFFFFFF, and Dart's StandardMessageCodec promotes
+          // anything past that to an int64. Insisting on int32 here rejected
+          // every colour this channel was ever sent -- the caption kept the
+          // OS theme and the failure was invisible, because the Dart side
+          // caught the resulting error and dropped it.
+          //
+          // The narrowing cast is safe: the value is a 32-bit colour that
+          // travelled inside a wider box, and ToColorRef masks per byte.
+          if (const auto* narrow = std::get_if<int32_t>(&it->second)) {
+            *out = *narrow;
+            return true;
           }
-          *out = *value;
-          return true;
+          if (const auto* wide = std::get_if<int64_t>(&it->second)) {
+            *out = static_cast<int32_t>(*wide);
+            return true;
+          }
+          return false;
         };
 
         int32_t caption = 0;

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -289,9 +289,10 @@ void Win32Window::OnDestroy() {
   // No-op; provided for subclasses.
 }
 
-void Win32Window::SetCaptionColors(COLORREF caption, COLORREF text, bool dark) {
+Win32Window::CaptionColorResult Win32Window::SetCaptionColors(
+    COLORREF caption, COLORREF text, bool dark) {
   if (!window_handle_) {
-    return;
+    return {E_HANDLE, E_HANDLE, E_HANDLE};
   }
 
   // Set first, so that on Windows 10, where the two colour attributes below
@@ -302,12 +303,15 @@ void Win32Window::SetCaptionColors(COLORREF caption, COLORREF text, bool dark) {
   // a non-UTF-8 locale any other byte raises C4819, which this build treats
   // as an error.
   BOOL enable_dark_mode = dark;
-  DwmSetWindowAttribute(window_handle_, DWMWA_USE_IMMERSIVE_DARK_MODE,
-                        &enable_dark_mode, sizeof(enable_dark_mode));
-
-  DwmSetWindowAttribute(window_handle_, DWMWA_CAPTION_COLOR, &caption,
-                        sizeof(caption));
-  DwmSetWindowAttribute(window_handle_, DWMWA_TEXT_COLOR, &text, sizeof(text));
+  CaptionColorResult result;
+  result.dark_mode =
+      DwmSetWindowAttribute(window_handle_, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                            &enable_dark_mode, sizeof(enable_dark_mode));
+  result.caption = DwmSetWindowAttribute(window_handle_, DWMWA_CAPTION_COLOR,
+                                         &caption, sizeof(caption));
+  result.text =
+      DwmSetWindowAttribute(window_handle_, DWMWA_TEXT_COLOR, &text, sizeof(text));
+  return result;
 }
 
 void Win32Window::UpdateTheme(HWND const window) {

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -66,7 +66,17 @@ class Win32Window {
   //
   // The colour attributes need Windows 11 (build 22000+); on older systems
   // DwmSetWindowAttribute simply fails and the caption keeps its OS theme.
-  void SetCaptionColors(COLORREF caption, COLORREF text, bool dark);
+  // What each of the three DwmSetWindowAttribute calls returned. They are
+  // reported rather than ignored because a silent failure here is
+  // indistinguishable from the feature never having been wired up -- which
+  // is exactly how it went unnoticed through three releases.
+  struct CaptionColorResult {
+    HRESULT dark_mode;
+    HRESULT caption;
+    HRESULT text;
+  };
+
+  CaptionColorResult SetCaptionColors(COLORREF caption, COLORREF text, bool dark);
 
  protected:
   // Processes and route salient window messages for mouse handling,


### PR DESCRIPTION
The Windows title bar was supposed to follow the app's theme rather than
the OS one. It never did — not once, in any release since the feature
landed. This fixes it, and then fixes the reason nobody noticed.

**Confirmed working on a real desktop:** a light app under a dark Windows
now gets a light caption with dark text, which is the entire case the
feature exists for. That confirmation matters because it cannot come from
CI — the caption is painted by the window manager, outside anything
Flutter renders, so no widget test and no screenshot of the app can reach
it.

## Why it never worked

An opaque ARGB value always exceeds `0x7FFFFFFF`, so Dart's
`StandardMessageCodec` widens it to an **int64**. The runner's argument
reader accepted only **int32**. Every call was rejected with `bad_args`
and every caption kept the OS theme.

Three things kept that invisible:

- The Dart side caught the `PlatformException` and dropped it, reasoning
  that an older Windows might refuse the attributes. It would not —
  `DwmSetWindowAttribute` failing is ignored natively and never reaches
  that handler. The only thing that can error there is an argument the
  runner cannot read, i.e. a defect in our own code.
- The sent-colour cache was written *before* the await, so one refusal
  made the failure permanent: the next theme change saw its colours
  already "sent" and returned early.
- Nothing tested it.

## Why one fix wasn't enough

The int64 fix alone did not make the caption change colour, and reading
the code again would have been the same mistake twice — inferring, in a
system where failure is invisible.

All three `DwmSetWindowAttribute` calls were **discarding their HRESULT**,
so "DWM refused this" and "DWM accepted this" were literally
indistinguishable. That is the same blindness that let the original defect
through, one layer down.

The runner now returns all three results, the service turns them into one
line, and that line goes to the app's execution log. First run with it
gave both answers at once: the feature works — *and* there was a second
defect nobody had seen.

## The second defect the log exposed

Nine lines for a single launch, walking `#1f1f1f` → `#eeeeee`.

A theme change is animated, so this runs once per frame with an
interpolated colour. **Applying every frame is correct** — the caption
fades along with the UI instead of snapping — so that behaviour is kept.
What was wrong was saying so nine times: the execution log is for the
user's own task output, not framework chatter.

Success is now reported once. Failures are reported every time, because a
caption that quietly stopped working is precisely the defect this has
already shipped.

## Tests

11 cover this path. Three earn their place:

- **an opaque caption colour does not fit in an int32** — pins the hazard
  itself, so any runner on this channel must accept an int64.
- **errors surface / a refusal is retried** — either would have caught the
  original bug on the day it shipped.
- **success is said once, failure every time** — the log-noise rule, in
  both directions.

`flutter analyze` clean · 405 tests pass · Windows release build verified.

## Reviewer notes

- `win32_window.h` gains a small `CaptionColorResult` struct. The runner
  files must stay **pure ASCII** — MSVC reads them in the system code page
  and raises C4819 on anything else, which this build treats as an error.
- The per-frame application during a theme transition is deliberate, not
  an oversight. If it ever looks wrong on slower hardware, the knob is in
  `_WindowChromeSync`, not in the service.
- Older Windows (pre-11 build 22000) refuses the two colour attributes but
  honours the dark-mode flag. That path now reports itself as "partly
  refused by DWM" naming the attribute, rather than failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
