### PR TITLE
fix(ui): drop redundant channel chip, share run console, harden overwrite confirm

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -960,6 +960,7 @@
   "overwriteSource": "Overwrite Original",
   "overwriteConfirmTitle": "Overwrite Original File?",
   "overwriteConfirmMessage": "This action will permanently replace the original file. Are you sure?",
+  "overwriteConfirmSaveCopyInstead": "Save Copy Instead",
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -820,6 +820,7 @@
   "overwriteSource": "元のファイルを上書き",
   "overwriteConfirmTitle": "元のファイルを上書きしますか？",
   "overwriteConfirmMessage": "この操作により、元のファイルが完全に置き換えられます。よろしいですか？",
+  "overwriteConfirmSaveCopyInstead": "代わりにコピーを保存",
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3623,6 +3623,12 @@ abstract class AppLocalizations {
   /// **'This action will permanently replace the original file. Are you sure?'**
   String get overwriteConfirmMessage;
 
+  /// No description provided for @overwriteConfirmSaveCopyInstead.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Copy Instead'**
+  String get overwriteConfirmSaveCopyInstead;
+
   /// No description provided for @saveToTempSuccess.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1940,6 +1940,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'This action will permanently replace the original file. Are you sure?';
 
   @override
+  String get overwriteConfirmSaveCopyInstead => 'Save Copy Instead';
+
+  @override
   String get saveToTempSuccess => 'Image saved to temporary workspace';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1896,6 +1896,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get overwriteConfirmMessage => 'この操作により、元のファイルが完全に置き換えられます。よろしいですか？';
 
   @override
+  String get overwriteConfirmSaveCopyInstead => '代わりにコピーを保存';
+
+  @override
   String get saveToTempSuccess => '画像が一時ワークスペースに保存されました';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1882,6 +1882,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get overwriteConfirmMessage => '此操作将永久修改原始文件，确定要继续吗？';
 
   @override
+  String get overwriteConfirmSaveCopyInstead => '改为保存副本';
+
+  @override
   String get saveToTempSuccess => '已保存至临时工作区';
 
   @override
@@ -4320,6 +4323,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get overwriteConfirmMessage => '此操作將永久替換原始檔案。您確定嗎？';
+
+  @override
+  String get overwriteConfirmSaveCopyInstead => '改為儲存副本';
 
   @override
   String get saveToTempSuccess => '圖片已儲存至臨時工作區';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -946,6 +946,7 @@
   "overwriteSource": "覆盖原图",
   "overwriteConfirmTitle": "确定覆盖原图？",
   "overwriteConfirmMessage": "此操作将永久修改原始文件，确定要继续吗？",
+  "overwriteConfirmSaveCopyInstead": "改为保存副本",
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -820,6 +820,7 @@
   "overwriteSource": "覆蓋原始檔案",
   "overwriteConfirmTitle": "覆蓋原始檔案？",
   "overwriteConfirmMessage": "此操作將永久替換原始檔案。您確定嗎？",
+  "overwriteConfirmSaveCopyInstead": "改為儲存副本",
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -151,6 +151,7 @@
   "overwriteSource": "Overwrite Original",
   "overwriteConfirmTitle": "Overwrite Original File?",
   "overwriteConfirmMessage": "This action will permanently replace the original file. Are you sure?",
+  "overwriteConfirmSaveCopyInstead": "Save Copy Instead",
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -151,6 +151,7 @@
   "overwriteSource": "元のファイルを上書き",
   "overwriteConfirmTitle": "元のファイルを上書きしますか？",
   "overwriteConfirmMessage": "この操作により、元のファイルが完全に置き換えられます。よろしいですか？",
+  "overwriteConfirmSaveCopyInstead": "代わりにコピーを保存",
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -151,6 +151,7 @@
   "overwriteSource": "覆盖原图",
   "overwriteConfirmTitle": "确定覆盖原图？",
   "overwriteConfirmMessage": "此操作将永久修改原始文件，确定要继续吗？",
+  "overwriteConfirmSaveCopyInstead": "改为保存副本",
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -151,6 +151,7 @@
   "overwriteSource": "覆蓋原始檔案",
   "overwriteConfirmTitle": "覆蓋原始檔案？",
   "overwriteConfirmMessage": "此操作將永久替換原始檔案。您確定嗎？",
+  "overwriteConfirmSaveCopyInstead": "改為儲存副本",
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",

--- a/lib/screens/batch/task_queue_screen.dart
+++ b/lib/screens/batch/task_queue_screen.dart
@@ -13,6 +13,7 @@ import '../../state/app_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
 import '../../widgets/app_icon_button.dart';
+import '../../widgets/app_run_console.dart';
 import '../../widgets/app_snackbar.dart';
 import '../../widgets/dialogs/task_log_dialog.dart';
 
@@ -45,19 +46,21 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
     final appState = Provider.of<AppState>(context);
     final l10n = AppLocalizations.of(context)!;
 
+    // Embedded presentation (workbench bottom-sheet console): the sheet already
+    // paints the canvas and its own run console, so nesting another one here
+    // would show a console inside the console it was opened from.
+    final inBottomSheet = context.findAncestorWidgetOfExactType<BottomSheet>() != null;
+
     if (Responsive.isNarrow(context)) {
-      return _buildMobileLayout(context, appState, l10n);
+      return _buildMobileLayout(context, appState, l10n, inBottomSheet: inBottomSheet);
     }
 
     final content = _buildDesktopContent(context, appState, l10n);
-
-    // Embedded presentation (workbench bottom-sheet console): the sheet already
-    // paints the canvas, so the content drops straight onto it.
-    final inBottomSheet = context.findAncestorWidgetOfExactType<BottomSheet>() != null;
     if (inBottomSheet) return content;
 
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+      bottomNavigationBar: const AppRunConsole(),
       body: content,
     );
   }
@@ -92,13 +95,19 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
 
   // ── Mobile layout ───────────────────────────────────────────────────────────
 
-  Widget _buildMobileLayout(BuildContext context, AppState appState, AppLocalizations l10n) {
+  Widget _buildMobileLayout(
+    BuildContext context,
+    AppState appState,
+    AppLocalizations l10n, {
+    required bool inBottomSheet,
+  }) {
     final queue = appState.taskQueue.queue;
     final tasks = _visibleTasks(queue);
     final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
       backgroundColor: colorScheme.surfaceContainer,
+      bottomNavigationBar: inBottomSheet ? null : const AppRunConsole(),
       appBar: AppBar(
         title: Text(l10n.taskQueueManager),
         actions: [

--- a/lib/screens/browser/file_browser_screen.dart
+++ b/lib/screens/browser/file_browser_screen.dart
@@ -17,6 +17,7 @@ import '../../state/app_state.dart';
 import '../../state/file_browser_state.dart';
 import '../../state/workbench_ui_state.dart';
 import '../../widgets/app_icon_button.dart';
+import '../../widgets/app_run_console.dart';
 import '../../widgets/dialogs/file_rename_dialog.dart';
 import '../../widgets/panel_resizer.dart';
 import '../../widgets/unified_sidebar.dart';
@@ -260,6 +261,7 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
         drawer: isNarrow
             ? const Drawer(child: UnifiedSidebar(useFileBrowserState: true))
             : null,
+        bottomNavigationBar: const AppRunConsole(),
         body: Padding(
           padding: const EdgeInsets.all(8),
           child: Row(

--- a/lib/screens/downloader/image_downloader_screen.dart
+++ b/lib/screens/downloader/image_downloader_screen.dart
@@ -10,6 +10,7 @@ import '../../l10n/app_localizations.dart';
 import '../../services/task_queue_service.dart';
 import '../../services/web_scraper_service.dart';
 import '../../state/app_state.dart';
+import '../../widgets/app_run_console.dart';
 import '../../widgets/app_snackbar.dart';
 import '../../widgets/panel_resizer.dart';
 import 'widgets/downloader_results_area.dart';
@@ -261,6 +262,7 @@ class _ImageDownloaderScreenState extends State<ImageDownloaderScreen> {
     // tinted surfaceContainer background.
     return Scaffold(
       backgroundColor: colorScheme.surfaceContainer,
+      bottomNavigationBar: const AppRunConsole(),
       body: Padding(
         padding: const EdgeInsets.all(8),
         child: PanelCard(

--- a/lib/screens/prompts/prompts_screen.dart
+++ b/lib/screens/prompts/prompts_screen.dart
@@ -9,6 +9,7 @@ import '../../services/database_service.dart';
 import '../../state/app_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_icon_button.dart';
+import '../../widgets/app_run_console.dart';
 import '../../widgets/app_segmented_control.dart';
 import '../../widgets/panel_resizer.dart';
 import 'prompts_io.dart';
@@ -127,6 +128,7 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
         tablet: _buildDesktopLayout(l10n, isTablet: true),
         desktop: _buildDesktopLayout(l10n),
       ),
+      bottomNavigationBar: const AppRunConsole(),
       floatingActionButton: _isSelectionMode ? _buildBulkActionFAB(l10n) : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
     );

--- a/lib/screens/workbench/widgets/crop_resize_toolbar.dart
+++ b/lib/screens/workbench/widgets/crop_resize_toolbar.dart
@@ -215,48 +215,81 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
     final uiState = Provider.of<WorkbenchUIState>(context, listen: false);
     final appState = Provider.of<AppState>(context, listen: false);
 
-    if (overwrite) {
-      final confirmTitle = l10n.overwriteConfirmTitle;
-      final confirmMessage = l10n.overwriteConfirmMessage;
-      final cancelLabel = l10n.cancel;
-      final overwriteLabel = l10n.overwriteSource;
+    final sourceImage = uiState.cropResizeSourceImage;
+    if (sourceImage == null) return;
 
+    final editorState = uiState.cropKey.currentState as ExtendedImageEditorState?;
+    if (editorState == null) return;
+
+    final cropRect = editorState.getCropRect();
+    if (cropRect == null) return;
+
+    final int? w = int.tryParse(_widthController.text);
+    final int? h = int.tryParse(_heightController.text);
+    final outputWidth = w ?? cropRect.width.round();
+    final outputHeight = h ?? cropRect.height.round();
+
+    if (overwrite) {
+      final originalMeta = await ImageMetadataService().getMetadata(sourceImage.path);
+      if (!mounted) return;
+
+      final colorScheme = Theme.of(context).colorScheme;
+      final originalSize =
+          originalMeta != null ? '${originalMeta.width}×${originalMeta.height}' : '–';
+
+      // true = overwrite, false = save a copy instead, null = cancelled.
       final confirmed = await AppDialog.show<bool>(
         context,
-        title: confirmTitle,
-        content: Text(confirmMessage),
+        title: l10n.overwriteConfirmTitle,
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(l10n.overwriteConfirmMessage),
+            const SizedBox(height: 14),
+            Text(
+              sourceImage.name,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            ),
+            const SizedBox(height: 3),
+            Text(
+              '$originalSize → $outputWidth×$outputHeight',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+        ),
         actions: [
           AppButton(
-            label: cancelLabel,
+            label: l10n.cancel,
             variant: AppButtonVariant.text,
+            onPressed: () => Navigator.pop(context, null),
+          ),
+          AppButton(
+            label: l10n.overwriteConfirmSaveCopyInstead,
+            variant: AppButtonVariant.secondary,
             onPressed: () => Navigator.pop(context, false),
           ),
           AppButton(
-            label: overwriteLabel,
+            label: l10n.overwriteSource,
             variant: AppButtonVariant.destructive,
             onPressed: () => Navigator.pop(context, true),
           ),
         ],
       );
-      if (confirmed != true) return;
+
+      if (confirmed == null) return;
+      if (confirmed == false) return _handleSave(overwrite: false);
     }
 
     if (!mounted) return;
     setState(() => _processingAction = overwrite ? 'overwrite' : 'save');
 
     try {
-      final sourceImage = uiState.cropResizeSourceImage;
-      if (sourceImage == null) return;
-
-      final state = uiState.cropKey.currentState as ExtendedImageEditorState?;
-      if (state == null) return;
-      
-      final cropRect = state.getCropRect();
-      if (cropRect == null) return;
-
-      final int? w = int.tryParse(_widthController.text);
-      final int? h = int.tryParse(_heightController.text);
-      
       SamplingMethod sampling;
       switch (uiState.samplingMethod) {
         case 'nearest': sampling = SamplingMethod.nearest; break;

--- a/lib/screens/workbench/widgets/workbench_top_bar.dart
+++ b/lib/screens/workbench/widgets/workbench_top_bar.dart
@@ -4,8 +4,6 @@ import 'package:provider/provider.dart';
 import '../../../core/constants.dart';
 import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
-import '../../../models/llm_channel.dart';
-import '../../../models/llm_model.dart';
 import '../../../state/app_state.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
@@ -35,27 +33,8 @@ class WorkbenchTopBar extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final isSidebarExpanded = context.select<AppState, bool>((s) => s.isSidebarExpanded);
     final concurrencyLimit = context.select<AppState, int>((s) => s.concurrencyLimit);
-    final imageModels = context.select<AppState, List<LLMModel>>((s) => s.imageModels);
-    final allChannels = context.select<AppState, List<LLMChannel>>((s) => s.allChannels);
-    final lastSelectedModelId = context.select<AppState, String?>((s) => s.lastSelectedModelId);
     final isNarrow = Responsive.isNarrow(context);
     final isMobile = Responsive.isMobile(context);
-
-    // Derive active channel name for the trailing chip.
-    String? channelName;
-    if (lastSelectedModelId != null && imageModels.isNotEmpty && allChannels.isNotEmpty) {
-      final dbId = int.tryParse(lastSelectedModelId);
-      LLMModel? model;
-      if (dbId != null) {
-        try { model = imageModels.firstWhere((m) => m.id == dbId); } catch (_) {}
-      }
-      if (model != null) {
-        try {
-          final ch = allChannels.firstWhere((c) => c.id == model!.channelId);
-          channelName = ch.displayName;
-        } catch (_) {}
-      }
-    }
 
     // Primary creation modes — the headline functions of the workbench.
     final primary = <_WbDest>[
@@ -161,32 +140,7 @@ class WorkbenchTopBar extends StatelessWidget {
                     icon: const Icon(Icons.tune),
                     tooltip: l10n.modelSelection,
                     onPressed: () => context.read<WorkbenchLayoutState>().openRightPanel(),
-                  )
-                else if (channelName != null) ...[
-                  const SizedBox(width: 8),
-                  Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
-                    decoration: BoxDecoration(
-                      color: colorScheme.surfaceContainerHighest,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.bolt, size: 15, color: colorScheme.primary),
-                        const SizedBox(width: 5),
-                        Text(
-                          channelName,
-                          style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                            fontFamily: 'monospace',
-                            fontWeight: FontWeight.w500,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      ],
-                    ),
                   ),
-                ],
               ],
             ),
           ),

--- a/lib/screens/workbench/workbench_screen.dart
+++ b/lib/screens/workbench/workbench_screen.dart
@@ -28,6 +28,7 @@ import '../../state/gallery_state.dart';
 import '../../state/workbench_ui_state.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
+import '../../widgets/app_run_console.dart';
 import '../../widgets/app_snackbar.dart';
 import '../../widgets/drawing_canvas.dart';
 import '../../widgets/unified_sidebar.dart';
@@ -46,7 +47,6 @@ import 'widgets/prompt_optimizer_toolbar.dart';
 import 'widgets/prompt_optimizer_view.dart';
 import 'widgets/video_config_panel.dart';
 import 'widgets/video_workbench_view.dart';
-import 'widgets/workbench_bottom_console.dart';
 import 'widgets/workbench_top_bar.dart';
 import 'workbench_config_panel.dart';
 import 'workbench_layout.dart';
@@ -849,7 +849,7 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
             return const SizedBox.shrink();
         }
       },
-      bottomPanel: const WorkbenchBottomConsole(),
+      bottomPanel: const AppRunConsole(),
       showLeftPanel: showLeftPanel,
       showRightPanel: showRightPanel,
       fabIcon: fabIcon,

--- a/lib/widgets/app_run_console.dart
+++ b/lib/widgets/app_run_console.dart
@@ -1,22 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../../core/responsive.dart';
-import '../../../l10n/app_localizations.dart';
-import '../../../services/task_queue_service.dart';
-import '../../../state/app_state.dart';
-import '../../../widgets/log_console.dart';
-import '../../../widgets/panel_resizer.dart';
-import '../../batch/task_queue_screen.dart';
+import '../core/responsive.dart';
+import '../l10n/app_localizations.dart';
+import '../services/task_queue_service.dart';
+import '../state/app_state.dart';
+import 'log_console.dart';
+import 'panel_resizer.dart';
+import '../screens/batch/task_queue_screen.dart';
 
-class WorkbenchBottomConsole extends StatefulWidget {
-  const WorkbenchBottomConsole({super.key});
+/// Shared run-status console: pulsing status dot, running/pending task
+/// summary, and an expandable execution log. Reads entirely from app-wide
+/// providers (`AppState`, `TaskQueueService`), so it can be dropped onto any
+/// screen's `Scaffold.bottomNavigationBar` unchanged.
+class AppRunConsole extends StatefulWidget {
+  const AppRunConsole({super.key});
 
   @override
-  State<WorkbenchBottomConsole> createState() => _WorkbenchBottomConsoleState();
+  State<AppRunConsole> createState() => _AppRunConsoleState();
 }
 
-class _WorkbenchBottomConsoleState extends State<WorkbenchBottomConsole>
+class _AppRunConsoleState extends State<AppRunConsole>
     with SingleTickerProviderStateMixin {
   double _height = 200;
   bool _heightInitialized = false;


### PR DESCRIPTION
## Summary

Follow-up to a design-spec compliance review against the "Joycai 设计规范" from claude.ai/design. The user reviewed the audit and made four decisions; this PR implements the three that required code changes (the theme/color-system finding was confirmed as intentional and needs no change).

- Removed the workbench toolbar's trailing "channel name" chip (`workbench_top_bar.dart`). It looked in a screenshot like a designed "silent API" toggle, but it was always just the active LLM channel's display name — redundant, so it's deleted outright rather than built into a real feature.
- Extracted the workbench's bottom run console into a shared `AppRunConsole` (`lib/widgets/app_run_console.dart`, moved from `lib/screens/workbench/widgets/workbench_bottom_console.dart`, logic unchanged) and wired it into Downloader, File Browser, Task Queue, and Prompt Library via `Scaffold.bottomNavigationBar` — previously run status was only visible from the Workbench screen. Task Queue got an explicit `inBottomSheet` guard so opening it from the console (mobile) doesn't nest a second console inside itself.
- Hardened the "overwrite original" confirmation dialog (`crop_resize_toolbar.dart`) to show the file name and original→target dimensions, and added an inline "Save Copy Instead" action next to Cancel/Overwrite so the destructive path always has a one-click escape hatch. Reuses the existing save-copy code path rather than duplicating file-write logic. Added one new l10n key (`overwriteConfirmSaveCopyInstead`) across all four locales.

## Test plan

- [x] `flutter analyze` — No issues found!
- [ ] Manually verify: workbench toolbar no longer shows a trailing chip on desktop
- [ ] Manually verify: the run console appears at the bottom of Downloader / File Browser / Task Queue / Prompt Library and doesn't overlap the file browser's floating selection bar or the prompt library's FAB
- [ ] Manually verify: opening Task Queue from the console (narrow window / mobile) does not show a nested console
- [ ] Manually verify: Crop & Scale → Overwrite Original shows file name + before→after dimensions, and "Save Copy Instead" saves a copy without touching the original
- [ ] Spot-check the new string in zh / zh_Hant / ja

🤖 Generated with [Claude Code](https://claude.com/claude-code)