### PR TITLE
test(ui): headless screenshot harness so UI layout can be seen, not inferred

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ dart tool/merge_l10n.dart && flutter gen-l10n     # regenerate l10n (run after e
 flutter run --release                              # run app (use --release on macOS — see Troubleshooting)
 flutter analyze                                    # MUST show "No issues found!" before any commit
 flutter build macos                                # or windows / linux / apk / ipa
+flutter test test/screenshots                      # render every screen to build/ui-screenshots/*.png
 ```
 
 ## Project Map
@@ -53,6 +54,7 @@ that fail silently when broken, and alternatives already tried and rejected.
 
 - **`flutter analyze` must pass** (zero issues, info-level included) after every code change.
 - **Responsive UI:** all changes must work on Mobile (<600px), Tablet (<1000px), Desktop (≥1000px). Use `Responsive`/`ResponsiveBuilder` (`lib/core/responsive.dart`). FileBrowser and ImageDownloader are desktop/tablet-only.
+- **Visual debugging:** to actually *see* a layout rather than infer it, run `flutter test test/screenshots` and open the PNGs in `build/ui-screenshots/`. They render the real screens with seeded data at all three widths, in light and dark. Overflows are printed to the run output, not asserted — this is never a regression gate. See [docs/ui-screenshot-harness.md](docs/ui-screenshot-harness.md).
 - **State:** use the existing state classes. Never use `StatefulWidget` for shared or persistent data. Always create new list/object instances before `notifyListeners()` — do not mutate in place.
 - **Data persistence:** all user data goes through `DatabaseService` and the repository layer.
 - **Business logic:** belongs in `lib/services/`, not in widgets or screens.

--- a/TESTING.md
+++ b/TESTING.md
@@ -17,6 +17,15 @@ To run the tests:
 flutter test
 ```
 
+## Visual Verification
+
+`flutter test test/screenshots` renders every screen of the real app at mobile,
+tablet and desktop widths (light and dark) against a seeded database, and writes
+PNGs to `build/ui-screenshots/`. It is a debugging tool for inspecting layout,
+not a golden regression gate — the comparator always overwrites and always
+passes, and layout exceptions are printed to the run output rather than
+asserted. See [docs/ui-screenshot-harness.md](docs/ui-screenshot-harness.md).
+
 ## Manual Verification
 - **Build:** Always ensure the app compiles for the target platform (Windows).
   ```bash

--- a/docs/ui-screenshot-harness.md
+++ b/docs/ui-screenshot-harness.md
@@ -1,0 +1,136 @@
+# UI Screenshot Harness
+
+Renders the real app, headlessly, at several window sizes and writes PNGs you
+can look at. It exists so an agent (or anyone without the app in front of them)
+can debug layout instead of guessing from source.
+
+```bash
+flutter test test/screenshots
+```
+
+```bash
+flutter test test/screenshots --plain-name workbench
+```
+
+Output: `build/ui-screenshots/<screen>_<size>_<brightness>[_<suffix>].png`
+— 8 screens × 3 widths in light, plus a dark shot of each, 32 files, ~30s.
+
+**This is not a regression gate.** The comparator installed by
+`flutter_test_config.dart` always overwrites and always passes, so a UI change
+can never fail `flutter test`. Layout exceptions are drained and printed rather
+than asserted — an overflow is the thing you want a picture of, and
+`expect(takeException(), isNull)` would abort before the PNG got written. Watch
+the run output for lines like:
+
+```
+[prompts_tablet_light] exception during pump: A RenderFlex overflowed by 113 pixels on the right.
+```
+
+## Why this and not a Flutter web build
+
+Web was the obvious idea and it does not pay off here. 56 files under `lib/`
+import `dart:io`, and the coupling is structural rather than incidental:
+`AppState` is a hard singleton behind `DatabaseService` → `sqflite_common_ffi`,
+and the models themselves are file-backed (`AppImage.imageProvider` returns
+`FileImage`). Every top-level screen fails to compile transitively. Even after
+a port there is no SQLite and no local filesystem on web, so every screen would
+photograph as an empty state — and each new `dart:io` call site would break the
+web build again. This harness renders the same widget tree the desktop app does,
+against a real database with seeded data.
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `test/screenshots/flutter_test_config.dart` | Loads real fonts; installs the always-overwrite golden comparator; disables the debug banner |
+| `test/screenshots/app_screens_test.dart` | The screen × size matrix |
+| `test/screenshots/harness/fixture_env.dart` | Temp directory tree, sqflite ffi, path_provider and plugin channel mocks |
+| `test/screenshots/harness/fixture_seed.dart` | Database rows and generated PNG fixtures |
+| `test/screenshots/harness/shoot.dart` | `shoot()`, the `AppScreen` enum and `kShotSizes` |
+
+## Extending it
+
+**A new size** — add to `kShotSizes` in `harness/shoot.dart`.
+
+**A variant** (a tab, an open dialog, a different view mode) — add a
+`testWidgets` with `suffix:` plus one of the hooks. `before` runs after the
+singleton is configured but before the first pump, for state a screen reads on
+mount; `after` runs on the settled tree, for taps.
+
+```dart
+testWidgets('workbench @ desktop, comparator tab', (WidgetTester tester) async {
+  await shoot(
+    tester,
+    env: env,
+    screen: AppScreen.workbench,
+    size: kShotSizes.last,
+    suffix: 'comparator',
+    before: (_) async => AppState().setWorkbenchTab(2),
+  );
+});
+```
+
+**A different locale** — `shoot(..., locale: const Locale('ja'))`. The parameter
+already exists; the matrix just fixes it at `zh` because CJK is the widest text
+and therefore the case most likely to overflow.
+
+**More seed data** — the seeders in `fixture_seed.dart` are split per area
+(`_seedSettings`, `_seedCatalog`, `_seedPrompts`, `_seedTasks`, `_seedUsage`,
+`_writeImages`). They all talk to `DatabaseService()` directly and must never
+touch `AppState()`.
+
+## Constraints worth knowing before you change it
+
+**`flutter_test_config.dart` must stay in `test/screenshots/`.** flutter_tools
+walks up from the test file's own directory and takes the first hit. At `test/`
+it would apply to all the other test files, changing their text metrics — and
+several of them assert on layout and overflow.
+
+**Setup order is load-bearing.** `installFixtureEnv` must run before the first
+`AppState()` call: `AppState` is a singleton whose `GalleryState` /
+`FileBrowserState` / `TaskQueueService` fields each fire an async database read
+from their constructors, so the DB path is chosen before you can await anything.
+Seeding must precede `loadSettings()`.
+
+**Seed `setup_completed`.** Without that row `AppState.loadSettings` sets
+`setupCompleted = false` and `_checkFirstRun` pushes `SetupWizard` over
+everything — every shot becomes the wizard.
+
+**Never seed `concurrency_limit`.** `loadSettings` only calls
+`taskQueue.updateConcurrency` when the row exists, and that path reaches
+`_attemptNextExecution()`, which would fire real LLM requests for the seeded
+pending tasks.
+
+**A `processing` task cannot be seeded through the database.**
+`TaskQueueService`'s constructor calls `cleanupStuckTasks()`, which rewrites
+every `processing` row to `failed`. `markOneTaskRunning()` mutates one in memory
+after load instead, then calls `refreshQueue()` — which is `notifyListeners()`
+only and does not execute anything.
+
+**Async work needs `runAsync`.** The `compute()` isolates behind the gallery and
+browser scans make no progress inside the fake-async zone. The first scan
+happens in `setUpAll` (real async); inside a test everything async goes through
+`tester.runAsync`. `FileImage` decoding is asynchronous too, which is why
+`shoot` precaches every fixture image before the final pump — skip that and
+every thumbnail captures blank.
+
+**Mobile size is not mobile platform.** `main.dart:256` reads
+`Platform.isAndroid || Platform.isIOS` to decide which nav destinations exist,
+and that is a `dart:io` check the harness cannot override on a macOS host. So
+the 390px shots show File Browser and Downloader in the nav even though a real
+phone hides them. The layout itself — `NavigationBar`, the drawer, the
+breakpoint behaviour — is faithful; only the destination set is not.
+
+**Timestamps are anchored to the real clock.** `kSeedNow` is `DateTime.now()`,
+deliberately: the task list and usage screens render relative times, so a pinned
+date drifts out of the present and renders as nonsense. Only the usage row
+distribution is deterministic (a seeded LCG).
+
+## Escape hatch: higher resolution
+
+Captures are 1× — a 1440×900 window produces a 1440×900 PNG, which is about the
+largest an agent can read without downsampling. If you ever need 2×,
+`captureImage` is exported from `package:flutter_test` and can replace
+`matchesGoldenFile` with a hand-rolled `toImage(pixelRatio: 2.0)` + write. It
+was left out on purpose: `matchesGoldenFile` already handles the repaint-boundary
+walk, the `runAsync` wrapping and the PNG encode correctly.

--- a/test/screenshots/app_screens_test.dart
+++ b/test/screenshots/app_screens_test.dart
@@ -1,0 +1,55 @@
+// Renders every screen of the real app to a PNG in build/ui-screenshots/.
+//
+//   flutter test test/screenshots
+//   flutter test test/screenshots --plain-name workbench
+//
+// This is a debugging tool, not a regression gate: the comparator installed by
+// flutter_test_config.dart always overwrites and always passes. See
+// docs/ui-screenshot-harness.md.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/state/app_state.dart';
+
+import 'harness/fixture_env.dart';
+import 'harness/fixture_seed.dart';
+import 'harness/shoot.dart';
+
+void main() {
+  final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
+  late FixtureEnv env;
+
+  setUpAll(() async {
+    // Order matters: the environment must exist before the first AppState()
+    // touch, and the seed before loadSettings() reads it back.
+    env = installFixtureEnv(binding);
+    await seedFixtures(env);
+
+    final AppState appState = AppState();
+    await appState.loadSettings();
+    // setUpAll runs in real async (no fake-async zone), which is the only place
+    // the compute()-based gallery and file-browser scans actually complete.
+    await Future<void>.delayed(const Duration(seconds: 1));
+    markOneTaskRunning(appState);
+  });
+
+  tearDownAll(() => env.dispose());
+
+  for (final AppScreen screen in AppScreen.values) {
+    for (final ShotSize size in kShotSizes) {
+      testWidgets('${screen.name} @ ${size.label}', (WidgetTester tester) async {
+        await shoot(tester, env: env, screen: screen, size: size);
+      });
+    }
+
+    testWidgets('${screen.name} @ desktop dark', (WidgetTester tester) async {
+      await shoot(
+        tester,
+        env: env,
+        screen: screen,
+        size: kShotSizes.last,
+        brightness: Brightness.dark,
+      );
+    });
+  }
+}

--- a/test/screenshots/flutter_test_config.dart
+++ b/test/screenshots/flutter_test_config.dart
@@ -1,0 +1,184 @@
+// Test configuration for the UI screenshot harness.
+//
+// ⚠️ THIS FILE MUST STAY IN `test/screenshots/`. flutter_tools discovers
+// `flutter_test_config.dart` by walking up from the test file's own directory
+// and taking the FIRST hit. Moving this to `test/` would apply it to all of the
+// other test files, changing their text metrics — several of them assert on
+// layout and overflow, so they would start failing for no real reason.
+//
+// It does two things:
+//   1. Loads real fonts. Without this, flutter_test's default font draws every
+//      glyph as a filled box and the screenshots are worthless.
+//   2. Installs a golden comparator that always overwrites and never fails, so
+//      these are a debugging tool rather than a pixel-diff regression gate.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// Where the PNGs land. `flutter test` runs with the package root as cwd, and
+/// `/build/` is already gitignored.
+const String kScreenshotDir = 'build/ui-screenshots';
+
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  // FontLoader and rootBundle both need a binding.
+  TestWidgetsFlutterBinding.ensureInitialized();
+  // MyApp does not set debugShowCheckedModeBanner, so without this every shot
+  // carries the DEBUG ribbon across its top-right corner.
+  WidgetsApp.debugAllowBannerOverride = false;
+  await _loadFonts();
+  goldenFileComparator = _ScreenshotWriter(Directory(kScreenshotDir));
+  await testMain();
+}
+
+/// Writes every capture to disk and always passes.
+///
+/// The stock [LocalFileComparator] turns `matchesGoldenFile` into a pixel-diff
+/// gate that fails on any UI change — exactly wrong for a tool whose whole job
+/// is to show what the UI currently looks like. Overriding [compare] to write
+/// also means no `--update-goldens` flag and lets the output live in `build/`
+/// instead of next to the test file.
+class _ScreenshotWriter extends GoldenFileComparator {
+  _ScreenshotWriter(this.outputDir);
+
+  final Directory outputDir;
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    await update(golden, imageBytes);
+    return true;
+  }
+
+  @override
+  Future<void> update(Uri golden, Uint8List imageBytes) async {
+    final File file = File(p.join(outputDir.path, golden.pathSegments.last));
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(imageBytes, flush: true);
+    debugPrint('screenshot → ${file.absolute.path}');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fonts
+// ---------------------------------------------------------------------------
+
+Future<void> _loadFonts() async {
+  // NotoSansSC first, and it is the one that matters: AppState.fontFamily
+  // defaults to 'NotoSansSC' and MyApp feeds that into ThemeData.fontFamily, so
+  // nearly all app text asks for it. It covers Latin *and* CJK, which is why a
+  // missing SDK Roboto degrades gracefully rather than ruining the shot.
+  final List<ByteData> noto = await _loadFromBundle(<String>[
+    'assets/fonts/NotoSansSC-Regular.ttf',
+    'assets/fonts/NotoSansSC-Bold.ttf',
+  ]);
+  await _register('NotoSansSC', noto);
+
+  // Families the app names but does not bundle: the nav rail task badge asks
+  // for 'monospace' (main.dart:637), the settings font picker previews each
+  // option in its own family, and FontService.systemFontFamily is whatever the
+  // OS provides. None of them resolve inside flutter_test, so their labels
+  // would photograph as boxes and read as a broken harness. Alias them all to
+  // NotoSansSC — the point is legibility, not typographic accuracy.
+  if (noto.isNotEmpty) {
+    for (final String alias in <String>[
+      'monospace',
+      'HarmonyOSSansSC',
+      'MiSans',
+      'PingFang SC',
+      'Microsoft YaHei',
+    ]) {
+      await _register(alias, <ByteData>[noto.first]);
+    }
+  }
+
+  // Icons: `uses-material-design: true` puts this in the asset bundle. Fall
+  // back to the SDK cache if the bundle lookup fails.
+  final List<ByteData> icons =
+      await _loadFromBundle(<String>['fonts/MaterialIcons-Regular.otf']);
+  await _register(
+    'MaterialIcons',
+    icons.isNotEmpty ? icons : _loadFromSdk(<String>['MaterialIcons-Regular.otf']),
+  );
+
+  // Roboto is only reached by text that names no family, so it is the least
+  // important of the three.
+  await _register(
+    'Roboto',
+    _loadFromSdk(<String>[
+      'Roboto-Regular.ttf',
+      'Roboto-Medium.ttf',
+      'Roboto-Bold.ttf',
+      'Roboto-Italic.ttf',
+    ]),
+  );
+}
+
+Future<void> _register(String family, List<ByteData> data) async {
+  if (data.isEmpty) {
+    debugPrint('[screenshots] font family "$family" unavailable — '
+        'text using it will render as boxes');
+    return;
+  }
+  final FontLoader loader = FontLoader(family);
+  for (final ByteData bytes in data) {
+    loader.addFont(Future<ByteData>.value(bytes));
+  }
+  await loader.load();
+}
+
+Future<List<ByteData>> _loadFromBundle(List<String> keys) async {
+  final List<ByteData> out = <ByteData>[];
+  for (final String key in keys) {
+    try {
+      out.add(await rootBundle.load(key));
+    } catch (_) {
+      // Missing from the bundle; the caller decides whether that is fatal.
+    }
+  }
+  return out;
+}
+
+List<ByteData> _loadFromSdk(List<String> fileNames) {
+  final String? dir = _materialFontsDir();
+  if (dir == null) return const <ByteData>[];
+  final List<ByteData> out = <ByteData>[];
+  for (final String name in fileNames) {
+    final File file = File(p.join(dir, name));
+    if (!file.existsSync()) continue;
+    final Uint8List bytes = file.readAsBytesSync();
+    out.add(ByteData.sublistView(bytes));
+  }
+  return out;
+}
+
+/// Locates `<flutter>/bin/cache/artifacts/material_fonts`, never hardcoded.
+String? _materialFontsDir() {
+  final List<String> roots = <String>[
+    // `flutter test` exports this (bin/internal/shared.sh).
+    ?Platform.environment['FLUTTER_ROOT'],
+    // Otherwise walk up from <flutter>/bin/cache/dart-sdk/bin/dart.
+    ..._ancestorsOf(Platform.resolvedExecutable),
+  ];
+  for (final String root in roots) {
+    final String dir = p.join(root, 'bin', 'cache', 'artifacts', 'material_fonts');
+    if (Directory(dir).existsSync()) return dir;
+  }
+  debugPrint('[screenshots] could not locate the Flutter SDK material_fonts '
+      'directory; falling back to bundled fonts only');
+  return null;
+}
+
+Iterable<String> _ancestorsOf(String path) sync* {
+  String dir = p.dirname(path);
+  for (int i = 0; i < 6; i++) {
+    yield dir;
+    final String parent = p.dirname(dir);
+    if (parent == dir) return;
+    dir = parent;
+  }
+}

--- a/test/screenshots/harness/fixture_env.dart
+++ b/test/screenshots/harness/fixture_env.dart
@@ -1,0 +1,129 @@
+// Isolated filesystem + plugin environment for the screenshot harness.
+//
+// Everything here must run BEFORE the first `AppState()` call. `AppState` is a
+// hard singleton (app_state.dart:34-35) whose GalleryState / FileBrowserState /
+// TaskQueueService fields each fire an async DB read from their constructors —
+// so by the time you can await anything, the database path is already chosen.
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// The temp directory tree every fixture writes into.
+class FixtureEnv {
+  FixtureEnv._(this.root)
+      : dataDir = Directory(p.join(root.path, 'data')),
+        tempDir = Directory(p.join(root.path, 'temp')),
+        docsDir = Directory(p.join(root.path, 'docs')),
+        sourceDir = Directory(p.join(root.path, 'source')),
+        outputDir = Directory(p.join(root.path, 'output')),
+        browserDir = Directory(p.join(root.path, 'browser'));
+
+  final Directory root;
+
+  /// `getApplicationSupportDirectory` — where `joycai_workbench.db` lands.
+  final Directory dataDir;
+
+  /// `getTemporaryDirectory`. GalleryState derives `<temp>/result_cache` from
+  /// this and scans it, so fixtures dropped there populate the processed view.
+  final Directory tempDir;
+
+  /// `getApplicationDocumentsDirectory`.
+  final Directory docsDir;
+
+  /// Workbench source folder, registered as a source directory.
+  final Directory sourceDir;
+
+  /// Workbench output folder.
+  final Directory outputDir;
+
+  /// File-browser root.
+  final Directory browserDir;
+
+  /// `<temp>/result_cache`, the processed-image view's scan root.
+  Directory get resultCacheDir => Directory(p.join(tempDir.path, 'result_cache'));
+
+  /// Every image file written by the seeder, for `precacheImage` warm-up.
+  final List<String> fixtureImagePaths = <String>[];
+
+  void dispose() {
+    try {
+      root.deleteSync(recursive: true);
+    } on FileSystemException {
+      // The sqflite handle may still be open; the OS reaps systemTemp anyway.
+    }
+  }
+}
+
+/// Creates the temp tree and redirects sqflite, path_provider and the plugins
+/// that fire during `build` at it.
+FixtureEnv installFixtureEnv(TestWidgetsFlutterBinding binding) {
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  // A directory of this harness's own. Point path_provider at the shared
+  // systemTemp and every test file opens the same database — `flutter test`
+  // runs files concurrently, so they race for its lock and whoever does the
+  // most I/O loses with "database is locked".
+  final FixtureEnv env = FixtureEnv._(
+    Directory.systemTemp.createTempSync('joycai_ui_shots'),
+  );
+  for (final Directory dir in <Directory>[
+    env.dataDir,
+    env.tempDir,
+    env.docsDir,
+    env.sourceDir,
+    env.outputDir,
+    env.browserDir,
+    env.resultCacheDir,
+  ]) {
+    dir.createSync(recursive: true);
+  }
+
+  // In `flutter test` no plugin registers, so PathProviderPlatform.instance
+  // stays the package's default MethodChannelPathProvider and this mock is what
+  // actually answers. Dispatch per method — the directories must stay distinct
+  // or the result-cache scan collides with the database.
+  binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    const MethodChannel('plugins.flutter.io/path_provider'),
+    (MethodCall call) async {
+      switch (call.method) {
+        case 'getTemporaryDirectory':
+          return env.tempDir.path;
+        case 'getApplicationDocumentsDirectory':
+          return env.docsDir.path;
+        case 'getApplicationSupportDirectory':
+        case 'getApplicationCachePath':
+        case 'getLibraryDirectory':
+        default:
+          return env.dataDir.path;
+      }
+    },
+  );
+
+  // The About section calls PackageInfo.fromPlatform() from initState; without
+  // this the Settings shot carries a MissingPluginException and a blank version.
+  PackageInfo.setMockInitialValues(
+    appName: 'Joycai Image AI Toolkits',
+    packageName: 'com.joycai.imageAiToolkits',
+    version: '3.13.0',
+    buildNumber: '1',
+    buildSignature: '',
+  );
+
+  // Mounted by the workbench gallery and the video config panel.
+  binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    const MethodChannel('desktop_drop'),
+    (MethodCall call) async => null,
+  );
+  binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    const MethodChannel('joycai/window_chrome'),
+    (MethodCall call) async => null,
+  );
+
+  return env;
+}

--- a/test/screenshots/harness/fixture_seed.dart
+++ b/test/screenshots/harness/fixture_seed.dart
@@ -1,0 +1,568 @@
+// Seed data for the screenshot harness.
+//
+// Fidelity is the whole point: an empty database photographs as a wall of empty
+// states, which would be barely more useful than not having the harness. So
+// this fills in enough of every table that each screen has something to lay out.
+//
+// Everything here talks to `DatabaseService()` directly and never touches
+// `AppState()` — the singleton must still be unbuilt when this returns.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:image/image.dart' as img;
+import 'package:joycai_image_ai_toolkits/core/constants.dart';
+import 'package:joycai_image_ai_toolkits/models/llm_channel.dart';
+import 'package:joycai_image_ai_toolkits/models/llm_model.dart';
+import 'package:joycai_image_ai_toolkits/models/pricing_group.dart';
+import 'package:joycai_image_ai_toolkits/models/prompt.dart';
+import 'package:joycai_image_ai_toolkits/models/prompt_history_entry.dart';
+import 'package:joycai_image_ai_toolkits/models/tag.dart';
+import 'package:joycai_image_ai_toolkits/models/task_item.dart';
+import 'package:joycai_image_ai_toolkits/services/database_service.dart';
+import 'package:joycai_image_ai_toolkits/state/app_state.dart';
+import 'package:path/path.dart' as p;
+
+import 'fixture_env.dart';
+
+/// The anchor every seeded timestamp is measured back from.
+///
+/// Deliberately the real clock, not a fixed date: the task list and usage
+/// screens render *relative* times ("今天", elapsed "0:26"), so a pinned anchor
+/// drifts out of the present and photographs as nonsense like "-234:-16".
+/// Captured once per run so all fixtures stay consistent with each other.
+final DateTime kSeedNow = DateTime.now();
+
+Future<void> seedFixtures(FixtureEnv env) async {
+  final DatabaseService db = DatabaseService();
+
+  // Image files first: task rows reference them by path.
+  final _Images images = await _writeImages(env);
+
+  await _seedSettings(db, env);
+  await db.addSourceDirectory(env.sourceDir.path);
+  final _Catalog catalog = await _seedCatalog(db);
+  await _seedPrompts(db);
+  await _seedTasks(db, catalog, images);
+  await _seedUsage(db, catalog);
+}
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+Future<void> _seedSettings(DatabaseService db, FixtureEnv env) async {
+  // The first saveSetting resolves DatabaseService.database, which creates the
+  // schema and runs syncPresets() — so the prompt library picks up the real
+  // assets/presets/prompts/*.json content for free.
+  await db.saveSetting('setup_completed', 'true');
+
+  // Without the row above, AppState.loadSettings sets setupCompleted = false
+  // (app_state.dart:277) and _checkFirstRun pushes SetupWizard over every
+  // screen — every shot would be the wizard.
+
+  await db.saveSetting('locale', 'zh');
+  await db.saveSetting('theme_mode', 'light');
+  await db.saveSetting('is_console_expanded', 'true');
+  await db.saveSetting('is_sidebar_expanded', 'true');
+  await db.saveSetting('sidebar_width', '400');
+  await db.saveSetting('console_height', '160');
+  await db.saveSetting('thumbnail_size', '150');
+  await db.saveSetting('image_prefix', 'result');
+  await db.saveSetting('output_directory', env.outputDir.path);
+  await db.saveSetting('browser_source_directories', env.browserDir.path);
+  await db.saveSetting('browser_active_directories', env.browserDir.path);
+  await db.saveSetting(
+    'last_prompt',
+    '把这张人像换成纯白背景的证件照风格，\n'
+        '保留原有的发型与面部细节，衣着改为深色正装，\n'
+        '光线均匀柔和，不要产生明显的边缘锯齿。',
+  );
+  await db.saveSetting('last_video_prompt', '镜头缓慢推近，背景虚化，暖色调黄昏光线。');
+
+  // Deliberately NOT seeded: `concurrency_limit`. AppState.loadSettings only
+  // calls taskQueue.updateConcurrency when that row exists (app_state.dart:280),
+  // and that path runs _attemptNextExecution() — which would fire real LLM
+  // requests for the pending tasks seeded below.
+}
+
+// ---------------------------------------------------------------------------
+// Channels / pricing groups / models
+// ---------------------------------------------------------------------------
+
+class _Catalog {
+  _Catalog(this.modelIds, this.modelPks);
+
+  /// Provider-facing model ids, for `token_usage.model_id`.
+  final List<String> modelIds;
+
+  /// Primary keys, for `token_usage.model_pk` and `TaskItem.modelDbId`.
+  final List<int> modelPks;
+}
+
+Future<_Catalog> _seedCatalog(DatabaseService db) async {
+  final int googleId = await db.addChannel(LLMChannel(
+    displayName: 'Google AI Studio',
+    endpoint: 'https://generativelanguage.googleapis.com',
+    apiKey: 'fixture-key-google',
+    type: 'google-genai',
+    tag: '官方',
+    tagColor: 0xFF4285F4,
+  ).toMap(includeId: false));
+
+  final int openaiId = await db.addChannel(LLMChannel(
+    displayName: '中转 · OpenAI 兼容',
+    endpoint: 'https://api.example-relay.com/v1',
+    apiKey: 'fixture-key-relay',
+    type: 'openai-api',
+    tag: '中转',
+    tagColor: 0xFF00897B,
+  ).toMap(includeId: false));
+
+  final int flashFee = await db.addPricingGroup(PricingGroup(
+    name: 'Gemini Flash',
+    inputPrice: 0.075,
+    cacheInputPrice: 0.01875,
+    outputPrice: 0.30,
+  ).toMap(includeId: false));
+
+  final int proFee = await db.addPricingGroup(PricingGroup(
+    name: 'Gemini Pro',
+    inputPrice: 1.25,
+    outputPrice: 10.0,
+  ).toMap(includeId: false));
+
+  final int perImageFee = await db.addPricingGroup(PricingGroup(
+    name: '按次计费 · 图片',
+    billingMode: 'request',
+    requestPrice: 0.04,
+  ).toMap(includeId: false));
+
+  final List<LLMModel> models = <LLMModel>[
+    LLMModel(
+      modelId: 'gemini-2.5-flash-image',
+      modelName: 'Nano Banana 图像生成',
+      type: 'google-genai',
+      tag: ModelTag.image.value,
+      channelId: googleId,
+      feeGroupId: perImageFee,
+      contextWindow: 1048576,
+      sortOrder: 0,
+    ),
+    LLMModel(
+      modelId: 'gemini-2.5-flash',
+      modelName: 'Gemini 2.5 Flash',
+      type: 'google-genai',
+      tag: ModelTag.multimodal.value,
+      channelId: googleId,
+      feeGroupId: flashFee,
+      contextWindow: 1048576,
+      sortOrder: 1,
+    ),
+    LLMModel(
+      modelId: 'gemini-2.5-pro',
+      modelName: 'Gemini 2.5 Pro',
+      type: 'google-genai',
+      tag: ModelTag.refiner.value,
+      channelId: googleId,
+      feeGroupId: proFee,
+      contextWindow: 2097152,
+      sortOrder: 2,
+    ),
+    LLMModel(
+      modelId: 'veo-3.1-generate-preview',
+      modelName: 'Veo 3.1 视频生成',
+      type: 'google-genai',
+      tag: ModelTag.video.value,
+      channelId: googleId,
+      feeGroupId: perImageFee,
+      sortOrder: 3,
+    ),
+    LLMModel(
+      modelId: 'gpt-5-chat',
+      modelName: 'GPT-5 Chat',
+      type: 'openai-api',
+      tag: ModelTag.chat.value,
+      channelId: openaiId,
+      feeGroupId: proFee,
+      contextWindow: 400000,
+      sortOrder: 4,
+    ),
+  ];
+
+  final List<int> pks = <int>[];
+  for (final LLMModel model in models) {
+    pks.add(await db.addModel(model.toMap(includeId: false)));
+  }
+  return _Catalog(models.map((LLMModel m) => m.modelId).toList(), pks);
+}
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
+Future<void> _seedPrompts(DatabaseService db) async {
+  final int portraitTag = await db.addPromptTag(
+      PromptTag(name: '人像', color: 0xFF8E24AA, sortOrder: 0).toMap(includeId: false));
+  final int productTag = await db.addPromptTag(
+      PromptTag(name: '电商', color: 0xFF1E88E5, sortOrder: 1).toMap(includeId: false));
+  final int styleTag = await db.addPromptTag(
+      PromptTag(name: '风格化', color: 0xFFF4511E, sortOrder: 2).toMap(includeId: false));
+
+  final List<(String, String, List<int>)> prompts = <(String, String, List<int>)>[
+    (
+      '证件照换底色',
+      '将人物背景替换为纯白色，保留头发丝级别的边缘细节，'
+          '衣着改为深色正装，光线均匀无阴影。',
+      <int>[portraitTag],
+    ),
+    (
+      '电商白底图',
+      '去除背景并替换为纯白 #FFFFFF，商品居中，'
+          '保留自然投影，输出方形构图，留白 8%。',
+      <int>[productTag],
+    ),
+    (
+      '胶片质感调色',
+      '模拟 Portra 400 的色彩响应：肤色偏暖，'
+          '高光柔和滚降，暗部保留青色倾向，加入细腻颗粒。',
+      <int>[styleTag],
+    ),
+    (
+      '人像磨皮但保留质感',
+      '均匀肤色与瑕疵，但必须保留毛孔与皮肤纹理，'
+          '不要产生塑料感，眼神光保持原样。',
+      <int>[portraitTag, styleTag],
+    ),
+    (
+      '批量生成场景变体',
+      '保持主体不变，仅替换环境：咖啡馆、海边栈道、'
+          '城市夜景霓虹，各输出一张。',
+      <int>[productTag, styleTag],
+    ),
+  ];
+
+  for (int i = 0; i < prompts.length; i++) {
+    final (String title, String content, List<int> tags) = prompts[i];
+    await db.addPrompt(
+      Prompt(title: title, content: content, sortOrder: i).toMap(includeId: false),
+      tagIds: tags,
+    );
+  }
+
+  for (final String entry in <String>[
+    '把背景换成纯白，主体不变',
+    '增加一点暖色调，模拟黄昏光线',
+    '保留原始构图，只提升清晰度和对比度',
+  ]) {
+    await db.addPromptHistory(PromptHistoryType.image, entry);
+  }
+  await db.addPromptHistory(PromptHistoryType.video, '镜头缓慢推近，背景虚化');
+}
+
+// ---------------------------------------------------------------------------
+// Tasks
+// ---------------------------------------------------------------------------
+
+Future<void> _seedTasks(DatabaseService db, _Catalog catalog, _Images images) async {
+  // TaskQueueService._loadRecentTasks only reads the newest 10 rows, so keep
+  // the total at or under that or the older ones simply never appear.
+  final List<TaskItem> tasks = <TaskItem>[
+    _task(
+      id: 'fixture-task-1',
+      catalog: catalog,
+      modelIndex: 0,
+      status: TaskStatus.completed,
+      imagePaths: images.source.take(2).toList(),
+      resultPaths: images.output.take(2).toList(),
+      startedMinutesAgo: 240,
+      durationSeconds: 47,
+    ),
+    _task(
+      id: 'fixture-task-2',
+      catalog: catalog,
+      modelIndex: 0,
+      status: TaskStatus.completed,
+      imagePaths: images.source.skip(2).take(1).toList(),
+      resultPaths: images.output.skip(2).take(1).toList(),
+      startedMinutesAgo: 180,
+      durationSeconds: 31,
+    ),
+    _task(
+      id: 'fixture-task-3',
+      catalog: catalog,
+      modelIndex: 1,
+      status: TaskStatus.failed,
+      imagePaths: images.source.skip(3).take(1).toList(),
+      startedMinutesAgo: 120,
+      durationSeconds: 12,
+      error: '429 RESOURCE_EXHAUSTED: 配额已用尽，请稍后重试',
+    ),
+    _task(
+      id: 'fixture-task-4',
+      catalog: catalog,
+      modelIndex: 3,
+      type: TaskType.videoGenerate,
+      status: TaskStatus.completed,
+      imagePaths: images.source.skip(4).take(1).toList(),
+      startedMinutesAgo: 90,
+      durationSeconds: 186,
+    ),
+    _task(
+      id: 'fixture-task-5',
+      catalog: catalog,
+      modelIndex: 2,
+      type: TaskType.promptRefine,
+      status: TaskStatus.cancelled,
+      imagePaths: const <String>[],
+      startedMinutesAgo: 60,
+      durationSeconds: 8,
+    ),
+    _task(
+      id: 'fixture-task-6',
+      catalog: catalog,
+      modelIndex: 0,
+      status: TaskStatus.pending,
+      imagePaths: images.source.skip(5).take(3).toList(),
+    ),
+    _task(
+      id: 'fixture-task-7',
+      catalog: catalog,
+      modelIndex: 0,
+      status: TaskStatus.pending,
+      imagePaths: images.source.skip(8).take(2).toList(),
+    ),
+  ];
+
+  for (final TaskItem task in tasks) {
+    await db.saveTask(task.toMap());
+  }
+}
+
+TaskItem _task({
+  required String id,
+  required _Catalog catalog,
+  required int modelIndex,
+  required TaskStatus status,
+  required List<String> imagePaths,
+  TaskType type = TaskType.imageProcess,
+  List<String> resultPaths = const <String>[],
+  int? startedMinutesAgo,
+  int durationSeconds = 0,
+  String? error,
+}) {
+  final DateTime? start = startedMinutesAgo == null
+      ? null
+      : kSeedNow.subtract(Duration(minutes: startedMinutesAgo));
+  final TaskItem task = TaskItem(
+    id: id,
+    type: type,
+    imagePaths: imagePaths,
+    modelId: catalog.modelIds[modelIndex],
+    modelDbId: catalog.modelPks[modelIndex],
+    channelTag: modelIndex == 4 ? '中转' : '官方',
+    channelColor: modelIndex == 4 ? 0xFF00897B : 0xFF4285F4,
+    parameters: <String, dynamic>{
+      'prompt': '把背景换成纯白，主体保持不变，保留发丝细节',
+      'aspect_ratio': '1:1',
+    },
+    status: status,
+    resultPaths: List<String>.from(resultPaths),
+    startTime: start,
+    endTime: start?.add(Duration(seconds: durationSeconds)),
+    logs: _logLines(status, error),
+  );
+  return task;
+}
+
+List<String> _logLines(TaskStatus status, String? error) {
+  final List<String> lines = <String>[
+    '[14:02:11] 任务已加入队列',
+    '[14:02:11] 解析模型配置：channel=官方',
+    '[14:02:12] 读取输入图片 (3 张)',
+    '[14:02:12] 压缩参考图：2.8MB → 940KB',
+    '[14:02:13] 构建请求负载 (inline_data ×3)',
+    '[14:02:13] POST /v1beta/models/gemini-2.5-flash-image:streamGenerateContent',
+    '[14:02:15] 收到首个响应块',
+    '[14:02:19] 已接收 12 个文本块',
+    '[14:02:24] 收到图像数据 (1024×1024, PNG)',
+    '[14:02:25] 写入输出目录',
+  ];
+  switch (status) {
+    case TaskStatus.completed:
+      lines.add('[14:02:25] 任务完成，用时 47.2s');
+    case TaskStatus.failed:
+      lines.add('[14:02:23] ERROR ${error ?? '未知错误'}');
+      lines.add('[14:02:23] 任务失败');
+    case TaskStatus.cancelled:
+      lines.add('[14:02:19] 用户取消了任务');
+    case TaskStatus.pending:
+    case TaskStatus.processing:
+      return lines.take(2).toList();
+  }
+  return lines;
+}
+
+/// Flips one pending task to "running" in memory.
+///
+/// It cannot be seeded through the database: TaskQueueService's constructor
+/// calls cleanupStuckTasks(), which rewrites every `processing` row to `failed`
+/// (task_repository.dart:26-33).
+void markOneTaskRunning(AppState appState) {
+  final List<TaskItem> queue = appState.taskQueue.queue;
+  final int index = queue.indexWhere((TaskItem t) => t.status == TaskStatus.pending);
+  if (index == -1) return;
+  queue[index]
+    ..status = TaskStatus.processing
+    ..progress = 0.42
+    ..startTime = kSeedNow.subtract(const Duration(seconds: 26))
+    ..logs = <String>[
+      '[14:29:34] 任务已加入队列',
+      '[14:29:35] 构建请求负载 (inline_data ×3)',
+      '[14:29:36] 已接收 8 个文本块…',
+    ];
+  // notifyListeners() only — it does not call _attemptNextExecution
+  // (task_queue_service.dart:185-187), so nothing actually executes.
+  appState.taskQueue.refreshQueue();
+}
+
+/// Refills the execution-log console.
+///
+/// Called per shot after `clearLogs()`: logs otherwise accumulate across shots,
+/// so the console strip would differ run to run for reasons unrelated to layout.
+void seedLogs(AppState appState) {
+  appState.addLog('Loading settings from database...');
+  appState.addLog('已加载 5 个模型 / 2 个渠道');
+  appState.addLog('扫描来源目录：找到 12 张图片');
+  appState.addLog('任务 fixture-task-1 完成，用时 47.2s');
+  appState.addLog('429 RESOURCE_EXHAUSTED: 配额已用尽，请稍后重试', level: 'ERROR');
+  appState.addLog('任务 fixture-task-6 已加入队列');
+}
+
+// ---------------------------------------------------------------------------
+// Token usage
+// ---------------------------------------------------------------------------
+
+Future<void> _seedUsage(DatabaseService db, _Catalog catalog) async {
+  int seed = 7;
+  int next(int max) {
+    // Deterministic LCG — Random() without a seed would make every run differ.
+    seed = (seed * 1103515245 + 12345) & 0x7FFFFFFF;
+    return seed % max;
+  }
+
+  for (int day = 29; day >= 0; day--) {
+    final int rowsToday = 1 + next(3);
+    for (int r = 0; r < rowsToday; r++) {
+      final int m = next(catalog.modelPks.length);
+      final DateTime ts = kSeedNow
+          .subtract(Duration(days: day))
+          .subtract(Duration(hours: next(10), minutes: next(60)));
+      final int inputTokens = 800 + next(9000);
+      final int cacheTokens = next(2) == 0 ? 0 : next(3000);
+      final int outputTokens = 200 + next(2500);
+      await db.recordTokenUsage(<String, dynamic>{
+        'task_id': 'fixture-usage-$day-$r',
+        'model_id': catalog.modelIds[m],
+        'model_pk': catalog.modelPks[m],
+        'timestamp': ts.toIso8601String(),
+        'input_tokens': inputTokens,
+        'cache_tokens': cacheTokens,
+        'output_tokens': outputTokens,
+        'input_price': 0.075,
+        'cache_price': 0.01875,
+        'output_price': 0.30,
+        'request_count': 1,
+        'request_price': 0.04,
+        'billing_mode': m == 0 || m == 3 ? 'request' : 'token',
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Image fixtures
+// ---------------------------------------------------------------------------
+
+class _Images {
+  _Images(this.source, this.output);
+  final List<String> source;
+  final List<String> output;
+}
+
+/// Generates PNGs rather than committing binary fixtures.
+///
+/// Aspect ratios are deliberately mixed: they drive the gallery grid's layout,
+/// so a set of uniform squares would hide exactly the bugs worth catching.
+Future<_Images> _writeImages(FixtureEnv env) async {
+  const List<(int, int)> shapes = <(int, int)>[
+    (512, 512),
+    (768, 512),
+    (512, 896),
+    (640, 640),
+    (896, 512),
+    (512, 768),
+  ];
+
+  Future<List<String>> writeSet(Directory dir, String prefix, int count) async {
+    final List<String> paths = <String>[];
+    for (int i = 0; i < count; i++) {
+      final (int w, int h) = shapes[i % shapes.length];
+      paths.add(await _writePng(env, dir, '${prefix}_${i + 1}', w, h, i));
+    }
+    return paths;
+  }
+
+  final List<String> source = await writeSet(env.sourceDir, 'source', 12);
+  final List<String> output = await writeSet(env.outputDir, 'result', 6);
+  await writeSet(env.resultCacheDir, 'cached', 6);
+  await writeSet(env.browserDir, 'photo', 8);
+
+  // Non-image types so the browser's category filters and icon fallbacks are
+  // actually exercised. These are stubs; they are meant to be listed, not played.
+  for (final String name in <String>['clip_a.mp4', 'clip_b.mov', 'notes.txt', 'voice.mp3']) {
+    File(p.join(env.browserDir.path, name))
+        .writeAsBytesSync(utf8.encode('fixture placeholder for $name'));
+  }
+
+  return _Images(source, output);
+}
+
+/// A flat colour block with its own name burned in, so a screenshot makes it
+/// obvious which fixture landed where.
+Future<String> _writePng(
+  FixtureEnv env,
+  Directory dir,
+  String name,
+  int width,
+  int height,
+  int index,
+) async {
+  const List<int> palette = <int>[
+    0xFF4285F4,
+    0xFF00897B,
+    0xFFF4511E,
+    0xFF8E24AA,
+    0xFF43A047,
+    0xFFFB8C00,
+  ];
+  final int argb = palette[index % palette.length];
+  final img.Image image = img.Image(width: width, height: height);
+  img.fill(
+    image,
+    color: img.ColorRgb8((argb >> 16) & 0xFF, (argb >> 8) & 0xFF, argb & 0xFF),
+  );
+  img.drawString(
+    image,
+    '$name\n$width×$height',
+    font: img.arial24,
+    x: 16,
+    y: 16,
+    color: img.ColorRgb8(255, 255, 255),
+  );
+
+  final File file = File(p.join(dir.path, '$name.png'));
+  await file.writeAsBytes(img.encodePng(image));
+  env.fixtureImagePaths.add(file.path);
+  return file.path;
+}

--- a/test/screenshots/harness/shoot.dart
+++ b/test/screenshots/harness/shoot.dart
@@ -1,0 +1,151 @@
+// The screenshot helper: mounts the real app at a given size and writes a PNG.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/main.dart';
+import 'package:joycai_image_ai_toolkits/state/app_state.dart';
+import 'package:provider/provider.dart';
+
+import 'fixture_env.dart';
+import 'fixture_seed.dart';
+
+/// Declared in the order of `_getNavDefinitions` in main.dart:239-248, so
+/// `AppScreen.index` *is* the argument `AppState.navigateToScreen` wants.
+///
+/// The mapping is 1:1 only because the harness runs on a desktop host: at
+/// main.dart:256 `isMobilePlatform` reads `Platform.isAndroid || isIOS`, so it
+/// is always false here and no destinations are filtered out. See the caveat
+/// in docs/ui-screenshot-harness.md about the 390px shots.
+enum AppScreen {
+  workbench,
+  fileBrowser,
+  tasks,
+  downloader,
+  prompts,
+  models,
+  usage,
+  settings,
+}
+
+class ShotSize {
+  const ShotSize(this.label, this.size);
+  final String label;
+  final Size size;
+}
+
+const List<ShotSize> kShotSizes = <ShotSize>[
+  ShotSize('mobile', Size(390, 844)), //   < 600  → NavigationBar + drawer
+  ShotSize('tablet', Size(834, 1112)), //  < 1000 → icon-only rail
+  ShotSize('desktop', Size(1440, 900)), // ≥ 1000 → labelled rail
+];
+
+/// Renders [screen] at [size] and writes `<screen>_<size>_<brightness><suffix>.png`
+/// into `build/ui-screenshots/`.
+///
+/// [before] runs after the singleton is configured but before the first pump —
+/// use it to set state the screen reads on mount. [after] runs on the settled
+/// tree, for taps that open a dialog or switch a tab.
+Future<void> shoot(
+  WidgetTester tester, {
+  required FixtureEnv env,
+  required AppScreen screen,
+  required ShotSize size,
+  Brightness brightness = Brightness.light,
+  Locale locale = const Locale('zh'),
+  String? suffix,
+  Future<void> Function(WidgetTester tester)? before,
+  Future<void> Function(WidgetTester tester)? after,
+}) async {
+  final String name =
+      '${screen.name}_${size.label}_${brightness.name}${suffix == null ? '' : '_$suffix'}';
+
+  tester.view.physicalSize = size.size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  final AppState appState = AppState();
+  appState.themeMode =
+      brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light;
+  appState.locale = locale;
+  // Logs accumulate across shots and would make the console strip differ run
+  // to run for reasons that have nothing to do with layout.
+  appState.clearLogs();
+  seedLogs(appState);
+  appState.navigateToScreen(screen.index);
+  await before?.call(tester);
+
+  // Real async: the screens' initState sqflite queries and the compute()
+  // isolates behind the gallery/browser scans only make progress out here.
+  await tester.runAsync(() async {
+    await tester.pumpWidget(_appTree(appState));
+    await Future<void>.delayed(const Duration(milliseconds: 700));
+    await tester.pump();
+    await _warmImageCache(tester, env);
+    await tester.pump();
+  });
+
+  // 800ms covers the nav rail's 140ms AnimatedContainer and the 200ms
+  // AppConstants.animationDuration used across the screens.
+  for (int i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  if (after != null) {
+    await after(tester);
+    for (int i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+  }
+
+  // Drain, never assert. An overflow is the bug we are hunting, and
+  // expect(takeException(), isNull) would abort before writing the PNG —
+  // losing exactly the picture worth looking at.
+  for (Object? e = tester.takeException(); e != null; e = tester.takeException()) {
+    debugPrint('[$name] exception during pump: $e');
+  }
+
+  await tester.pump();
+  await expectLater(find.byType(MyApp), matchesGoldenFile('$name.png'));
+}
+
+Widget _appTree(AppState appState) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<AppState>.value(value: appState),
+      ChangeNotifierProvider.value(value: appState.taskQueue),
+      ChangeNotifierProvider.value(value: appState.workbenchUIState),
+      ChangeNotifierProvider.value(value: appState.fileBrowserState),
+      // main.dart does not register this one, but several widgets read it.
+      ChangeNotifierProvider.value(value: appState.galleryState),
+      ChangeNotifierProvider.value(value: appState.downloaderState),
+    ],
+    child: const MyApp(version: '3.13.0'),
+  );
+}
+
+/// Decoding a [FileImage] is asynchronous, so without this every thumbnail
+/// captures as an empty box — the classic golden-test failure.
+///
+/// Must run after the gallery scan: `GalleryState._evictImages` clears the
+/// image cache on every scan, which would undo the warm-up.
+Future<void> _warmImageCache(WidgetTester tester, FixtureEnv env) async {
+  final Finder app = find.byType(MyApp);
+  if (app.evaluate().isEmpty) return;
+  final BuildContext context = tester.element(app);
+
+  for (final String path in env.fixtureImagePaths) {
+    try {
+      await precacheImage(FileImage(File(path)), context);
+    } catch (_) {
+      // A format the decoder does not handle (the .mp4/.mp3 stubs); the widget
+      // shows its own error placeholder, which is what the real app does too.
+    }
+  }
+  try {
+    await precacheImage(const AssetImage('assets/icon/icon.png'), context);
+  } catch (_) {
+    // Only the About block's logo; not worth failing a shot over.
+  }
+}


### PR DESCRIPTION
## Why

The app is desktop-only, so there was no way to actually *look* at a layout — only to read the widget tree and guess.

The obvious fix was a Flutter web build for UI debugging. I investigated it and it does not pay off here:

- 56 files under `lib/` import `dart:io`; 27 are directly in `lib/screens` / `lib/widgets`.
- The coupling is structural, not incidental: `AppState` is a hard singleton behind `DatabaseService` → `sqflite_common_ffi`, and the models themselves are file-backed — `AppImage.imageProvider` and `BrowserFile.imageProvider` both return `FileImage(File(path))`. Every top-level screen fails to compile transitively, even the ones that look clean.
- Even after a port there is no SQLite and no filesystem on web, so every screen would render as an **empty state** — not the layouts worth debugging — while each new `dart:io` call site broke the web build again. A permanent maintenance tax for poor fidelity.

So this renders the real widget tree headlessly instead. `test/responsive_layout_test.dart` already boots the real `MyApp` at three widths against real sqflite; it just threw the pixels away. This keeps them.

## What

```bash
flutter test test/screenshots          # 32 PNGs into build/ui-screenshots/, ~30s
flutter test test/screenshots --plain-name workbench
```

8 screens × 3 widths in light, plus a dark shot of each.

| File | Responsibility |
|---|---|
| `test/screenshots/flutter_test_config.dart` | Loads real fonts; installs the always-overwrite golden comparator; disables the debug banner |
| `test/screenshots/app_screens_test.dart` | The screen × size matrix |
| `test/screenshots/harness/fixture_env.dart` | Temp directory tree, sqflite ffi, path_provider + plugin channel mocks |
| `test/screenshots/harness/fixture_seed.dart` | Database rows and generated PNG fixtures |
| `test/screenshots/harness/shoot.dart` | `shoot()`, the `AppScreen` enum, `kShotSizes` |

**No production code changed.** Navigation uses the existing public `AppState.navigateToScreen`, the same call the nav rail, drawer and `Ctrl+1..8` all make.

Fidelity is the point, so the fixtures seed enough that screens have something to lay out: 2 channels, 5 models, 5 prompts plus the bundled presets, 7 tasks across every status (including one running at 42%), 30 days of token usage, and generated PNGs at mixed aspect ratios (uniform squares would hide grid bugs).

## It already found real bugs

First full run:

```
[prompts_tablet_light]   A RenderFlex overflowed by 113 pixels on the right.
[prompts_mobile_light]   A RenderFlex overflowed by 33 pixels on the right.
[tasks_mobile_light]     Multiple exceptions
[workbench_mobile_light] Multiple exceptions
```

Out of scope for this PR — tracked separately.

## For reviewers

**This is deliberately not a regression gate.** The comparator always overwrites and always passes, so a UI change can never fail `flutter test`. Layout exceptions are drained and printed rather than asserted: an overflow is exactly the thing you want a picture of, and `expect(takeException(), isNull)` would abort before the PNG got written.

**`flutter_test_config.dart` must stay in `test/screenshots/`.** flutter_tools takes the nearest one walking up from the test file. At `test/` it would apply to all 49 existing tests and change their text metrics — several of them assert on layout and overflow.

**Known limitation: mobile size ≠ mobile platform.** `main.dart:256` reads `Platform.isAndroid || Platform.isIOS` to decide which nav destinations exist, and that is a `dart:io` check the harness cannot override on a macOS host. So the 390px shots show File Browser and Downloader even though a real phone hides them. Layout — `NavigationBar`, drawer, breakpoints — is faithful; only the destination set is not. Documented.

Rationale, setup-order constraints and extension instructions are in `docs/ui-screenshot-harness.md`.

## Verification

- `flutter analyze` → **No issues found!**
- `flutter test` → **428 passed** (9 skips are pre-existing); the 49 existing tests are unchanged
- 32 PNGs generated; each inspected for readable text, correct CJK, visible Material icons
- Worktree stays clean: no stray `joycai_workbench.db`, no PNGs outside gitignored `build/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)