### PR TITLE
fix(ui): stop four toolbars and rows overflowing on narrow layouts

### DIFF
--- a/lib/screens/batch/task_queue_screen.dart
+++ b/lib/screens/batch/task_queue_screen.dart
@@ -693,67 +693,95 @@ class _TaskCardState extends State<_TaskCard> {
 
     final muted = textTheme.bodySmall!.copyWith(color: colorScheme.onSurfaceVariant);
     final (marker, modelId) = _splitModelMarker(task.modelId);
-    final children = <Widget>[];
-
-    void addSeparator() {
-      if (children.isEmpty) return;
-      children.add(Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 7),
-        child: Text('·', style: textTheme.bodySmall?.copyWith(color: colorScheme.outline)),
-      ));
-    }
-
-    if (marker != null) {
-      children.add(Padding(
-        padding: const EdgeInsets.only(right: 6),
-        child: _MetaBadge(label: marker, color: colorScheme.onSurfaceVariant),
-      ));
-    }
-    children.add(Flexible(
-      child: Text(
-        _shortModelId(modelId),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: muted.copyWith(fontFamily: 'monospace'),
+    // One entry per fact, each indivisible: the marker rides with the model id
+    // it qualifies, the clock with the duration it measures. What the line is
+    // allowed to break between is decided here.
+    final facts = <Widget>[
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (marker != null) ...[
+            _MetaBadge(label: marker, color: colorScheme.onSurfaceVariant),
+            const SizedBox(width: 6),
+          ],
+          Flexible(
+            child: Text(
+              _shortModelId(modelId),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: muted.copyWith(fontFamily: 'monospace'),
+            ),
+          ),
+        ],
       ),
-    ));
+    ];
 
     if (task.channelTag != null) {
-      addSeparator();
-      children.add(_MetaBadge(
+      facts.add(_MetaBadge(
         label: task.channelTag!,
         color: Color(task.channelColor ?? 0xFF607D8B),
       ));
     }
 
     if (task.imagePaths.length > 1) {
-      addSeparator();
-      children.add(Text(l10n.filesCount(task.imagePaths.length), style: muted));
+      facts.add(Text(l10n.filesCount(task.imagePaths.length), style: muted));
     }
 
     switch (task.status) {
       case TaskStatus.pending:
         final position = _queuePosition(task);
         if (position > 0) {
-          addSeparator();
-          children.add(Text(l10n.queuedPosition(position), style: muted));
+          facts.add(Text(l10n.queuedPosition(position), style: muted));
         }
       case TaskStatus.completed:
         final duration = _elapsed(task);
         if (duration != null) {
-          addSeparator();
-          children.add(Icon(Icons.schedule, size: 12, color: colorScheme.onSurfaceVariant));
-          children.add(const SizedBox(width: 5));
-          children.add(Text(l10n.tookDuration(duration), style: muted));
+          facts.add(Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.schedule, size: 12, color: colorScheme.onSurfaceVariant),
+              const SizedBox(width: 5),
+              Text(l10n.tookDuration(duration), style: muted),
+            ],
+          ));
         }
       case TaskStatus.cancelled:
-        addSeparator();
-        children.add(Text(l10n.statusCancelled, style: muted));
+        facts.add(Text(l10n.statusCancelled, style: muted));
       default:
         break;
     }
 
-    return Row(mainAxisSize: MainAxisSize.min, children: children);
+    // A Wrap, not a Row: on a phone the title column is ~230px and four facts
+    // plus their separators do not fit on one line. A Row could only get there
+    // by truncating, and every one of these is short enough that a second line
+    // costs less than an ellipsis does. Wide layouts never reach the wrap point
+    // and read exactly as before.
+    //
+    // Each dot travels with the fact in front of it, so a line that wraps opens
+    // on the next fact instead of on a stray separator.
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      runSpacing: 4,
+      children: [
+        for (int i = 0; i < facts.length; i++)
+          if (i == facts.length - 1)
+            facts[i]
+          else
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Flexible(child: facts[i]),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 7),
+                  child: Text(
+                    '·',
+                    style: textTheme.bodySmall?.copyWith(color: colorScheme.outline),
+                  ),
+                ),
+              ],
+            ),
+      ],
+    );
   }
 
   // ── Trailing: status/action → time → thumbnail → menu ──────────────────────

--- a/lib/screens/prompts/prompts_screen.dart
+++ b/lib/screens/prompts/prompts_screen.dart
@@ -245,7 +245,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
                 children: [
                   Padding(
                     padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-                    child: _buildSearchField(l10n, isMobile: true),
+                    child: _buildSearchField(l10n),
                   ),
                   TabBar(
                     controller: _tabController,
@@ -340,7 +340,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
                         ),
                       ),
                       child: _buildDesktopHeader(l10n, colorScheme,
-                          isTablet: isTablet, isCategories: isCategories),
+                          isCategories: isCategories),
                     ),
                     // Tablet: horizontal category filter when on user prompts tab
                     if (isTablet && _tabController.index == 0 && _tags.isNotEmpty)
@@ -415,7 +415,6 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
   Widget _buildDesktopHeader(
     AppLocalizations l10n,
     ColorScheme colorScheme, {
-    bool isTablet = false,
     bool isCategories = false,
   }) {
     // ── Selection mode ──────────────────────────────────────────────────────
@@ -471,28 +470,61 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
     }
 
     // ── User / System prompts ───────────────────────────────────────────────
-    return Row(
-      children: [
-        _buildTabToggle(l10n, colorScheme),
-        const Spacer(),
-        _buildSearchField(l10n, width: isTablet ? 180 : 250),
-        const SizedBox(width: 10),
-        _buildImportExportActions(l10n),
-        const SizedBox(width: 10),
-        AppButton(
-          label: _addLabel(l10n),
-          icon: Icons.add,
-          onPressed: _handleAddAction,
-        ),
-      ],
+    //
+    // Measured, not switched on the breakpoint: the sidebar beside this header
+    // is drag-resizable, so a tablet header is anywhere between ~310px and
+    // ~710px wide and the breakpoint says nothing about which. Below the
+    // threshold the toolbar folds — tighter track, import and export back into
+    // the one overflow menu the phone layout already uses, shorter create
+    // button — which is what the four controls at full size cost in width.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final tight = constraints.maxWidth < 560;
+
+        return Row(
+          children: [
+            _buildTabToggle(l10n, colorScheme, compact: tight),
+            // Takes the slack so the actions stay flush right — the field
+            // itself keeps its width until the slack runs out, and only then
+            // gives way. A Spacer with a fixed-width field beside it cannot do
+            // that: it holds its share and the row overflows instead.
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 250),
+                  child: _buildSearchField(l10n),
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            if (tight)
+              _buildImportExportMenu(l10n)
+            else
+              _buildImportExportActions(l10n),
+            const SizedBox(width: 10),
+            AppButton(
+              label: _addLabel(l10n),
+              icon: Icons.add,
+              onPressed: _handleAddAction,
+              size: tight ? AppButtonSize.compact : AppButtonSize.normal,
+            ),
+          ],
+        );
+      },
     );
   }
 
   /// Which list the header is over. The same control the rest of the app uses
   /// for a choice of two — this screen had grown its own, a track with a plain
   /// raised chip, which said the same thing in a second dialect.
-  Widget _buildTabToggle(AppLocalizations l10n, ColorScheme colorScheme) {
+  Widget _buildTabToggle(
+    AppLocalizations l10n,
+    ColorScheme colorScheme, {
+    bool compact = false,
+  }) {
     return AppSegmentedControl<int>(
+      compact: compact,
       segments: [
         AppSegment(value: 0, label: l10n.userPrompts),
         AppSegment(value: 1, label: l10n.systemTemplates),
@@ -584,11 +616,12 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
     ];
   }
 
-  Widget _buildSearchField(AppLocalizations l10n, {bool isMobile = false, double width = 300}) {
+  /// Fills whatever width it is given. The desktop header caps it; the phone
+  /// header hands it the full row.
+  Widget _buildSearchField(AppLocalizations l10n) {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Container(
-      width: isMobile ? double.infinity : width,
       height: 38,
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),

--- a/lib/screens/workbench/directory_tree_item.dart
+++ b/lib/screens/workbench/directory_tree_item.dart
@@ -168,14 +168,20 @@ class _DirectoryTreeItemState extends State<DirectoryTreeItem> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // The box is a Material rather than a decorated Container: ListTile
+        // paints its own fill and its ink onto the nearest Material ancestor,
+        // and a Container painting on top of that hid both — the framework
+        // says so at every build. Same fill, same border, same radius.
         Container(
           margin: const EdgeInsets.fromLTRB(6, 2, 6, 2),
-          decoration: BoxDecoration(
-            color: boxColor,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: borderColor),
-          ),
-          child: ListTile(
+          child: Material(
+            color: boxColor ?? Colors.transparent,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: BorderSide(color: borderColor),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: ListTile(
           dense: true,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           contentPadding: EdgeInsets.only(left: widget.isRoot ? 8 : 4, right: 4),
@@ -262,6 +268,7 @@ class _DirectoryTreeItemState extends State<DirectoryTreeItem> {
               appState.galleryState.setViewFolder(widget.path);
             }
           },
+            ),
           ),
         ),
 

--- a/lib/screens/workbench/widgets/image_card.dart
+++ b/lib/screens/workbench/widgets/image_card.dart
@@ -331,25 +331,32 @@ class _ImageCardState extends State<ImageCard> {
         child: Container(
           color: _overlayScrimStrong,
           padding: const EdgeInsets.symmetric(horizontal: 2),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _buildOverlayButton(
-                icon: Icons.compare,
-                onPressed: () => _handleCompare(context),
-                tooltip: l10n.comparator,
-              ),
-              _buildOverlayButton(
-                icon: Icons.brush,
-                onPressed: () => _handleMask(context),
-                tooltip: l10n.maskEditor,
-              ),
-              _buildOverlayButton(
-                icon: Icons.crop,
-                onPressed: () => _handleCrop(context),
-                tooltip: l10n.cropAndResize,
-              ),
-            ],
+          // The bar sits over a grid cell whose width is the column count's to
+          // decide, and on a phone three columns leave less than the three
+          // buttons measure. Scaling the capsule down keeps all three reachable
+          // where a Row would put the third one past the edge of the picture.
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildOverlayButton(
+                  icon: Icons.compare,
+                  onPressed: () => _handleCompare(context),
+                  tooltip: l10n.comparator,
+                ),
+                _buildOverlayButton(
+                  icon: Icons.brush,
+                  onPressed: () => _handleMask(context),
+                  tooltip: l10n.maskEditor,
+                ),
+                _buildOverlayButton(
+                  icon: Icons.crop,
+                  onPressed: () => _handleCrop(context),
+                  tooltip: l10n.cropAndResize,
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/prompt_card.dart
+++ b/lib/widgets/prompt_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
+import '../core/responsive.dart';
 import '../l10n/app_localizations.dart';
 import '../models/prompt.dart';
 
@@ -78,46 +79,63 @@ class PromptCard extends StatelessWidget {
   }
 
   Widget _buildHeader(BuildContext context, ColorScheme colorScheme) {
+    // Everything on this row apart from the title is fixed-width chrome — a
+    // chevron and up to five icon buttons. On a phone that leaves the title a
+    // word at best, and a card carrying two tags overflows outright. The tags
+    // are the one part that can move, so below the mobile breakpoint they drop
+    // to a line of their own, indented to meet the preview text underneath.
+    final tagsInline = !Responsive.isMobile(context);
+
     return InkWell(
       onTap: onToggle,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(12, 12, 8, 12),
-        child: Row(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (leading != null) ...[
-              leading!,
-              const SizedBox(width: 8),
-            ],
-            AnimatedRotation(
-              duration: const Duration(milliseconds: 200),
-              turns: isExpanded ? 0.25 : 0,
-              child: Icon(
-                Icons.chevron_right_rounded,
-                size: 20,
-                color: isExpanded ? colorScheme.primary : colorScheme.outline,
-              ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                prompt.title,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: isExpanded ? FontWeight.bold : FontWeight.w600,
-                      color: isExpanded ? colorScheme.primary : colorScheme.onSurface,
-                    ),
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            if (showCategory) ...[
-              _buildTagsList(context),
-              const SizedBox(width: 8),
-            ],
+            Row(
+              children: [
+                if (leading != null) ...[
+                  leading!,
+                  const SizedBox(width: 8),
+                ],
+                AnimatedRotation(
+                  duration: const Duration(milliseconds: 200),
+                  turns: isExpanded ? 0.25 : 0,
+                  child: Icon(
+                    Icons.chevron_right_rounded,
+                    size: 20,
+                    color: isExpanded ? colorScheme.primary : colorScheme.outline,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    prompt.title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: isExpanded ? FontWeight.bold : FontWeight.w600,
+                          color: isExpanded ? colorScheme.primary : colorScheme.onSurface,
+                        ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (showCategory && tagsInline) ...[
+                  _buildTagsList(context, alignment: WrapAlignment.end),
+                  const SizedBox(width: 8),
+                ],
 
-            // Reordering actions
-            if (onMoveToTop != null || onMoveToBottom != null)
-              _buildSortActions(context, colorScheme),
+                // Reordering actions
+                if (onMoveToTop != null || onMoveToBottom != null)
+                  _buildSortActions(context, colorScheme),
 
-            ...?actions,
+                ...?actions,
+              ],
+            ),
+            if (showCategory && !tagsInline)
+              Padding(
+                padding: const EdgeInsets.only(left: 28, top: 8),
+                child: _buildTagsList(context),
+              ),
           ],
         ),
       ),
@@ -150,15 +168,15 @@ class PromptCard extends StatelessWidget {
     );
   }
 
-  Widget _buildTagsList(BuildContext context) {
-    final displayTags = prompt.tags.isEmpty 
-        ? [null] 
+  Widget _buildTagsList(BuildContext context, {WrapAlignment alignment = WrapAlignment.start}) {
+    final displayTags = prompt.tags.isEmpty
+        ? [null]
         : prompt.tags;
 
     return Wrap(
       spacing: 4,
       runSpacing: 4,
-      alignment: WrapAlignment.end,
+      alignment: alignment,
       children: displayTags.map((t) => _buildCategoryTag(
             context,
         t?.name ?? 'General',


### PR DESCRIPTION
## What

Fixes every RenderFlex overflow the UI screenshot harness surfaced on the narrow shots, plus a Material warning on the file browser.

| Shot | Overflow | Source |
|---|---|---|
| `prompts_tablet_light` | 113px | Prompts toolbar — `prompts_screen.dart:474` |
| `prompts_mobile_light` | 33px | Prompt card header — `prompt_card.dart:85` |
| `tasks_mobile_light` | 60px + 1.4px | Task meta line — `task_queue_screen.dart:756` |
| `workbench_mobile_light` | 17px ×24 | Image card hover bar — `image_card.dart:334` |
| `fileBrowser_desktop_{light,dark}` | ListTile ink warning | `directory_tree_item.dart:171` |

## Why these fixes

Each overflow is a row of fixed-width chrome with nothing in it allowed to give way. The fix in each case names what may shrink, wrap or fold rather than shaving pixels off the contents.

**Prompts toolbar** — the filter field was a fixed width beside a `Spacer`, so the `Spacer` held its share and the row overflowed instead of the field yielding. It is now `Expanded` and right-aligned under its old 250px cap, so it gives space back before the row breaks. Below 560px the toolbar folds: tighter segmented track, import/export into the overflow menu the phone layout already uses, compact create button.

The threshold is measured with a `LayoutBuilder`, not switched on the breakpoint. The sidebar beside this header is drag-resizable (170–340px), so a "tablet" header is anywhere between ~310px and ~710px wide and the breakpoint says nothing about which.

**Prompt card header** — a chevron plus up to five icon buttons left the title nothing; it was already rendering at zero width before the tags pushed the row over. The tags are the one part that can move, so on a phone they drop to their own line, indented to meet the preview text below, and the title gets the row back.

**Task meta line** — `Row` → `Wrap`. Regrouped into indivisible facts (marker rides with its model id, clock with its duration), and each separator dot travels with the fact in front of it so a wrapped line never opens on a stray `·`. Wide layouts never reach the wrap point and render exactly as before.

**Image card hover bar** — three 44px buttons need 131px; a three-column phone grid gives 114px. A `FittedBox(scaleDown)` keeps all three reachable at ~38px. Pinning the buttons to the 30px they nominally ask for would have made the touch targets *smaller*.

**File browser directory rows** — a decorated `Container` wrapping a `ListTile` hid the tile's own fill and ink splashes, which the framework reported on every build. It is a `Material` now carrying the same fill, border and radius.

## Verification

- `flutter analyze` → **No issues found!**
- `flutter test test` → **428 passed**, 9 skipped
- Screenshot harness re-run across all 32 shots → **zero exceptions**; before/after PNGs checked, wide shots unchanged

## Notes for the reviewer

**The harness is not in this branch.** `test/screenshots/` and `docs/ui-screenshot-harness.md` do not exist in this worktree or in any commit — they are uncommitted work in a sibling worktree (`flutter-web-ui-debug-15b200`). I copied them in to reproduce and verify, and deliberately left them out of this commit so this PR does not publish another branch's WIP. To re-run the verification you need that harness in place first.

Two things in the original report were off, corrected here: the 33px mobile overflow is the prompt card, not the Prompts toolbar (mobile uses a `SliverAppBar`, not that toolbar), and the workbench shot logged 24 exceptions, not 3 — all the same bug, once per grid cell.

**Known and left alone:** on `prompts_mobile`, cards showing both reorder arrows still ellipsize the title to ~3 characters. The remaining squeeze is the five icon buttons; compact density would recover ~24px but shrinks touch targets on a phone for two more characters. It no longer overflows and every title is legible. Worth a separate pass if the density bothers you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)