### PR TITLE
feat(ui): 设计令牌层与标准组件对齐（多主题色适配规则）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ flutter run --release                              # run app (use --release on m
 flutter analyze                                    # MUST show "No issues found!" before any commit
 flutter build macos                                # or windows / linux / apk / ipa
 flutter test test/screenshots                      # render every screen to build/ui-screenshots/*.png
+flutter test test/screenshots/component_gallery_test.dart  # every component, 7 theme seeds × light/dark
 ```
 
 ## Project Map
@@ -49,12 +50,14 @@ Read the relevant note before changing that subsystem — each records invariant
 that fail silently when broken, and alternatives already tried and rejected.
 
 - **[Prompt Assistant context management](docs/architecture/assistant-context.md)** — elide/compact layers, the `context_window` tri-state, knowledge-read budgeting and paging. Required reading before touching `prompt_optimizer_agent.dart`, `context_budget.dart`, or `knowledge_base_service.dart`.
+- **[Design tokens & multi-theme rule](docs/architecture/design-tokens.md)** — how the design spec's single teal maps onto 7 seed colours: the `onAccentTint` brightness branch, the alpha ladder (and its dark-mode ceiling), which colours must *not* follow the seed, and the deliberate divergences from the spec. Required reading before touching `design_tokens.dart`, `app_semantic_colors.dart`, `app_theme.dart`, or any accent/status colour in `widgets/`.
 
 ## Development Rules
 
 - **`flutter analyze` must pass** (zero issues, info-level included) after every code change.
 - **Responsive UI:** all changes must work on Mobile (<600px), Tablet (<1000px), Desktop (≥1000px). Use `Responsive`/`ResponsiveBuilder` (`lib/core/responsive.dart`). FileBrowser and ImageDownloader are desktop/tablet-only.
 - **Visual debugging:** to actually *see* a layout rather than infer it, run `flutter test test/screenshots` and open the PNGs in `build/ui-screenshots/`. They render the real screens with seeded data at all three widths, in light and dark. Overflows are printed to the run output, not asserted — this is never a regression gate. See [docs/ui-screenshot-harness.md](docs/ui-screenshot-harness.md).
+  For anything touching accent or status colour, use `component_gallery_test.dart` instead: it puts every component on one page and renders it under all 7 theme seeds in both brightnesses (14 PNGs), which is the only way to see whether a colour rule survives a seed change. `shoot()` also takes a `seedColor` if you need a whole screen at a specific seed.
 - **State:** use the existing state classes. Never use `StatefulWidget` for shared or persistent data. Always create new list/object instances before `notifyListeners()` — do not mutate in place.
 - **Data persistence:** all user data goes through `DatabaseService` and the repository layer.
 - **Business logic:** belongs in `lib/services/`, not in widgets or screens.

--- a/docs/architecture/design-tokens.md
+++ b/docs/architecture/design-tokens.md
@@ -1,0 +1,106 @@
+# 设计令牌与多主题色适配规则
+
+《Joycai 设计规范》(`Joycai 设计规范.dc.html`) 用 teal `#12897C` **一种**主色画完了全部示例。本应用支持 **7 套种子色**（`AppConstants.presetThemes`：BlueGrey / Indigo / Teal / Green / Orange / DeepPurple / Rose）。
+
+所以设计稿里的每一个十六进制值都**不能照抄**。这份文档记录的是把它们翻译成「主题角色 + 透明度」的规则——换种子色时结构不变、色相自动跟随。
+
+> 动本文件涉及的任何令牌前，先读这里。`test/design_tokens_test.dart` 把下面每一条都钉住了，`test/screenshots/component_gallery_test.dart` 在 7 个种子色 × 明暗下各出一张图。
+
+## 令牌住在哪
+
+| 文件 | 内容 |
+|---|---|
+| `lib/core/design_tokens.dart` | `AppRadius` / `AppSize` / `AppAlpha` 几何与透明度阶梯，`extension AppAccent on ColorScheme` |
+| `lib/core/app_semantic_colors.dart` | `AppSemanticColors`（ThemeExtension）——成功 / 警告 / 信息 |
+| `lib/core/app_theme.dart` | `buildAppColorScheme` / `buildAppTheme`，以及各 Material 子主题 |
+
+分工规则：**编译期不变量写成 `const double`；随明暗变化的颜色进 ThemeExtension 或 `AppAccent`。**
+
+## 1 · 主色：三种形态，不是一个色值
+
+设计稿从不把主色当成任意色号用。它只以三种形态出现，各自对应一个 `ColorScheme` 角色：
+
+| 设计稿 | 形态 | 用 |
+|---|---|---|
+| 主色实底 | 主 CTA 填充 | `buttonFillScheme(seed).primary`（已有，light+vibrant，保证暗色下不发灰） |
+| 主色描边 / 开关开 / 复选框选中 / 聚焦边 | 纯色 | `colorScheme.primary` |
+| 主色 12% 底 | 选中态背景 | `colorScheme.accentTint` |
+| 「主色深」——12% 底**上的文字/图标** | 文字色 | `colorScheme.onAccentTint` |
+
+### `onAccentTint` 是这里唯一的难点
+
+设计稿的「主色深」在 light 下比主色**暗**、dark 下比主色**亮**。Flutter 里没有单一角色两边都对，所以它是个分支：
+
+```dart
+Color get onAccentTint =>
+    brightness == Brightness.light ? onPrimaryFixedVariant : onPrimaryContainer;
+```
+
+实测（`ColorScheme.fromSeed`，teal）：
+
+| | `primary` | `onPrimaryContainer` | `onPrimaryFixedVariant` | `primaryFixedDim` |
+|---|---|---|---|---|
+| light | `#006A60` | `#005048` | `#005048` | `#82D5C8` |
+| dark | `#82D5C8` | `#9EF2E4` | `#005048` | `#82D5C8` |
+
+- **dark 下 `primaryFixedDim` 恰好等于 `primary`**（7 个种子色全部如此）。用它 = 让文字和它脚下的底色同一个色调，正是要避免的失败。
+- **light 下两个候选完全相同**。仍然取 `Fixed` 那个，因为它的色调是定义上钉死的；`onPrimaryContainer` 的色调是随明暗指派的，Material 历史上改过一次（曾是近黑的 tone 10，那样在 12% 底上就只是深色文字，不再是「主色」）。今天像素一致，改了也不塌。
+
+**为什么 7 个种子色不用逐个调**：HCT 里 tone 就是 L\*，而 L\* 决定相对亮度，与色相无关。在 teal 上量到的对比度，在 orange 上是同一个数。
+
+❌ **不要**用 `primary.withValues()` 手工调暗当「主色深」——teal 上看着对，Orange / Rose 上会失控。
+
+## 2 · 透明度阶梯
+
+设计稿用了 .08/.10/.11/.12/.14/.18/.30/.32/.40/.45/.50/.60 十一档，多数差异低于感知阈值。收敛成四档（`AppAlpha`）：
+
+| 令牌 | 值 | 用途 |
+|---|---|---|
+| `tint` | 0.12 | 选中底：工具页签、导航项、状态徽标、对话框图标底板 |
+| `ring` | 0.32 | 选中描边 / 输入框聚焦光晕 |
+| `edge` | 0.50 | 描边式危险按钮的边、CTA 彩色投影 |
+| `disabled` | 0.38 | Material 自己的禁用前景 |
+
+> ⚠️ **`tint` 不要超过 0.14。** 暗色下这层底上放的是 `onAccentTint`：0.12 约 4.9:1，0.14 约 4.6:1，到 0.18 就跌破 4.5:1 不合规。**亮色下余量极大（约 8:1）不会报警**——事故只在暗色发生，而「让选中态更明显一点」正是最容易踩的一脚。
+
+固定的 alpha 在明暗两边都成立，正是因为底色取 `primary`，而它的 tone 随明暗在 40↔80 翻转。**永远用 `primary` 打底，不要用某个固定角色。**
+
+## 3 · 不跟随种子色的颜色
+
+| | 归属 | 原因 |
+|---|---|---|
+| 危险 | `colorScheme.error` / `errorContainer` | `ColorScheme.fromSeed` 的 error 调色板本就与种子色无关。**不要**为它新建令牌 |
+| 成功 / 警告 / 信息 | `AppSemanticColors` | Material 没有对应角色；最接近的 `tertiaryContainer` 由种子色推导，那样「警告」对一个用户是青色、对另一个是粉色，等于没有信号 |
+| 身份色（计费口径、模型类型、标签、费率组） | 各自的调色板模块（见 `core/fee_group_palette.dart`） | 它们用色相**区分类别**，不是**陈述状态**。放进 `AppSemanticColors` 会让它变成杂物抽屉 |
+
+`AppSemanticColors` 每色三个槽：`color`（实底/图标）、`container`（**不透明**的浅底）、`onContainer`（底上的文字）。容器刻意不用 alpha——徽标会落在卡片、面板和画布上，半透明在每种底上都是另一个颜色。
+
+## 4 · 与设计稿的已知偏离
+
+这些是**故意的**，不是漏改。改回去之前先读原因。
+
+| 项 | 设计稿 | 本应用 | 原因 |
+|---|---|---|---|
+| 静默按钮标签 | 次级文字灰 | 主题色（Material 默认） | 应用已用两个组件解决了这个问题：`AppButton.text` 带主色（对话框的「取消」需要），`AppToolButton` 中性。比设计稿的一个组件更精确 |
+| 分段控件选中态 | 浮起白片 | 主色 12% 底 + 描边（`tinted`） | `AppSegmentStyle` 区分了「选设置」用 `tinted`、「选视图」用 `raised`，比「一律浮起」更细。`raised` 仍可选 |
+| 主 CTA | 主色渐变 | 纯色实底 + 同色投影 | `ButtonStyle` 表达不了渐变；套 `Ink(gradient:)` 会丢 Material 状态层与波纹。现有 `elevation:2 + shadowColor: fill.primary` 已复现设计稿彩色投影的意图 |
+| 开关尺寸 | 36×20 | Material 默认 52×32 | `SwitchThemeData` 够不到轨道/滑块几何，只能改颜色。要到 36×20 得包 `Transform.scale` 或自建组件，是另一件事 |
+| 计数徽标 | 实底红 | 主题色实底 | 本应用里红色已经表示「任务失败」，而这个数字统计的是**进行中**的工作。染红会让健康的忙碌队列看起来像坏了 |
+| 状态徽标 · 失败 | 危险 10% 底 | `error` @ `tint` 底（非 `errorContainer`） | Material 暗色 `errorContainer` 是接近实心的深红，跟另外三个浅色底放一起不再像同一组状态，而像一条警报 |
+| 成功文字色 | `#158046` | `#127843` | 前者在其容器上实测 4.40:1，差一点点不合规——最糟的位置。压暗一档过 4.5 |
+| 字号 | 多处 12.5px | 类型阶梯的 12 / 13 | 半个像素不值得动 541 个 `textTheme` 引用。只采纳设计稿要求的**字重** |
+
+## 验证
+
+```bash
+flutter test test/design_tokens_test.dart          # 7 种子 × 明暗的对比度与角色断言
+flutter test test/screenshots/component_gallery_test.dart   # 14 张组件全景图
+```
+
+看 `build/ui-screenshots/gallery_*.png`，逐张确认：
+
+- 灰阶保持中性，面板/轨道/分隔线没有被种子色染上
+- 每个选中态都用 `accentTint` / `accentRing`，强度一致
+- 成功/警告/信息在 7 张图里**完全一致**
+- 输入框聚焦光晕在每个种子色、明暗两边都看得见
+- 分段控件选中项的标签在暗色下读得出

--- a/docs/reports/design-spec-audit.md
+++ b/docs/reports/design-spec-audit.md
@@ -1,0 +1,79 @@
+# 《Joycai 设计规范》逐项核对报告
+
+对照 claude.ai/design 项目 `925a4d48-684e-4733-bca2-1aa808b7e18f` 的 `Joycai 设计规范.dc.html`。
+
+设计稿三章：**标准组件**（10a light / 10b dark）、**主要页面**（10c–10i）、**对话框**（10j–10l）。
+
+本轮范围：审计全部三章 + 落地令牌层 + 对齐「标准组件」章。**主要页面的布局只核对、不改代码。**
+
+多主题色适配规则见 [`docs/architecture/design-tokens.md`](../architecture/design-tokens.md)。
+
+---
+
+## 一、标准组件（10a / 10b）
+
+图例：✅ 符合 · ◐ 结构对、数值漂移 · ✗ 不符 · ⚖️ 与代码中已有明确理由的决策冲突
+
+| 组件 | 设计稿 | 改前 | 结论 | 现状 |
+|---|---|---|---|---|
+| 主操作按钮 | 高 34 · 圆角 8 · 主色渐变 · 彩色投影 | 高 38 · 圆角 10 · 纯色 · `elevation:2`+同色阴影 | ◐ | 已改几何。渐变不做（见偏离表） |
+| 次级操作按钮 | 圆角 8 · 1px 描边 · surface 底 · 灰字 | `FilledButton.tonal`（`secondaryContainer` 实底） | ✗ | **已改为 `OutlinedButton`**（18 处调用点，无需改调用代码） |
+| 危险操作按钮 | 描边 `rgba(danger,.4)` + danger 文字 | `error` 描边 @0.5 + error 文字 | ✅ | 0.5 换成 `AppAlpha.edge` 令牌 |
+| 静默操作按钮 | 透明底 · **次级文字灰** | Material 默认主色前景 | ⚖️ | **保留现状**——见偏离表 |
+| 图标按钮 | 32×32 · 圆角 8 · 1px 描边 · 图标 16 | 38×38 · 圆角 10 · `outline@0.45` · 图标 ≈18 | ✗ | 已改 32 / 圆角 8 / 图标 16 / `outlineVariant` |
+| 分段控件 | 轨道 pad 3 圆角 9；选中片**浮起 surface** + 主色深文字 | 轨道 pad 4 圆角 12；选中片主色 15% 底 + 主色 60% 描边 | ⚖️ ◐ | 轨道 pad 3 / 圆角 10；15%→`accentTint`，60%→`accentRing`，选中文字→`onAccentTint`。**选中样式保留 `tinted`** |
+| 工具页签 | 圆角 8 · 激活 = 主色 12% 底 + 主色深字 | `AppToolButton`：已是主色 12% 底，但前景是 `primary` | ◐ | 前景改 `onAccentTint`，底改 `accentTint` |
+| 导航项 | 圆角 10 · 激活 = 主色 12% 底 + 主色深前景 | `withAlpha(28)`≈11% 底 + `primary` 前景；抽屉里另有一份 `withAlpha(24)` | ◐ | 两处都改 `accentTint` / `onAccentTint` |
+| 输入框 | 高 32 · 圆角 8 · **1px 描边 + surface 底**；聚焦 1.5px 主色 + 3px 光晕 | `AppTextField` 填充无边框——但**全应用只有 1 处调用**；真实输入是 **42 处裸 `TextField`**（25 文件）+ 56 处手写 `InputDecoration` | ✗ | **加了 `inputDecorationTheme`**（描边式，一次覆盖 42 处裸调用）+ `AppTextField` 改描边并补光晕环 |
+| 开关 | 36×20 · 滑块 16 白 · 开=主色 | 24 处裸 `Switch`，Material 默认 52×32 | ✗ | **加了 `switchTheme`**——颜色到位，几何到不了（见偏离表） |
+| 复选框 | 18×18 · 圆角 5 · 主色实底 · 1.5px 描边 | 裸 `Checkbox`，Material 默认圆角 2 | ◐ | **加了 `checkboxTheme`**，圆角/描边/填充全部到位 |
+| 状态徽标 | 胶囊 · 执行中/待处理/已完成/失败 四态 | `task_queue_screen.dart:28` 硬编码 `Colors.green`，各页自绘 | ✗ | **新建 `AppStatusBadge`** |
+| 计数徽标 | 19px 圆 · 实底红 · 白字 | 无统一实现，nav rail 里手写 15px | ⚖️ | **新建 `AppCountBadge`**，几何采纳、颜色不采纳（见偏离表） |
+| 日志条 | 圆角 8 · 高一阶底色 · 等宽 11.5 | `log_console.dart:236-242` 8 个硬编码 hex + 手写 isDark 分支 | ✗ | 级别色改读 `AppSemanticColors` |
+| 分组小标题 | 600/11 · 字距 .1em · 三级文字 | 无对应槽 | ◐ | 组件全景图里用 `labelMedium` + `letterSpacing: 1.1` 表达；未抽成共享组件 |
+| 对话框外壳 | 圆角 14 · 44px 图标底板 · 关闭按钮 · 头尾分隔线 · 底部按钮高 36 | 圆角 12 · 22px 裸图标 · 无底板/关闭键/分隔线 | ✗ | 圆角→14；`icon` 自动升级为 44px 底板；新增可选 `onClose` / `divided`（默认开）。**52 处调用点全部无需改动** |
+
+## 二、主要页面（10c–10i）——只核对
+
+| 页面 | 设计稿自陈 | 结论 |
+|---|---|---|
+| 10f 图像下载器 · 10g 文件浏览器 · 10h 任务队列 · 10i 提示词库 | 「由深色稿转换 · **布局不变**」 | 布局本就与现状一致。差异集中在选中态表达与语义色——`accentTint`/`accentRing` 与 `AppSemanticColors` 落地后已自动收敛。**无需页面级改动** |
+| 10c 工作台 · 10d 提示词助手 · 10e 裁剪与缩放 | 「定稿 · 原 7a/8a/9a 方案」 | 是**新方案**，需要页面级重排（列宽、面板层级、工具栏分组均与现状不同）。超出本轮范围，建议单独一批推进 |
+
+## 三、对话框（10j–10l）
+
+| | 结论 |
+|---|---|
+| 10j 添加费率组 / 10k 编辑费率组 | 设计稿是 `PricingGroupManager` 的**重设计**：fieldset 式浮起图例标签、46px 图标底板、11px 字段框。`AppDialog` 的新外壳（底板 / 分隔线 / 圆角）已把骨架对齐；字段级重设计未做 |
+| 10l 覆盖原图确认 | 标注「**新增**」——应用中尚不存在这个确认弹窗。未实现。`AppDialog(icon:, iconColor: colorScheme.error, onClose:, divided:)` 已经能直接搭出设计稿的形状，实现成本很低 |
+
+## 四、顺带修掉的既有缺陷
+
+| 位置 | 问题 |
+|---|---|
+| `app_theme.dart` filledButtonTheme | **`styleFrom` 的 `elevation` 在所有状态生效，包括禁用**。配上主色 `shadowColor`，一个禁用按钮会投出满强度的主题色光晕——暗色下看起来像按钮周围套了个发光环，让唯一不能点的控件成了整行最抢眼的东西。已改为禁用时 `elevation: 0` |
+| `application_section.dart:122,140,187,224`、`about_section.dart:63,72` | `Colors.grey.shade300` 描边，暗色模式下必错 → `outlineVariant` |
+| `color_picker_widget.dart:92` | `Colors.black` 选中环，暗色下不可见 → `onSurface`；同文件 `Colors.grey` 标签 → `onSurfaceVariant` |
+| `main.dart:391` | `Color(0xFFB794F6)` 固定紫与 `colorScheme.primary` 组渐变，与 7 个种子色中的 6 个打架 → `primaryContainer` |
+| `log_console.dart` ↔ `task_log_dialog.dart` ↔ `app_snackbar.dart` | 同一组日志级别 / 警告色抄了三份，各带手写 isDark 分支 → 统一读 `AppSemanticColors` |
+| `constants.dart:68-78` | 9 个零调用点的死令牌（`cardRadius` / `smallRadius` / `defaultPadding` / `opacityLow`…）→ 删除，几何统一到 `design_tokens.dart` |
+
+## 五、已知未做
+
+| 项 | 说明 |
+|---|---|
+| 42 处裸 `TextField` 的手写 `InputDecoration` | `inputDecorationTheme` 已给出描边式基线，但调用点自己写了 `border:`/`filled:` 的会局部覆盖主题。逐个清掉是 25 个文件的机械改动，建议按屏单独推进 |
+| 身份色去重 | `usage_summary.dart` ↔ `pricing_group_manager.dart`（计费口径 5 色）、`models_screen.dart` ↔ `discovery_dialog.dart` ↔ `model_edit_dialog.dart`（模型类型 5 色）仍各自硬编码。它们是身份色不是语义色，应仿 `core/fee_group_palette.dart` 各抽一个调色板模块 |
+| `data_section.dart:319-407` ↔ `wizard_import.dart:97-187` | 近乎逐行重复，含各自的 `Colors.grey` |
+| 10c–10e 页面重排、10l 新弹窗、10j/10k 字段级重设计 | 见上 |
+| 分组小标题组件 | 目前只在组件全景图里表达，未抽成共享组件 |
+
+## 验证方式
+
+```bash
+flutter analyze
+flutter test
+flutter test test/screenshots/component_gallery_test.dart
+```
+
+`build/ui-screenshots/gallery_<seed>_<brightness>.png` —— 7 个种子色 × 明暗，一页放下全部标准组件，用来确认结构在换色后不塌。判读要点见 [`design-tokens.md`](../architecture/design-tokens.md#验证)。

--- a/lib/core/app_semantic_colors.dart
+++ b/lib/core/app_semantic_colors.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+
+/// Success, warning and information — the three meanings the seed colour is
+/// not allowed to touch.
+///
+/// Everything else in the app takes its hue from whichever of the seven
+/// [AppConstants.presetThemes] the user picked. These three must not: green
+/// means *this worked* and amber means *look at this* in every theme, and a
+/// success badge that turned orange because the user likes orange would be
+/// telling them something false. So these are literals — the only literals in
+/// the theme — with a pair per brightness, taken from the *Joycai 设计规范*
+/// sheet.
+///
+/// **Destructive is deliberately absent.** [ColorScheme.error] already is this
+/// colour: [ColorScheme.fromSeed] builds the error palette from a fixed hue
+/// rather than from the seed, so it is seed-independent for the same reason
+/// these are, and Material supplies the container/on-container pair too. A
+/// fourth field here would be a second answer to a question already answered —
+/// which is exactly how the app ended up with the same amber written out in
+/// three files. Use `colorScheme.error` / `errorContainer` / `onErrorContainer`.
+///
+/// **Identity colours are also absent** — the per-metric accents in
+/// `usage_summary.dart` and the model-type chip colours in `models_screen.dart`
+/// pick a hue to tell categories apart, not to state a condition. Those belong
+/// in their own palette module beside `core/fee_group_palette.dart`; putting
+/// them here would make this a junk drawer of every colour that isn't the seed.
+@immutable
+class AppSemanticColors extends ThemeExtension<AppSemanticColors> {
+  /// The colour at full strength: an icon, a dot, a progress bar, a 1px rule.
+  ///
+  /// For *text*, prefer [onSuccessContainer] on [successContainer] — a label
+  /// in this colour on a plain surface is legible but shouty, and the spec
+  /// only ever draws it as a fill.
+  final Color success;
+
+  /// A label sitting on a solid [success] fill.
+  final Color onSuccess;
+
+  /// The wash behind a success badge. Opaque, not an alpha over the surface:
+  /// these land on cards, panels and the canvas alike, and a translucent
+  /// version would read as a different colour on each.
+  final Color successContainer;
+
+  /// Text and icons on [successContainer]. A tone darker (light) or lighter
+  /// (dark) than [success], which is what keeps a badge's label readable
+  /// without the badge itself going solid.
+  final Color onSuccessContainer;
+
+  final Color warning;
+  final Color onWarning;
+  final Color warningContainer;
+  final Color onWarningContainer;
+
+  final Color info;
+  final Color onInfo;
+  final Color infoContainer;
+  final Color onInfoContainer;
+
+  const AppSemanticColors({
+    required this.success,
+    required this.onSuccess,
+    required this.successContainer,
+    required this.onSuccessContainer,
+    required this.warning,
+    required this.onWarning,
+    required this.warningContainer,
+    required this.onWarningContainer,
+    required this.info,
+    required this.onInfo,
+    required this.infoContainer,
+    required this.onInfoContainer,
+  });
+
+  /// Spec §色板, light. Base hues are the sheet's own values; the containers
+  /// are those hues flattened at ~11% over the sheet's white surface, so they
+  /// match what it draws while staying opaque.
+  static const AppSemanticColors light = AppSemanticColors(
+    success: Color(0xFF1A9E57),
+    onSuccess: Color(0xFFFFFFFF),
+    successContainer: Color(0xFFE5F4ED),
+    // The sheet draws #158046 here. That measures 4.40:1 on the container
+    // above — near enough to look right and just under AA, which is the worst
+    // place for a value to sit. Darkened one step to clear 4.5; see
+    // design_tokens_test.
+    onSuccessContainer: Color(0xFF127843),
+    warning: Color(0xFFE09030),
+    // Amber is the one hue where white is unreadable at any usable tone, so a
+    // solid warning fill carries dark text. This is why `onWarning` exists as
+    // a field rather than every semantic fill assuming white.
+    onWarning: Color(0xFF3A2600),
+    warningContainer: Color(0xFFFBF3E8),
+    onWarningContainer: Color(0xFF9A6417),
+    info: Color(0xFF1F6FD6),
+    onInfo: Color(0xFFFFFFFF),
+    infoContainer: Color(0xFFE6EFFB),
+    onInfoContainer: Color(0xFF1A5AAE),
+  );
+
+  /// Spec §色板, dark. Not the light values inverted: the sheet lifts each hue
+  /// toward its lighter tones so it survives a near-black canvas, the same
+  /// move Material makes between its own light and dark schemes.
+  static const AppSemanticColors dark = AppSemanticColors(
+    success: Color(0xFF3FC47F),
+    onSuccess: Color(0xFF062616),
+    successContainer: Color(0xFF172D22),
+    onSuccessContainer: Color(0xFF5FD494),
+    warning: Color(0xFFE8A852),
+    onWarning: Color(0xFF2E1D00),
+    warningContainer: Color(0xFF2E291C),
+    onWarningContainer: Color(0xFFF0BC74),
+    info: Color(0xFF5F9FF2),
+    onInfo: Color(0xFF06264D),
+    infoContainer: Color(0xFF1B2732),
+    onInfoContainer: Color(0xFF8CBAF6),
+  );
+
+  /// The set registered on the ambient theme.
+  ///
+  /// Falls back on [ThemeData.brightness] rather than asserting: a widget test
+  /// that mounts a bare [MaterialApp], and the several dialogs the app builds
+  /// under a locally-constructed theme, would otherwise crash on a null
+  /// extension for a colour that was never in doubt.
+  static AppSemanticColors of(BuildContext context) {
+    final theme = Theme.of(context);
+    return theme.extension<AppSemanticColors>() ??
+        (theme.brightness == Brightness.dark ? dark : light);
+  }
+
+  @override
+  AppSemanticColors copyWith({
+    Color? success,
+    Color? onSuccess,
+    Color? successContainer,
+    Color? onSuccessContainer,
+    Color? warning,
+    Color? onWarning,
+    Color? warningContainer,
+    Color? onWarningContainer,
+    Color? info,
+    Color? onInfo,
+    Color? infoContainer,
+    Color? onInfoContainer,
+  }) {
+    return AppSemanticColors(
+      success: success ?? this.success,
+      onSuccess: onSuccess ?? this.onSuccess,
+      successContainer: successContainer ?? this.successContainer,
+      onSuccessContainer: onSuccessContainer ?? this.onSuccessContainer,
+      warning: warning ?? this.warning,
+      onWarning: onWarning ?? this.onWarning,
+      warningContainer: warningContainer ?? this.warningContainer,
+      onWarningContainer: onWarningContainer ?? this.onWarningContainer,
+      info: info ?? this.info,
+      onInfo: onInfo ?? this.onInfo,
+      infoContainer: infoContainer ?? this.infoContainer,
+      onInfoContainer: onInfoContainer ?? this.onInfoContainer,
+    );
+  }
+
+  @override
+  AppSemanticColors lerp(ThemeExtension<AppSemanticColors>? other, double t) {
+    if (other is! AppSemanticColors) return this;
+    return AppSemanticColors(
+      success: Color.lerp(success, other.success, t)!,
+      onSuccess: Color.lerp(onSuccess, other.onSuccess, t)!,
+      successContainer: Color.lerp(successContainer, other.successContainer, t)!,
+      onSuccessContainer: Color.lerp(onSuccessContainer, other.onSuccessContainer, t)!,
+      warning: Color.lerp(warning, other.warning, t)!,
+      onWarning: Color.lerp(onWarning, other.onWarning, t)!,
+      warningContainer: Color.lerp(warningContainer, other.warningContainer, t)!,
+      onWarningContainer: Color.lerp(onWarningContainer, other.onWarningContainer, t)!,
+      info: Color.lerp(info, other.info, t)!,
+      onInfo: Color.lerp(onInfo, other.onInfo, t)!,
+      infoContainer: Color.lerp(infoContainer, other.infoContainer, t)!,
+      onInfoContainer: Color.lerp(onInfoContainer, other.onInfoContainer, t)!,
+    );
+  }
+}
+
+/// `context.semantic.success` at a call site, matching how `colorScheme` is
+/// reached for everywhere else in the app.
+extension AppSemanticColorsX on BuildContext {
+  AppSemanticColors get semantic => AppSemanticColors.of(this);
+}

--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
 
+import 'app_semantic_colors.dart';
+import 'design_tokens.dart';
+
 /// Corner radius shared by buttons and the boxed controls beside them, so a
 /// header of mixed shapes still reads as one row.
 ///
 /// Kept well under half a button's height on purpose: at half, a rounded rect
 /// becomes a capsule, and 12 on the ~30px buttons this app renders was close
-/// enough to read as one.
-const double appButtonRadius = 10;
+/// enough to read as one. The design spec draws 8, which at the heights below
+/// is squarer still — so the reasoning holds, only the number moved. Aliased
+/// rather than replaced: 35 call sites already import this name.
+const double appButtonRadius = AppRadius.control;
 
 /// Height of a filled button, matching the boxed icon actions it sits next to.
 ///
@@ -14,7 +19,10 @@ const double appButtonRadius = 10;
 /// Material defaults to compact, which quietly subtracts 8px from a button's
 /// minimum height. That left these ~30px tall, and at 30 a 10px corner is two
 /// thirds of the way to a capsule — which is exactly what they looked like.
-const double appButtonMinHeight = 38;
+///
+/// The spec's icon buttons are two pixels shorter than its labelled ones, so
+/// [AppIconButton] no longer defaults to this; see [AppSize.iconButton].
+const double appButtonMinHeight = AppSize.control;
 
 /// The app's palette: accents from the user's seed, greys from nobody's.
 ///
@@ -82,7 +90,30 @@ ThemeData buildAppTheme({
     colorScheme: colorScheme,
     fontFamily: fontFamily,
     textTheme: _buildTextTheme(colorScheme, fontFamily),
+    extensions: [
+      brightness == Brightness.dark ? AppSemanticColors.dark : AppSemanticColors.light,
+    ],
+    // The sub-themes below exist because of where the app's controls actually
+    // come from. There are ~40 bare `TextField`s and ~24 bare `Switch`/
+    // `Checkbox`es scattered across the screens, none of them routed through a
+    // shared widget — so a component is the wrong lever for those and the
+    // theme is the right one. Styling them here reaches every call site
+    // without touching any of them.
+    inputDecorationTheme: _buildInputDecorationTheme(colorScheme),
+    switchTheme: _buildSwitchTheme(colorScheme),
+    checkboxTheme: _buildCheckboxTheme(colorScheme),
+    dividerTheme: DividerThemeData(
+      color: colorScheme.outlineVariant,
+      thickness: 1,
+      space: 1,
+    ),
     filledButtonTheme: FilledButtonThemeData(
+      // `.copyWith` on top of `styleFrom`, because `styleFrom` has no
+      // `disabledElevation`: it lifts the button in *every* state, disabled
+      // included. Paired with the accent `shadowColor` below, a disabled
+      // button was casting a full-strength glow in the user's own theme
+      // colour — on a dark canvas it read as a ring around the button, making
+      // the one control that does nothing the loudest thing in the row.
       style: FilledButton.styleFrom(
         backgroundColor: fill.primary,
         foregroundColor: fill.onPrimary,
@@ -99,6 +130,10 @@ ThemeData buildAppTheme({
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(appButtonRadius)),
         minimumSize: const Size(0, appButtonMinHeight),
         visualDensity: VisualDensity.standard,
+      ).copyWith(
+        elevation: WidgetStateProperty.resolveWith(
+          (states) => states.contains(WidgetState.disabled) ? 0 : 2,
+        ),
       ),
     ),
     // The other two button types need the same shape, or the library's own
@@ -126,6 +161,113 @@ ThemeData buildAppTheme({
         visualDensity: VisualDensity.standard,
       ),
     ),
+  );
+}
+
+/// The spec's input: a hairline box on the surface, not a grey slab.
+///
+/// This reverses a decision [AppTextField] documents — it fills with
+/// `surfaceContainerHighest` so inputs and the segmented control's track read
+/// as one system. Worth recording why the reversal is right rather than just
+/// deferential to the spec: that pairing only ever governed two call sites,
+/// because `AppTextField` was never adopted (`api_key_field.dart` is its only
+/// user). The other ~40 inputs in the app are bare `TextField`s rendering
+/// Material's stock outlined default. So the app already ships an outlined
+/// input almost everywhere, and adopting the spec here makes it *more*
+/// internally consistent, not less.
+///
+/// The focus glow the spec draws around a focused field — a 3px accent ring
+/// outside the border — is not expressible through [InputDecoration], which
+/// owns only the border itself. [AppTextField] draws it; a bare `TextField`
+/// gets the 1.5px accent border below and no halo.
+InputDecorationTheme _buildInputDecorationTheme(ColorScheme colorScheme) {
+  OutlineInputBorder border(Color color, double width) => OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadius.control),
+        borderSide: BorderSide(color: color, width: width),
+      );
+
+  return InputDecorationTheme(
+    filled: false,
+    isDense: true,
+    // Tighter than Material's default, which budgets for a floating label on
+    // every field. Most of this app's inputs sit in dense config panels and
+    // carry a separate label above them instead.
+    contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+    border: border(colorScheme.outlineVariant, 1),
+    enabledBorder: border(colorScheme.outlineVariant, 1),
+    // A disabled field keeps its box — without one it reads as a gap in the
+    // form rather than as a control that is temporarily unavailable.
+    disabledBorder: border(colorScheme.outlineVariant.withValues(alpha: AppAlpha.disabled), 1),
+    focusedBorder: border(colorScheme.primary, 1.5),
+    errorBorder: border(colorScheme.error, 1),
+    focusedErrorBorder: border(colorScheme.error, 1.5),
+  );
+}
+
+/// The spec's switch: a 36×20 track with a 16px thumb.
+///
+/// Only the colours are set. Material 3's switch geometry — a 52×32 track and
+/// a thumb that grows on selection — is baked into `Switch`'s own painting and
+/// is not reachable from [SwitchThemeData]; the spec's proportions would need
+/// a `Transform.scale` per call site or a replacement widget. That is a
+/// separate change from this one, and doing half of it here (colours at spec,
+/// geometry at Material's) is the honest stopping point: every switch in the
+/// app becomes the user's accent colour, and none of them changes size.
+SwitchThemeData _buildSwitchTheme(ColorScheme colorScheme) {
+  return SwitchThemeData(
+    thumbColor: WidgetStateProperty.resolveWith((states) {
+      if (states.contains(WidgetState.disabled)) {
+        return colorScheme.onSurface.withValues(alpha: AppAlpha.disabled);
+      }
+      // White on the accent when on, matching the spec's floating thumb; the
+      // scheme's own `onPrimary` would be dark under a pale seed.
+      return states.contains(WidgetState.selected) ? Colors.white : colorScheme.outline;
+    }),
+    trackColor: WidgetStateProperty.resolveWith((states) {
+      if (states.contains(WidgetState.disabled)) {
+        return colorScheme.onSurface.withValues(alpha: 0.12);
+      }
+      return states.contains(WidgetState.selected)
+          ? colorScheme.primary
+          : colorScheme.surfaceContainerHighest;
+    }),
+    trackOutlineColor: WidgetStateProperty.resolveWith((states) {
+      // The spec's "off" track is a flat grey pill with no edge. Material
+      // draws one by default, which at this size reads as a second border
+      // around the thumb.
+      return states.contains(WidgetState.selected) ? Colors.transparent : colorScheme.outlineVariant;
+    }),
+  );
+}
+
+/// The spec's checkbox: 18px, 6px corners, 1.5px edge when unchecked.
+///
+/// Unlike the switch, all of this *is* reachable from the theme — `Checkbox`
+/// takes its shape and side from here — so this one lands on spec exactly.
+CheckboxThemeData _buildCheckboxTheme(ColorScheme colorScheme) {
+  return CheckboxThemeData(
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppRadius.xs)),
+    side: WidgetStateBorderSide.resolveWith((states) {
+      if (states.contains(WidgetState.disabled)) {
+        return BorderSide(
+          color: colorScheme.onSurface.withValues(alpha: AppAlpha.disabled),
+          width: 1.5,
+        );
+      }
+      return BorderSide(color: colorScheme.outline, width: 1.5);
+    }),
+    fillColor: WidgetStateProperty.resolveWith((states) {
+      if (states.contains(WidgetState.disabled)) {
+        return colorScheme.onSurface.withValues(alpha: 0.12);
+      }
+      // Unselected must be transparent, not a fill: the `side` above is what
+      // draws an unchecked box, and a fill would paint over it.
+      return states.contains(WidgetState.selected) ? colorScheme.primary : Colors.transparent;
+    }),
+    checkColor: WidgetStatePropertyAll(Colors.white),
+    // Material reserves a 48px tap target around a 40px checkbox by default,
+    // which in a dense settings list leaves the box marooned in whitespace.
+    visualDensity: VisualDensity.compact,
   );
 }
 

--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -64,19 +64,11 @@ class AppConstants {
   static const int workbenchTabCount = 6;
   static const Duration animationDuration = Duration(milliseconds: 200);
 
-  // Opacity levels
-  static const double opacityLow = 0.05;
-  static const double opacityMedium = 0.3;
-  static const double opacityHigh = 0.5;
+  // Padding, radius, opacity and font-size constants used to live here and
+  // had no call sites at all — the app measured itself in literals instead.
+  // Geometry now lives in `core/design_tokens.dart` (AppRadius / AppSize /
+  // AppAlpha) and type sizes in the scale that `core/app_theme.dart` builds.
 
-  // UI Layout Constants
-  static const double defaultPadding = 16.0;
-  static const double smallPadding = 8.0;
-  static const double cardRadius = 12.0;
-  static const double smallRadius = 8.0;
-  static const double inputFontSize = 13.0;
-  static const double smallFontSize = 11.0;
-  
   static const double minThumbnailSize = 80.0;
   static const double maxThumbnailSize = 400.0;
 

--- a/lib/core/design_tokens.dart
+++ b/lib/core/design_tokens.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+
+/// The geometry and accent-tint ladders the widget library measures against,
+/// instead of a literal number at each call site.
+///
+/// These come from the *Joycai 设计规范* sheet. That sheet is drawn once, in
+/// teal — but the app ships seven seed colours, so nothing here stores a hue.
+/// Geometry is absolute; anything coloured is expressed as a role on the
+/// ambient [ColorScheme] plus an alpha from [AppAlpha], which is what lets the
+/// same rule render in whichever colour the user picked. See
+/// `docs/architecture/design-tokens.md` for the full mapping.
+
+/// Corner radii.
+///
+/// The spec draws eleven distinct radii (5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+/// 16). Most of those differences are a pixel or two and read as noise rather
+/// than as a system — 7 and 9 sit either side of 8 on the *same* control, the
+/// segmented track and the chip inside it. Quantised to six steps: the spec's
+/// 5–7 collapse to [xs]/[control], 9–11 to [md]/[lg], 13–16 to [lg]/[dialog].
+class AppRadius {
+  /// Checkboxes and other ~18px boxes, where [control] would round a small
+  /// square into a blob.
+  static const double xs = 6;
+
+  /// The app's default. Buttons, inputs, icon buttons, tool tabs, log bars —
+  /// every control that sits in a row with another control.
+  static const double control = 8;
+
+  /// Containers holding controls: a segmented track, a nav rail item, an
+  /// inline info box. One step out from what it wraps.
+  static const double md = 10;
+
+  /// Cards and panels.
+  static const double lg = 12;
+
+  /// Dialog surfaces. The one shape allowed to be rounder than a card, because
+  /// it floats over everything rather than sitting in the grid with it.
+  static const double dialog = 14;
+
+  /// Status badges and any other capsule. Far past half the height of anything
+  /// it is used on, which is what makes the ends semicircular.
+  static const double pill = 999;
+}
+
+/// Control heights and icon sizes.
+///
+/// Heights are a hard constraint, not a preference: a row mixing a button, an
+/// icon button and a segmented control only reads as one row if they agree.
+class AppSize {
+  /// A labelled button. The spec draws 34 on the component sheet and 36 in the
+  /// dialog footers; 36 is taken as the single value because it is the more
+  /// common of the two in the page mockups and leaves a usable touch target.
+  static const double control = 36;
+
+  /// A square icon action. Deliberately two pixels under [control] — the spec
+  /// sets them apart so a bare glyph doesn't read as heavy as a labelled verb.
+  static const double iconButton = 32;
+
+  /// A button inside a popup, a slim toolbar strip or a card footer.
+  static const double compact = 30;
+
+  /// A sheet's committing action, or a panel's single main call to action.
+  static const double large = 48;
+
+  /// Glyph inside an [iconButton]-sized box, and beside a [compact] label.
+  static const double iconSm = 16;
+
+  /// Glyph beside a [control]-sized label.
+  static const double iconMd = 18;
+
+  /// Glyph beside a [large] label, and in a nav rail item.
+  static const double iconLg = 20;
+}
+
+/// The alphas the accent is allowed to be drawn at.
+///
+/// The spec reaches for eleven (.08 through .60), which is more precision than
+/// any of them earn — .10 and .12 appear on the same kind of surface two cards
+/// apart. Four steps, each with one job. Using a value not on this ladder is
+/// how the app drifted the first time.
+class AppAlpha {
+  /// A selected thing's background: an active tool tab, a nav rail item, a
+  /// status badge, a dialog's icon plate.
+  ///
+  /// **Do not raise this past 0.14.** In dark mode the label on such a tint is
+  /// [AppAccent.onAccentTint] (tone 80), and the tint is what sits behind it:
+  /// at 0.12 that pairing computes to ~4.9:1, at 0.14 to ~4.6:1, and by 0.18
+  /// it has fallen through 4.5:1 and fails AA. Light mode has an enormous
+  /// margin (~8:1) and will not warn you — the failure is dark-only, and the
+  /// obvious "make the selection more visible" nudge is what causes it.
+  static const double tint = 0.12;
+
+  /// The edge or focus ring around a selected thing. Reads as an outline at
+  /// this strength without competing with the label inside it.
+  static const double ring = 0.32;
+
+  /// A border that carries meaning on its own — the outline of a destructive
+  /// button, or the depth of a primary button's coloured shadow.
+  static const double edge = 0.5;
+
+  /// Material's own disabled tone, restated so call sites stop guessing.
+  static const double disabled = 0.38;
+}
+
+/// The accent, in the three forms the design spec actually uses it.
+///
+/// This is the whole multi-theme rule in one place. The spec shows a single
+/// teal, but never as an arbitrary hex — it appears as a solid fill, as a
+/// wash behind something selected, and as text sitting on that wash. Each maps
+/// to a [ColorScheme] role, so swapping the seed re-renders the same structure
+/// in the new hue rather than breaking it.
+///
+/// Anything that means *success*, *warning* or *information* is not accent and
+/// must not come from here — those keep their meaning across themes and live
+/// in `AppSemanticColors`. Destructive is [ColorScheme.error], whose palette
+/// [ColorScheme.fromSeed] already derives independently of the seed.
+extension AppAccent on ColorScheme {
+  /// The wash behind a selected or active element.
+  Color get accentTint => primary.withValues(alpha: AppAlpha.tint);
+
+  /// The edge around that element, and the glow ring on a focused input.
+  Color get accentRing => primary.withValues(alpha: AppAlpha.ring);
+
+  /// Text and icons drawn *on* [accentTint].
+  ///
+  /// The spec's 主色深 is a tone *near* the accent, not a near-black: measured
+  /// off the sheet, light is `#0B6E64` ≈ tone 41 against a `#12897C` ≈ tone 51
+  /// accent, and dark is `#4ECDC0` ≈ tone 76 against `#3FC1B0` ≈ tone 71. Ten
+  /// tones of separation, so the label still reads *as the accent*.
+  ///
+  /// Measured against the SDK rather than reasoned from the tone tables, which
+  /// have churned across Material revisions. What
+  /// [ColorScheme.fromSeed] actually returns today, at teal:
+  ///
+  /// | | `primary` | `onPrimaryContainer` | `onPrimaryFixedVariant` | `primaryFixedDim` |
+  /// |---|---|---|---|---|
+  /// | light | `#006A60` | `#005048` | `#005048` | `#82D5C8` |
+  /// | dark  | `#82D5C8` | `#9EF2E4` | `#005048`   | `#82D5C8` |
+  ///
+  /// Two things fall out, both true at all seven seeds:
+  ///
+  /// - In **dark**, `primaryFixedDim` is *exactly* [primary]. Using it would
+  ///   make the label one tone reading against its own tint — the precise
+  ///   failure this getter exists to prevent. `onPrimaryContainer` is a step
+  ///   lighter than the accent, which is what dark mode needs.
+  /// - In **light**, the two candidates are *identical*. The `Fixed` role is
+  ///   taken anyway because its tone is pinned by definition, where
+  ///   `onPrimaryContainer`'s is a brightness-dependent assignment that
+  ///   Material has already moved once (it was near-black at tone 10 for a
+  ///   spell, which on a 12% wash reads as plain dark text, not as the accent).
+  ///   Same pixels today, insured against that revision returning.
+  ///
+  /// No per-seed tuning is needed because in HCT tone *is* L\*, so relative
+  /// luminance is fixed regardless of hue — a contrast figure measured on teal
+  /// is the same figure on orange. `design_tokens_test` asserts it for every
+  /// seed in both brightnesses rather than trusting that.
+  Color get onAccentTint =>
+      brightness == Brightness.light ? onPrimaryFixedVariant : onPrimaryContainer;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 
 import 'core/app_theme.dart';
+import 'core/design_tokens.dart';
 import 'core/responsive.dart';
 import 'l10n/app_localizations.dart';
 import 'screens/batch/task_queue_screen.dart';
@@ -29,6 +30,7 @@ import 'services/task_queue_service.dart';
 import 'services/video_thumbnail_service.dart';
 import 'services/window_chrome_service.dart';
 import 'state/app_state.dart';
+import 'widgets/app_status_badge.dart';
 import 'widgets/task_capsule_monitor.dart';
 
 void main() async {
@@ -387,12 +389,18 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                   width: 38,
                   height: 38,
                   decoration: BoxDecoration(
+                    // Both stops from the seed. The second used to be a fixed
+                    // lavender, which read as intentional only for the one
+                    // seed near it and fought the other six — an indigo app
+                    // with a purple-tipped logo looks like a rendering bug.
+                    // `primaryContainer` is the seed's own lighter tone, so
+                    // the sweep stays a sweep at every theme.
                     gradient: LinearGradient(
-                      colors: [colorScheme.primary, const Color(0xFFB794F6)],
+                      colors: [colorScheme.primary, colorScheme.primaryContainer],
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
                     ),
-                    borderRadius: BorderRadius.circular(10),
+                    borderRadius: BorderRadius.circular(AppRadius.md),
                   ),
                   child: const Icon(Icons.auto_awesome, size: 20, color: Colors.white),
                 ),
@@ -583,13 +591,17 @@ class _RailItemState extends State<_RailItem> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    // Selected takes `onAccentTint`, not `primary`: the label sits on a wash
+    // of primary, and primary on its own tint is one tone reading against
+    // itself — fine in light by accident, washed out in dark where primary is
+    // already the pale tone 80.
     final color = widget.isSelected
-        ? colorScheme.primary
+        ? colorScheme.onAccentTint
         : _hovering
             ? colorScheme.onSurfaceVariant
             : colorScheme.onSurfaceVariant.withAlpha(140);
     final bgColor = widget.isSelected
-        ? colorScheme.primary.withAlpha(28)
+        ? colorScheme.accentTint
         : _hovering
             ? colorScheme.onSurfaceVariant.withAlpha(16)
             : Colors.transparent;
@@ -620,25 +632,11 @@ class _RailItemState extends State<_RailItem> {
                       Positioned(
                         top: -5,
                         right: -8,
-                        child: Container(
-                          constraints: const BoxConstraints(minWidth: 15),
-                          height: 15,
-                          padding: const EdgeInsets.symmetric(horizontal: 4),
-                          decoration: BoxDecoration(
-                            color: colorScheme.primary,
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Center(
-                            child: Text(
-                              widget.badge > 99 ? '99+' : '${widget.badge}',
-                              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                color: Colors.white,
-                                fontWeight: FontWeight.w700,
-                                fontFamily: 'monospace',
-                              ),
-                            ),
-                          ),
-                        ),
+                        // Deliberately not the spec's red. This counts work in
+                        // flight, and red already means "a task failed" all
+                        // over this app — a busy queue would read as a broken
+                        // one. See AppCountBadge.
+                        child: AppCountBadge(count: widget.badge),
                       ),
                   ],
                 ),
@@ -685,8 +683,9 @@ class _DrawerItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final color = isSelected ? colorScheme.primary : colorScheme.onSurfaceVariant;
-    final bg = isSelected ? colorScheme.primary.withAlpha(24) : Colors.transparent;
+    // Same pairing as _RailItem above — this is the drawer's copy of it.
+    final color = isSelected ? colorScheme.onAccentTint : colorScheme.onSurfaceVariant;
+    final bg = isSelected ? colorScheme.accentTint : Colors.transparent;
 
     return GestureDetector(
       onTap: onTap,
@@ -695,7 +694,7 @@ class _DrawerItem extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
         decoration: BoxDecoration(
           color: bg,
-          borderRadius: BorderRadius.circular(11),
+          borderRadius: BorderRadius.circular(AppRadius.md),
         ),
         child: Row(
           children: [

--- a/lib/screens/batch/task_queue_screen.dart
+++ b/lib/screens/batch/task_queue_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 
+import '../../core/app_semantic_colors.dart';
 import '../../core/app_theme.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
@@ -22,10 +23,11 @@ enum _TaskFilter { all, running, pending, done, failed }
 /// The colour a status is spoken in, shared by a task's accent stripe, its
 /// leading tile and its count in the header — so one glance down the stripes
 /// answers the same question the header summary does.
-Color _statusColor(TaskStatus status, ColorScheme colorScheme) => switch (status) {
+Color _statusColor(TaskStatus status, ColorScheme colorScheme, AppSemanticColors semantic) =>
+    switch (status) {
       TaskStatus.processing => colorScheme.primary,
       TaskStatus.pending => colorScheme.onSurfaceVariant,
-      TaskStatus.completed => Colors.green,
+      TaskStatus.completed => semantic.success,
       TaskStatus.failed => colorScheme.error,
       TaskStatus.cancelled => colorScheme.outline,
     };
@@ -279,7 +281,7 @@ class _TaskQueueScreenState extends State<TaskQueueScreen> {
       spans.add(TextSpan(text: '  ·  ', style: TextStyle(color: colorScheme.outline)));
       spans.add(TextSpan(
         text: '$label $count',
-        style: TextStyle(color: _statusColor(status, colorScheme), fontWeight: FontWeight.w600),
+        style: TextStyle(color: _statusColor(status, colorScheme, context.semantic), fontWeight: FontWeight.w600),
       ));
     }
 
@@ -579,7 +581,7 @@ class _TaskCardState extends State<_TaskCard> {
 
     final isProcessing = task.status == TaskStatus.processing;
     final isFailed = task.status == TaskStatus.failed;
-    final accent = _statusColor(task.status, colorScheme);
+    final accent = _statusColor(task.status, colorScheme, context.semantic);
 
     // A card of its own rather than a PanelCard: the stripe has to reach both
     // edges, and a failed card carries a wash of its status through the surface.

--- a/lib/screens/settings/widgets/about_section.dart
+++ b/lib/screens/settings/widgets/about_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+import '../../../core/design_tokens.dart';
 import '../../../core/file_utils.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../widgets/app_section.dart';
@@ -60,7 +61,7 @@ class _AboutSectionState extends State<AboutSection> {
         ListTile(
           title: Text(l10n.aboutGithubRepo),
           subtitle: Text(l10n.aboutViewSource),
-          shape: RoundedRectangleBorder(side: BorderSide(color: Colors.grey.shade300), borderRadius: BorderRadius.circular(8)),
+          shape: RoundedRectangleBorder(side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant), borderRadius: BorderRadius.circular(AppRadius.control)),
           leading: const Icon(Icons.code),
           trailing: const Icon(Icons.open_in_new, size: 18),
           onTap: () => FileUtils.openUri(Uri.parse(_githubUrl)),
@@ -69,7 +70,7 @@ class _AboutSectionState extends State<AboutSection> {
         ListTile(
           title: Text(l10n.aboutLicense),
           subtitle: const Text('MIT License'),
-          shape: RoundedRectangleBorder(side: BorderSide(color: Colors.grey.shade300), borderRadius: BorderRadius.circular(8)),
+          shape: RoundedRectangleBorder(side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant), borderRadius: BorderRadius.circular(AppRadius.control)),
           leading: const Icon(Icons.gavel_outlined),
         ),
         const SizedBox(height: 24),

--- a/lib/screens/settings/widgets/application_section.dart
+++ b/lib/screens/settings/widgets/application_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../core/app_paths.dart';
+import '../../../core/design_tokens.dart';
 import '../../../core/file_utils.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/database_service.dart';
@@ -119,7 +120,7 @@ class _ApplicationSectionState extends State<ApplicationSection> {
         ListTile(
           title: Text(l10n.assistantRetention),
           subtitle: Text(l10n.assistantRetentionDesc),
-          shape: RoundedRectangleBorder(side: BorderSide(color: Colors.grey.shade300), borderRadius: BorderRadius.circular(8)),
+          shape: RoundedRectangleBorder(side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant), borderRadius: BorderRadius.circular(AppRadius.control)),
           trailing: DropdownButton<int>(
             value: const [10, 20, 50, 100].contains(_assistantRetention) ? _assistantRetention : 20,
             underline: const SizedBox.shrink(),
@@ -137,7 +138,7 @@ class _ApplicationSectionState extends State<ApplicationSection> {
         ListTile(
           title: Text(l10n.assistantContextRatio),
           subtitle: Text(l10n.assistantContextRatioDesc),
-          shape: RoundedRectangleBorder(side: BorderSide(color: Colors.grey.shade300), borderRadius: BorderRadius.circular(8)),
+          shape: RoundedRectangleBorder(side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant), borderRadius: BorderRadius.circular(AppRadius.control)),
           trailing: DropdownButton<double>(
             value: _contextRatios.contains(_assistantContextRatio)
                 ? _assistantContextRatio
@@ -184,7 +185,7 @@ class _ApplicationSectionState extends State<ApplicationSection> {
         subtitle,
         style: warn ? TextStyle(color: colorScheme.error) : null,
       ),
-      shape: RoundedRectangleBorder(side: BorderSide(color: Colors.grey.shade300), borderRadius: BorderRadius.circular(8)),
+      shape: RoundedRectangleBorder(side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant), borderRadius: BorderRadius.circular(AppRadius.control)),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -221,7 +222,7 @@ class _ApplicationSectionState extends State<ApplicationSection> {
           title: Text(l10n.outputDirectory),
           subtitle: Text(_outputDirController.text.isEmpty ? l10n.notSet : _outputDirController.text),
           trailing: const Icon(Icons.folder_open),
-          shape: RoundedRectangleBorder(side: BorderSide(color: Colors.grey.shade300), borderRadius: BorderRadius.circular(8)),
+          shape: RoundedRectangleBorder(side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant), borderRadius: BorderRadius.circular(AppRadius.control)),
           onTap: () async {
             String? path = await FilePicker.getDirectoryPath();
             if (path != null) {

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../core/app_theme.dart';
+import '../core/design_tokens.dart';
 
 /// Which of the app's four button treatments to draw.
 ///
@@ -14,9 +15,19 @@ enum AppButtonVariant {
   /// Material's washed-out default.
   primary,
 
-  /// A secondary action beside a primary one. [tonalButtonStyle] passed in
-  /// explicitly, because the app-wide filled-button theme otherwise outranks
-  /// [FilledButton.tonal]'s own default and paints it fully primary.
+  /// A secondary action beside a primary one: a hairline outline on the
+  /// surface, carrying no accent of its own.
+  ///
+  /// Was [FilledButton.tonal] — a `secondaryContainer` slab. That spent the
+  /// seed's colour on the action the user *isn't* meant to take, which is the
+  /// one thing the design spec is emphatic about ("主题色只出现在选中态、主
+  /// CTA 与徽标上"). An outline separates it from the primary by weight
+  /// instead of by hue, leaving the accent to mean something.
+  ///
+  /// [tonalButtonStyle] is still exported for the handful of hand-rolled
+  /// [FilledButton.tonal]s elsewhere, which still need it — the app-wide
+  /// filled-button theme outranks the tonal variant's own default and would
+  /// otherwise paint them fully primary.
   secondary,
 
   /// The lowest-emphasis action — cancel, dismiss, "skip this".
@@ -143,16 +154,16 @@ class AppButton extends StatelessWidget {
 
     final (height, density, padding, textStyle) = switch (size) {
       AppButtonSize.compact => (
-          30.0,
+          AppSize.compact,
           VisualDensity.compact,
           const EdgeInsets.symmetric(horizontal: 10),
           textTheme.labelMedium,
         ),
-      AppButtonSize.normal => (appButtonMinHeight, null, null, null),
+      AppButtonSize.normal => (AppSize.control, null, null, null),
       // A screen's main action carries a little more weight than the buttons
       // beside it; several of these had spelled that out as a bold label.
       AppButtonSize.large => (
-          48.0,
+          AppSize.large,
           null,
           const EdgeInsets.symmetric(horizontal: 20),
           textTheme.titleMedium,
@@ -196,12 +207,12 @@ class AppButton extends StatelessWidget {
   Widget _button({required ButtonStyle? style, required VoidCallback? onPressed, required Widget child}) {
     switch (variant) {
       case AppButtonVariant.primary:
-      case AppButtonVariant.secondary:
       case AppButtonVariant.destructive:
         return FilledButton(style: style, onPressed: onPressed, child: child);
       case AppButtonVariant.text:
       case AppButtonVariant.destructiveText:
         return TextButton(style: style, onPressed: onPressed, child: child);
+      case AppButtonVariant.secondary:
       case AppButtonVariant.destructiveOutline:
         return OutlinedButton(style: style, onPressed: onPressed, child: child);
     }
@@ -215,7 +226,6 @@ class AppButton extends StatelessWidget {
   }) {
     switch (variant) {
       case AppButtonVariant.primary:
-      case AppButtonVariant.secondary:
       case AppButtonVariant.destructive:
         return FilledButton.icon(
           style: style,
@@ -231,6 +241,7 @@ class AppButton extends StatelessWidget {
           icon: Icon(icon, size: _iconSize),
           label: label,
         );
+      case AppButtonVariant.secondary:
       case AppButtonVariant.destructiveOutline:
         return OutlinedButton.icon(
           style: style,
@@ -242,9 +253,9 @@ class AppButton extends StatelessWidget {
   }
 
   double get _iconSize => switch (size) {
-        AppButtonSize.compact => 15,
-        AppButtonSize.normal => 18,
-        AppButtonSize.large => 20,
+        AppButtonSize.compact => AppSize.iconSm,
+        AppButtonSize.normal => AppSize.iconMd,
+        AppButtonSize.large => AppSize.iconLg,
       };
 
   ButtonStyle? _styleFor(BuildContext context, ColorScheme colorScheme) {
@@ -255,7 +266,15 @@ class AppButton extends StatelessWidget {
         // naming a style here would just repeat it.
         return null;
       case AppButtonVariant.secondary:
-        return tonalButtonStyle(colorScheme);
+        return OutlinedButton.styleFrom(
+          // `surface`, not transparent: these sit on the canvas and on cards
+          // alike, and an unfilled outline over a card's own tone reads as a
+          // hole punched in it rather than as a button.
+          backgroundColor: colorScheme.surface,
+          foregroundColor: colorScheme.onSurface,
+          side: BorderSide(color: colorScheme.outlineVariant),
+          disabledForegroundColor: colorScheme.onSurface.withValues(alpha: AppAlpha.disabled),
+        );
       case AppButtonVariant.destructive:
         return FilledButton.styleFrom(
           backgroundColor: colorScheme.error,
@@ -266,13 +285,13 @@ class AppButton extends StatelessWidget {
       case AppButtonVariant.destructiveOutline:
         return OutlinedButton.styleFrom(
           foregroundColor: colorScheme.error,
-          side: BorderSide(color: colorScheme.error.withValues(alpha: 0.5)),
-          disabledForegroundColor: colorScheme.onSurface.withValues(alpha: 0.38),
+          side: BorderSide(color: colorScheme.error.withValues(alpha: AppAlpha.edge)),
+          disabledForegroundColor: colorScheme.onSurface.withValues(alpha: AppAlpha.disabled),
         );
       case AppButtonVariant.destructiveText:
         return TextButton.styleFrom(
           foregroundColor: colorScheme.error,
-          disabledForegroundColor: colorScheme.onSurface.withValues(alpha: 0.38),
+          disabledForegroundColor: colorScheme.onSurface.withValues(alpha: AppAlpha.disabled),
         );
     }
   }
@@ -287,7 +306,7 @@ class AppButton extends StatelessWidget {
         return Theme.of(context).filledButtonTheme.style?.foregroundColor?.resolve(const {}) ??
             colorScheme.onPrimary;
       case AppButtonVariant.secondary:
-        return colorScheme.onSecondaryContainer;
+        return colorScheme.onSurface;
       case AppButtonVariant.text:
         return colorScheme.primary;
       case AppButtonVariant.destructive:

--- a/lib/widgets/app_card.dart
+++ b/lib/widgets/app_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../core/design_tokens.dart';
+
 /// A rounded content card for grouping related widgets inside a panel — a
 /// settings block, a list row, a summary tile.
 ///
@@ -44,7 +46,7 @@ class AppCard extends StatelessWidget {
       // shape, never borderRadius: Material asserts if given both, and the
       // outlined tone needs a side.
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppRadius.lg),
         side: outlined ? BorderSide(color: colorScheme.outlineVariant) : BorderSide.none,
       ),
       child: InkWell(

--- a/lib/widgets/app_dialog.dart
+++ b/lib/widgets/app_dialog.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 
+import '../core/design_tokens.dart';
 import '../core/responsive.dart';
+import '../l10n/app_localizations.dart';
 
 /// Corner radius shared by every dialog.
 ///
-/// The same 12 the inset panels use ([PanelCard], [AppCard],
-/// [AppSegmentedControl]). Dialogs used to be hand-rolled at 24 and Material's
-/// own default is 28, but one radius across the app was the call: a dialog is
-/// another surface in the same system, not a visitor from another one.
-const double appDialogRadius = 12;
+/// Dialogs used to be hand-rolled at 24 and Material's own default is 28; this
+/// sat at the cards' 12 for a while on the argument that a dialog is another
+/// surface in the same system. The design spec puts it one step above the
+/// cards instead, which is the better reading of the same idea: a dialog is in
+/// the system but *floating over* it, and one step of extra curvature is what
+/// says so without breaking the family.
+const double appDialogRadius = AppRadius.dialog;
 
 /// The app's dialog chrome: rounded surface, title in [TextTheme.titleLarge],
 /// right-aligned action row.
@@ -88,6 +92,23 @@ class AppDialog extends StatelessWidget {
   /// ink-splashing child would otherwise paint over them.
   final Clip clipBehavior;
 
+  /// Adds an ✕ in the heading's trailing corner, calling this.
+  ///
+  /// Opt-in rather than automatic. The spec draws one on every dialog, but
+  /// most of this app's dialogs already carry a Cancel in the footer and are
+  /// barrier-dismissible besides — a third way out is clutter, not clarity.
+  /// Reach for it on dialogs with no footer, or whose footer commits to
+  /// something and has nothing to dismiss with.
+  final VoidCallback? onClose;
+
+  /// Hairline rules separating the heading and the footer from the body.
+  ///
+  /// On by default: they are what let the body run edge-to-edge under a
+  /// heading without the two appearing to merge, which is the shape the spec
+  /// draws and the shape a scrolling body needs anyway. Only drawn on the
+  /// sides that actually have a neighbour.
+  final bool divided;
+
   const AppDialog({
     super.key,
     this.title,
@@ -103,6 +124,8 @@ class AppDialog extends StatelessWidget {
     this.scrollable = false,
     this.contentPadding,
     this.clipBehavior = Clip.none,
+    this.onClose,
+    this.divided = true,
   }) : assert(title == null || titleWidget == null,
             'Give AppDialog a title or a titleWidget, not both');
 
@@ -124,6 +147,8 @@ class AppDialog extends StatelessWidget {
     EdgeInsetsGeometry? contentPadding,
     Clip clipBehavior = Clip.none,
     bool barrierDismissible = true,
+    VoidCallback? onClose,
+    bool divided = true,
   }) {
     return showDialog<T>(
       context: context,
@@ -142,6 +167,8 @@ class AppDialog extends StatelessWidget {
         scrollable: scrollable,
         contentPadding: contentPadding,
         clipBehavior: clipBehavior,
+        onClose: onClose,
+        divided: divided,
       ),
     );
   }
@@ -163,13 +190,17 @@ class AppDialog extends StatelessWidget {
     // full-bleed list — while the title and actions above and below it stay
     // inset. The default absorbs the outer inset on whichever sides have no
     // neighbour to provide it.
+    // Without a rule between them, the heading's own bottom inset is the gap
+    // and the body adds none. With one, that inset now sits *above* the rule,
+    // so the body has to supply the space beneath it or the first line of
+    // content ends up flush against the hairline. Same on the footer side.
     body = Padding(
       padding: contentPadding ??
           EdgeInsets.only(
             left: _pad,
             right: _pad,
-            top: heading == null ? _pad : 0,
-            bottom: footer == null ? _pad : 0,
+            top: (heading == null || divided) ? _pad : 0,
+            bottom: (footer == null || divided) ? _pad : 0,
           ),
       child: body,
     );
@@ -198,20 +229,24 @@ class AppDialog extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (heading != null)
+            if (heading != null) ...[
               Padding(
-                padding: const EdgeInsets.fromLTRB(_pad, _pad, _pad, 16),
+                padding: EdgeInsets.fromLTRB(_pad, _pad, _pad, divided ? _pad : 16),
                 child: heading,
               ),
+              if (divided) const Divider(height: 1),
+            ],
             // The only slot allowed to take the height left over, so a
             // maxHeight bounds the scrolling body rather than cutting the
             // action row off the bottom of the dialog.
             Flexible(child: body),
-            if (footer != null)
+            if (footer != null) ...[
+              if (divided) const Divider(height: 1),
               Padding(
                 padding: const EdgeInsets.fromLTRB(_pad, _pad, _pad, _pad),
                 child: footer,
               ),
+            ],
           ],
         ),
       ),
@@ -239,14 +274,51 @@ class AppDialog extends StatelessWidget {
       ],
     );
 
-    if (icon == null) return text;
+    if (icon == null && onClose == null) return text;
+
+    final accent = iconColor ?? colorScheme.primary;
 
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Icon(icon, size: 22, color: iconColor ?? colorScheme.primary),
-        const SizedBox(width: 10),
+        if (icon != null) ...[
+          // A plate, not a bare glyph. The spec gives the heading icon a
+          // tinted square so it reads as the dialog's subject rather than as
+          // decoration beside the title — and because `iconColor` already
+          // carries the dialog's mood, a destructive dialog passing
+          // `iconColor: error` gets the spec's red plate with no extra API.
+          Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: AppAlpha.tint),
+              borderRadius: BorderRadius.circular(AppRadius.lg),
+            ),
+            child: Icon(icon, size: 22, color: accent),
+          ),
+          const SizedBox(width: 14),
+        ],
         Expanded(child: text),
+        if (onClose != null) ...[
+          const SizedBox(width: 12),
+          IconButton(
+            icon: const Icon(Icons.close, size: AppSize.iconSm),
+            tooltip: AppLocalizations.of(context)!.close,
+            onPressed: onClose,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints.tightFor(
+              width: AppSize.iconButton,
+              height: AppSize.iconButton,
+            ),
+            style: IconButton.styleFrom(
+              foregroundColor: colorScheme.onSurfaceVariant,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppRadius.control),
+                side: BorderSide(color: colorScheme.outlineVariant),
+              ),
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/lib/widgets/app_icon_button.dart
+++ b/lib/widgets/app_icon_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../core/app_theme.dart';
+import '../core/design_tokens.dart';
 
 /// An icon action in a box of its own.
 ///
@@ -24,8 +24,12 @@ class AppIconButton extends StatelessWidget {
   /// whose action is currently on.
   final bool selected;
 
-  /// Both sides of the square. Defaults to the height of a filled button so the
-  /// two line up in a header.
+  /// Both sides of the square.
+  ///
+  /// Two pixels under a labelled button rather than equal to it. The design
+  /// spec sets them apart deliberately — a bare glyph with no word beside it
+  /// should not carry the same visual weight as a stated verb — and at this
+  /// difference the two still read as one row.
   final double size;
 
   const AppIconButton({
@@ -35,7 +39,7 @@ class AppIconButton extends StatelessWidget {
     required this.onPressed,
     this.color,
     this.selected = false,
-    this.size = appButtonMinHeight,
+    this.size = AppSize.iconButton,
   });
 
   @override
@@ -47,15 +51,19 @@ class AppIconButton extends StatelessWidget {
       width: size,
       height: size,
       child: IconButton(
-        icon: Icon(icon, size: size * 0.47),
+        // Half the box, per the spec's 16-in-32. The old 0.47 predates the box
+        // being 32 and came out a pixel light once it shrank.
+        icon: Icon(icon, size: size * 0.5),
         color: selected ? accent : color,
         padding: EdgeInsets.zero,
         style: IconButton.styleFrom(
-          backgroundColor: selected ? accent.withValues(alpha: 0.14) : null,
+          // `color` when the caller named one — a destructive action's box
+          // should wash in its own red, not in the accent.
+          backgroundColor: selected ? accent.withValues(alpha: AppAlpha.tint) : null,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(appButtonRadius),
+            borderRadius: BorderRadius.circular(AppRadius.control),
             side: BorderSide(
-              color: selected ? accent.withValues(alpha: 0.6) : colorScheme.outline.withValues(alpha: 0.45),
+              color: selected ? accent.withValues(alpha: AppAlpha.ring) : colorScheme.outlineVariant,
             ),
           ),
         ),

--- a/lib/widgets/app_segmented_control.dart
+++ b/lib/widgets/app_segmented_control.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../core/design_tokens.dart';
+
 /// One choice in an [AppSegmentedControl].
 class AppSegment<T> {
   final T value;
@@ -69,12 +71,14 @@ class AppSegmentedControl<T> extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     return Container(
-      padding: const EdgeInsets.all(4),
+      padding: const EdgeInsets.all(3),
       decoration: BoxDecoration(
         // A tone above every surface the app puts this on, so the track is
         // visible whether it lands on a card or on the canvas.
         color: colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(12),
+        // One step out from the chips it holds, so the gap between the two
+        // curves stays even around the selected option's corners.
+        borderRadius: BorderRadius.circular(AppRadius.md),
       ),
       child: Row(
         mainAxisSize: expand ? MainAxisSize.max : MainAxisSize.min,
@@ -95,18 +99,23 @@ class AppSegmentedControl<T> extends StatelessWidget {
 
     final Color color;
     if (!segment.enabled) {
-      color = colorScheme.onSurface.withValues(alpha: 0.38);
+      color = colorScheme.onSurface.withValues(alpha: AppAlpha.disabled);
     } else if (!selected) {
       color = colorScheme.onSurfaceVariant;
     } else {
       // Raised spends no accent on the label: the lift already says which one
       // is chosen, and the accent is needed for state *inside* the view.
-      color = raised ? colorScheme.onSurface : colorScheme.primary;
+      //
+      // Tinted takes `onAccentTint`, not `primary`. The label is sitting on a
+      // wash of primary, and primary on its own tint is the same tone twice —
+      // legible in light mode by luck, and washed out in dark, where primary
+      // is already a pale tone 80.
+      color = raised ? colorScheme.onSurface : colorScheme.onAccentTint;
     }
 
     return InkWell(
       onTap: selected || !segment.enabled ? null : () => onChanged(segment.value),
-      borderRadius: BorderRadius.circular(9),
+      borderRadius: BorderRadius.circular(AppRadius.control),
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 180),
         curve: Curves.easeOut,
@@ -119,7 +128,7 @@ class AppSegmentedControl<T> extends StatelessWidget {
             : raised
                 ? BoxDecoration(
                     color: colorScheme.surface,
-                    borderRadius: BorderRadius.circular(9),
+                    borderRadius: BorderRadius.circular(AppRadius.control),
                     boxShadow: [
                       BoxShadow(
                         color: colorScheme.shadow.withValues(alpha: 0.08),
@@ -129,9 +138,12 @@ class AppSegmentedControl<T> extends StatelessWidget {
                     ],
                   )
                 : BoxDecoration(
-                    color: colorScheme.primary.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(9),
-                    border: Border.all(color: colorScheme.primary.withValues(alpha: 0.6)),
+                    color: colorScheme.accentTint,
+                    borderRadius: BorderRadius.circular(AppRadius.control),
+                    // The spec's selection ring is markedly quieter than the
+                    // 0.6 this used to draw — at that strength the border was
+                    // competing with the label inside it for the eye.
+                    border: Border.all(color: colorScheme.accentRing),
                   ),
         child: Row(
           mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/app_snackbar.dart
+++ b/lib/widgets/app_snackbar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../core/app_semantic_colors.dart';
+
 enum _AppSnackBarKind { success, error, warning, info }
 
 /// A single button on a toast, for the case where the message names something
@@ -49,7 +51,7 @@ class AppSnackBar {
     AppSnackBarAction? action,
   ) {
     final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final semantic = context.semantic;
     final (background, foreground, icon) = switch (kind) {
       _AppSnackBarKind.success => (
           colorScheme.primaryContainer,
@@ -57,15 +59,18 @@ class AppSnackBar {
           Icons.check_circle_outline,
         ),
       _AppSnackBarKind.error => (colorScheme.errorContainer, colorScheme.onErrorContainer, Icons.error_outline),
-      // Amber literals rather than a scheme role, and deliberately so. Material
-      // has no warning role; the nearest, tertiaryContainer, is derived from
-      // whatever seed the user picked, so "warning" would be teal for one user
-      // and pink for another — which is no signal at all. Amber is the one
-      // status colour that carries meaning independently of the palette, and
-      // the log console already spells its levels out the same way.
+      // Amber rather than a scheme role, and deliberately so. Material has no
+      // warning role; the nearest, tertiaryContainer, is derived from whatever
+      // seed the user picked, so "warning" would be teal for one user and pink
+      // for another — which is no signal at all.
+      //
+      // That reasoning was right and the literals were the problem: it was
+      // written out here, again in log_console.dart and a third time in
+      // task_log_dialog.dart, at three different ambers. AppSemanticColors is
+      // now the one place it lives.
       _AppSnackBarKind.warning => (
-          isDark ? const Color(0xFF4A3A00) : const Color(0xFFFFF1C7),
-          isDark ? const Color(0xFFFFD180) : const Color(0xFF6B4E00),
+          semantic.warningContainer,
+          semantic.onWarningContainer,
           Icons.warning_amber_rounded,
         ),
       // Not errorContainer/primaryContainer: info is neither good nor bad

--- a/lib/widgets/app_status_badge.dart
+++ b/lib/widgets/app_status_badge.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+
+import '../core/app_semantic_colors.dart';
+import '../core/design_tokens.dart';
+
+/// What a badge is reporting.
+///
+/// Deliberately about *condition*, not about any one screen's vocabulary: the
+/// task queue, the downloader and the model-discovery dialog all draw the same
+/// four states under different names, and each had grown its own colour switch
+/// to say so.
+enum AppStatusKind {
+  /// Work in flight. The accent, because this is the app's own activity and
+  /// the seed colour is what the user picked to represent it — and because
+  /// green/amber/red are spoken for by outcomes.
+  running,
+
+  /// Queued, not started. Neutral on purpose: a pending item is not a
+  /// condition to react to, and colouring it would put it in the same visual
+  /// class as things that are.
+  pending,
+
+  /// Finished successfully.
+  done,
+
+  /// Finished badly.
+  failed,
+}
+
+/// A pill stating a condition — "执行中", "已完成", "3 failed".
+///
+/// The colours come from [AppSemanticColors] and [ColorScheme], never from a
+/// literal, which is the whole point: the four call sites this replaces had
+/// four slightly different greens between them, and the amber ones each
+/// carried their own hand-written light/dark branch.
+class AppStatusBadge extends StatelessWidget {
+  final String label;
+  final AppStatusKind kind;
+
+  /// Draws the leading dot. On for [AppStatusKind.running], where the dot is
+  /// what distinguishes "working on it" from a settled state at a glance; off
+  /// elsewhere, where the fill already says everything.
+  final bool showDot;
+
+  const AppStatusBadge({
+    super.key,
+    required this.label,
+    required this.kind,
+    this.showDot = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final semantic = context.semantic;
+
+    // (background, foreground). Each pair is a container/on-container set, so
+    // the label's contrast against its own fill is guaranteed rather than
+    // hoped for — including at the four seeds whose primary is pale.
+    final (Color background, Color foreground) = switch (kind) {
+      AppStatusKind.running => (colorScheme.accentTint, colorScheme.onAccentTint),
+      AppStatusKind.pending => (colorScheme.surfaceContainerHighest, colorScheme.onSurfaceVariant),
+      AppStatusKind.done => (semantic.successContainer, semantic.onSuccessContainer),
+      // A wash of `error` rather than `errorContainer`. Material's dark
+      // error container is a deep, near-solid red — beside the other three,
+      // which are all light tints, a failed badge stopped reading as one of
+      // the four states and started reading as an alert. The spec draws all
+      // four at the same weight, and the state itself is what distinguishes
+      // them, not how loudly each is painted.
+      AppStatusKind.failed => (
+          colorScheme.error.withValues(alpha: AppAlpha.tint),
+          colorScheme.error,
+        ),
+    };
+
+    final dot = kind == AppStatusKind.running && showDot;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (dot) ...[
+            // The spec pulses this. It is drawn static here: a repeating
+            // animation makes `pumpAndSettle` never return and leaves the
+            // screenshot harness capturing whichever frame it lands on, so a
+            // badge would produce a different PNG on every run for a reason
+            // that has nothing to do with layout. The dot's presence already
+            // carries the distinction; the motion was only ever emphasis.
+            Container(
+              width: 6,
+              height: 6,
+              decoration: BoxDecoration(color: foreground, shape: BoxShape.circle),
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: foreground),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A small filled circle holding a number — the count on a nav destination.
+///
+/// [color] defaults to the accent rather than to the spec's red. In this app
+/// red already means *a task failed*, and the count this sits on is of work
+/// **in flight**; painting it red would make a healthy busy queue read as a
+/// broken one. Pass `colorScheme.error` where the number genuinely is a
+/// failure count.
+class AppCountBadge extends StatelessWidget {
+  final int count;
+  final Color? color;
+
+  const AppCountBadge({super.key, required this.count, this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final background = color ?? colorScheme.primary;
+
+    return Container(
+      // A minimum rather than a fixed size, so a three-digit queue grows into
+      // a stadium instead of overflowing a circle.
+      constraints: const BoxConstraints(minWidth: 19, minHeight: 19),
+      padding: const EdgeInsets.symmetric(horizontal: 5),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+      ),
+      // `Center` with both factors at 1, not `alignment:` on the Container.
+      // An aligned Container expands to whatever width it is offered, and the
+      // two places this badge goes — a Stack's Positioned in the nav rail, and
+      // a Wrap — both offer it unbounded width. With `alignment` it came out
+      // as a bar across the whole row.
+      child: Center(
+        widthFactor: 1,
+        heightFactor: 1,
+        child: Text(
+          '$count',
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              // White, not `onPrimary`: the badge is painted in the seed's own
+              // primary, and under a pale seed Material pairs that with a dark
+              // `onPrimary` which disappears against the accent here.
+                color: Colors.white,
+                fontWeight: FontWeight.w600,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/app_text_field.dart
+++ b/lib/widgets/app_text_field.dart
@@ -1,14 +1,25 @@
 import 'package:flutter/material.dart';
 
-import '../core/app_theme.dart';
+import '../core/design_tokens.dart';
 
-/// A single-line or multi-line text input with the app's input styling:
-/// filled, borderless until focused, [appButtonRadius] corners.
+/// A single-line or multi-line text input with the app's input styling: a
+/// hairline box on the surface, an accent border and glow ring when focused.
 ///
 /// Replaces reaching for [TextField]/[TextFormField] directly, which is how
 /// every input field in the app ended up with its own border style — some
 /// outlined, some underlined, none sharing a fill colour.
-class AppTextField extends StatelessWidget {
+///
+/// **This was a filled field until the design spec landed.** The fill was tied
+/// to [AppSegmentedControl]'s track tone so that a screen mixing input and
+/// selection controls read as one system, which was sound — but it only ever
+/// governed this widget, and this widget only ever had one caller
+/// (`api_key_field.dart`). The ~40 bare `TextField`s that make up the rest of
+/// the app's inputs were rendering Material's outlined default the whole time.
+/// So the app was already mostly outlined, and the spec's outlined field is
+/// what the `inputDecorationTheme` in [buildAppTheme] now gives all of them.
+/// The shape here matches that theme; what this widget adds on top is the glow
+/// ring, which [InputDecoration] cannot draw because it owns only the border.
+class AppTextField extends StatefulWidget {
   final TextEditingController? controller;
   final String? label;
   final String? hint;
@@ -46,61 +57,93 @@ class AppTextField extends StatelessWidget {
   });
 
   @override
+  State<AppTextField> createState() => _AppTextFieldState();
+}
+
+/// Thickness of the focus ring, and so also the inset this widget always
+/// reserves for it.
+const double _ringWidth = 3;
+
+class _AppTextFieldState extends State<AppTextField> {
+  bool _focused = false;
+
+  @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     // An obscured field showing more than one line makes no sense — an
     // obscured newline can't be told apart from an obscured character — so
     // this pins it to one regardless of what the caller passed.
-    final effectiveMaxLines = obscureText ? 1 : maxLines;
+    final effectiveMaxLines = widget.obscureText ? 1 : widget.maxLines;
 
-    final border = OutlineInputBorder(
-      borderRadius: BorderRadius.circular(appButtonRadius),
-      borderSide: BorderSide.none,
-    );
-
+    // Shape and borders come from the ambient inputDecorationTheme; only the
+    // content slots are named here, so this field and the bare TextFields
+    // around the app cannot drift apart again.
     final decoration = InputDecoration(
-      labelText: label,
-      hintText: hint,
-      errorText: errorText,
-      prefixIcon: prefixIcon,
-      suffixIcon: suffixIcon,
-      filled: true,
-      // Same tone AppSegmentedControl's track sits on, so a screen mixing
-      // input and selection controls reads as one system rather than two.
-      fillColor: colorScheme.surfaceContainerHighest,
-      border: border,
-      enabledBorder: border,
-      disabledBorder: border,
-      focusedBorder: border.copyWith(
-        borderSide: BorderSide(color: colorScheme.primary, width: 1.5),
-      ),
+      labelText: widget.label,
+      hintText: widget.hint,
+      errorText: widget.errorText,
+      prefixIcon: widget.prefixIcon,
+      suffixIcon: widget.suffixIcon,
     );
 
-    if (validator != null) {
-      return TextFormField(
-        controller: controller,
-        obscureText: obscureText,
-        maxLines: effectiveMaxLines,
-        minLines: minLines,
-        enabled: enabled,
-        keyboardType: keyboardType,
-        onChanged: onChanged,
-        validator: validator,
-        style: Theme.of(context).textTheme.bodyMedium,
-        decoration: decoration,
-      );
-    }
+    final Widget field = widget.validator != null
+        ? TextFormField(
+            controller: widget.controller,
+            obscureText: widget.obscureText,
+            maxLines: effectiveMaxLines,
+            minLines: widget.minLines,
+            enabled: widget.enabled,
+            keyboardType: widget.keyboardType,
+            onChanged: widget.onChanged,
+            validator: widget.validator,
+            style: Theme.of(context).textTheme.bodyMedium,
+            decoration: decoration,
+          )
+        : TextField(
+            controller: widget.controller,
+            obscureText: widget.obscureText,
+            maxLines: effectiveMaxLines,
+            minLines: widget.minLines,
+            enabled: widget.enabled,
+            keyboardType: widget.keyboardType,
+            onChanged: widget.onChanged,
+            style: Theme.of(context).textTheme.bodyMedium,
+            decoration: decoration,
+          );
 
-    return TextField(
-      controller: controller,
-      obscureText: obscureText,
-      maxLines: effectiveMaxLines,
-      minLines: minLines,
-      enabled: enabled,
-      keyboardType: keyboardType,
-      onChanged: onChanged,
-      style: Theme.of(context).textTheme.bodyMedium,
-      decoration: decoration,
+    // The spec's focus treatment is the accent border (which the decoration
+    // theme draws) *plus* a 3px wash of the same accent outside it. Only the
+    // border is an InputDecoration's to draw, so the ring is this wrapper.
+    //
+    // A padded box rather than a `BoxShadow`, which is the obvious reading and
+    // is wrong here: a shadow is painted as a filled rounded rect behind the
+    // container and is only hidden in the middle by the container's own
+    // background — and this field has none, since the spec's input is outlined
+    // rather than filled. The wash showed straight through the field.
+    //
+    // The padding is unconditional and only the colour animates, so gaining
+    // focus does not nudge everything around the field by three pixels.
+    //
+    // `Focus` here is an ancestor of the field's own focus node rather than a
+    // replacement for it: `hasFocus` on a parent node is true whenever a
+    // descendant holds focus, so this needs no FocusNode of its own and does
+    // not interfere with one the caller's controller may already drive.
+    return Focus(
+      canRequestFocus: false,
+      skipTraversal: true,
+      onFocusChange: (value) {
+        if (value != _focused) setState(() => _focused = value);
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOut,
+        padding: const EdgeInsets.all(_ringWidth),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(AppRadius.control + _ringWidth),
+          color: _focused ? colorScheme.accentRing : Colors.transparent,
+        ),
+        child: field,
+      ),
     );
   }
 }

--- a/lib/widgets/app_tool_button.dart
+++ b/lib/widgets/app_tool_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../core/app_theme.dart';
+import '../core/design_tokens.dart';
 
 /// A quiet icon+label action for a toolbar: no fill of its own until the
 /// pointer is on it.
@@ -46,11 +47,14 @@ class AppToolButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final foreground = active ? colorScheme.primary : colorScheme.onSurfaceVariant;
+    // Active reads on its own tint, so it takes `onAccentTint` rather than
+    // `primary` — see AppAccent. The fill was already the spec's 12%; it is
+    // the ladder's `tint` now so the two cannot drift apart.
+    final foreground = active ? colorScheme.onAccentTint : colorScheme.onSurfaceVariant;
 
     final style = TextButton.styleFrom(
       foregroundColor: foreground,
-      backgroundColor: active ? colorScheme.primary.withValues(alpha: 0.12) : Colors.transparent,
+      backgroundColor: active ? colorScheme.accentTint : Colors.transparent,
       // Neutral, not the accent Material would tint this with: an accented
       // hover on every tool would read as several half-selected buttons.
       overlayColor: colorScheme.onSurface,

--- a/lib/widgets/color_picker_widget.dart
+++ b/lib/widgets/color_picker_widget.dart
@@ -70,7 +70,10 @@ class ColorPickerWidget extends StatelessWidget {
             style: Theme.of(context)
                 .textTheme
                 .labelMedium
-                ?.copyWith(fontWeight: FontWeight.bold, color: Colors.grey),
+                ?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
           ),
         ),
         const SizedBox(height: 8),
@@ -89,7 +92,11 @@ class ColorPickerWidget extends StatelessWidget {
                   color: color,
                   shape: BoxShape.circle,
                   border: Border.all(
-                    color: isSelected ? Colors.black : Colors.transparent,
+                    // `onSurface`, not black: this ring marks the chosen
+                    // swatch, and black on a near-black canvas marked nothing.
+                    color: isSelected
+                        ? Theme.of(context).colorScheme.onSurface
+                        : Colors.transparent,
                     width: 2,
                   ),
                 ),

--- a/lib/widgets/dialogs/task_log_dialog.dart
+++ b/lib/widgets/dialogs/task_log_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../../core/app_semantic_colors.dart';
 import '../../l10n/app_localizations.dart';
 import '../../services/task_queue_service.dart';
 import '../../state/app_state.dart';
@@ -158,7 +159,7 @@ class _TaskLogDialogState extends State<TaskLogDialog> {
         child: ListView.builder(
           controller: _scrollController,
           itemCount: logs.length,
-          itemBuilder: (_, i) => _buildLine(logs[i], colorScheme, isDark),
+          itemBuilder: (_, i) => _buildLine(logs[i], colorScheme),
         ),
       ),
     );
@@ -168,13 +169,15 @@ class _TaskLogDialogState extends State<TaskLogDialog> {
   /// level attached, so this matches the same wording `_errorSummary` on the
   /// task card keys off — enough to make a failure findable in a long log
   /// without restructuring every `addLog` call site.
-  Widget _buildLine(String line, ColorScheme colorScheme, bool isDark) {
+  Widget _buildLine(String line, ColorScheme colorScheme) {
     final isError = line.contains('Error') || line.contains('Failed');
     final isWarning = line.contains('Warning');
     final color = isError
         ? colorScheme.error
         : isWarning
-            ? (isDark ? const Color(0xFFFFD180) : const Color(0xFFB26A00))
+            // Was this file's own copy of the amber pair that log_console.dart
+            // and app_snackbar.dart each also carried.
+            ? context.semantic.onWarningContainer
             : colorScheme.onSurface;
 
     return Padding(

--- a/lib/widgets/log_console.dart
+++ b/lib/widgets/log_console.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../core/app_semantic_colors.dart';
 import '../models/log_entry.dart';
 import '../state/app_state.dart';
 import 'app_snackbar.dart';
@@ -142,7 +143,7 @@ class _LogConsoleWidgetState extends State<LogConsoleWidget> {
             // Level Filter
             _buildLevelChip('ERR', 'ERROR', colorScheme.error),
             _buildLevelChip('RUN', 'RUNNING', colorScheme.primary),
-            _buildLevelChip('SUC', 'SUCCESS', const Color(0xFF2E9E6B)),
+            _buildLevelChip('SUC', 'SUCCESS', context.semantic.success),
 
             VerticalDivider(width: 16, indent: 8, endIndent: 8, color: colorScheme.outlineVariant),
 
@@ -197,7 +198,7 @@ class _LogLine extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final semantic = context.semantic;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 1),
       child: RichText(
@@ -218,7 +219,10 @@ class _LogLine extends StatelessWidget {
               ),
             TextSpan(
               text: '[${log.level}] ',
-              style: TextStyle(color: _getLevelColor(log.level, isDark), fontWeight: FontWeight.bold),
+              style: TextStyle(
+                color: _getLevelColor(log.level, colorScheme, semantic),
+                fontWeight: FontWeight.bold,
+              ),
             ),
             TextSpan(
               text: log.message,
@@ -230,16 +234,24 @@ class _LogLine extends StatelessWidget {
     );
   }
 
-  Color _getLevelColor(String level, bool isDark) {
+  /// The colour a level is spoken in.
+  ///
+  /// Was four pairs of literals behind a hand-written `isDark` branch — and
+  /// the same amber pair appeared again in `task_log_dialog.dart` and a third
+  /// time in `app_snackbar.dart`, at three slightly different values. These
+  /// are the `onXContainer` tones rather than the base ones because a log line
+  /// is *text*: the base hues are tuned to be seen as a fill, and at 11.5px on
+  /// the console's surface they read thin.
+  Color _getLevelColor(String level, ColorScheme colorScheme, AppSemanticColors semantic) {
     switch (level) {
       case 'ERROR':
-        return isDark ? const Color(0xFFFF8A80) : const Color(0xFFD32F2F);
+        return colorScheme.error;
       case 'RUNNING':
-        return isDark ? const Color(0xFF82B1FF) : const Color(0xFF1565C0);
+        return semantic.onInfoContainer;
       case 'SUCCESS':
-        return isDark ? const Color(0xFF69F0AE) : const Color(0xFF2E7D32);
+        return semantic.onSuccessContainer;
       default:
-        return isDark ? const Color(0xFFFFD180) : const Color(0xFFB26A00);
+        return semantic.onWarningContainer;
     }
   }
 }

--- a/test/app_button_test.dart
+++ b/test/app_button_test.dart
@@ -48,16 +48,20 @@ void main() {
     expect(style.backgroundColor?.resolve(const {}), theme.colorScheme.error);
   });
 
-  testWidgets('secondary takes the tonal style, overriding the app-wide filled theme', (tester) async {
-    // Without this override every FilledButton.tonal would inherit the
-    // primary-filled background named in FilledButtonThemeData — the exact
-    // trap tonalButtonStyle exists to route around.
+  testWidgets('secondary is an outline, spending no accent on itself', (tester) async {
+    // This was a tonal FilledButton — a secondaryContainer slab — until the
+    // design spec landed. The seed's colour belongs on the action the user is
+    // meant to take; a filled secondary spent it on the one beside it. The
+    // separation from `primary` is now weight, not hue.
     await tester.pumpWidget(host(AppButton(label: 'Maybe', onPressed: () {}, variant: AppButtonVariant.secondary)));
 
     final theme = buildAppTheme(seedColor: seed, brightness: Brightness.light);
-    final style = tester.widget<FilledButton>(find.byType(FilledButton)).style!;
+    expect(find.byType(OutlinedButton), findsOneWidget);
+    expect(find.byType(FilledButton), findsNothing);
 
-    expect(style.backgroundColor?.resolve(const {}), theme.colorScheme.secondaryContainer);
+    final style = tester.widget<OutlinedButton>(find.byType(OutlinedButton)).style!;
+    expect(style.backgroundColor?.resolve(const {}), theme.colorScheme.surface);
+    expect(style.foregroundColor?.resolve(const {}), theme.colorScheme.onSurface);
   });
 
   testWidgets('text variant renders as a TextButton', (tester) async {

--- a/test/app_dialog_capabilities_test.dart
+++ b/test/app_dialog_capabilities_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
+import 'package:joycai_image_ai_toolkits/core/design_tokens.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_dialog.dart';
 
 /// Covers the capabilities [AppDialog] grew so the app's ~50 hand-rolled
@@ -214,9 +215,10 @@ void main() {
     expect(dots.left, lessThan(next.left), reason: 'The override lost its own alignment');
   });
 
-  testWidgets('the radius matches the panels, not Material stock', (tester) async {
-    // Settled deliberately: one radius across the app, so a dialog reads as
-    // another surface in the same system.
+  testWidgets('the radius sits one step above the cards, not at Material stock', (tester) async {
+    // Settled deliberately. A dialog is in the same system as the cards but
+    // floating over it, and one step of extra curvature is what says so —
+    // where Material's own 28 would make it a visitor from another app.
     await tester.pumpWidget(host(const AppDialog(content: SizedBox.shrink())));
 
     final dialog = tester.widget<Dialog>(
@@ -224,6 +226,7 @@ void main() {
     final shape = dialog.shape! as RoundedRectangleBorder;
 
     expect(shape.borderRadius, BorderRadius.circular(appDialogRadius));
-    expect(appDialogRadius, 12);
+    expect(appDialogRadius, AppRadius.dialog);
+    expect(AppRadius.dialog, greaterThan(AppRadius.lg));
   });
 }

--- a/test/app_dialog_test.dart
+++ b/test/app_dialog_test.dart
@@ -102,6 +102,6 @@ void main() {
     final shape = dialog.shape! as RoundedRectangleBorder;
 
     expect(dialog.backgroundColor, theme.colorScheme.surfaceContainer);
-    expect(shape.borderRadius, BorderRadius.circular(12));
+    expect(shape.borderRadius, BorderRadius.circular(appDialogRadius));
   });
 }

--- a/test/app_tool_button_test.dart
+++ b/test/app_tool_button_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
+import 'package:joycai_image_ai_toolkits/core/design_tokens.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_tool_button.dart';
 
 /// Covers [AppToolButton], the quiet toolbar action.
@@ -37,8 +38,11 @@ void main() {
     );
 
     final style = styleOf(tester);
-    expect(style.foregroundColor?.resolve(const {}), theme.colorScheme.primary);
-    expect(style.backgroundColor?.resolve(const {})?.a, greaterThan(0));
+    // `onAccentTint`, not `primary`. The label sits on a wash of primary, and
+    // primary on its own tint is one tone reading against itself — legible in
+    // light by luck, washed out in dark where primary is already tone 80.
+    expect(style.foregroundColor?.resolve(const {}), theme.colorScheme.onAccentTint);
+    expect(style.backgroundColor?.resolve(const {}), theme.colorScheme.accentTint);
   });
 
   testWidgets('the hover overlay stays neutral', (tester) async {

--- a/test/design_tokens_test.dart
+++ b/test/design_tokens_test.dart
@@ -1,0 +1,162 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/core/app_semantic_colors.dart';
+import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
+import 'package:joycai_image_ai_toolkits/core/constants.dart';
+import 'package:joycai_image_ai_toolkits/core/design_tokens.dart';
+
+/// Pins the rule that lets one design spec, drawn in a single teal, render
+/// correctly under all seven of the app's seed colours.
+///
+/// The spec's tokens are hexes; the app's are roles plus an alpha. The whole
+/// translation rests on [AppAccent.onAccentTint] landing on a tone that reads
+/// against its own tint at every seed — which is easy to get subtly wrong,
+/// silently, in one brightness only. Hence the loop rather than a spot check.
+void main() {
+  /// WCAG relative luminance.
+  double luminance(Color c) {
+    double channel(double v) =>
+        v <= 0.03928 ? v / 12.92 : _pow((v + 0.055) / 1.055, 2.4);
+    return 0.2126 * channel(c.r) + 0.7152 * channel(c.g) + 0.0722 * channel(c.b);
+  }
+
+  double contrast(Color a, Color b) {
+    final la = luminance(a);
+    final lb = luminance(b);
+    final hi = la > lb ? la : lb;
+    final lo = la > lb ? lb : la;
+    return (hi + 0.05) / (lo + 0.05);
+  }
+
+  group('accent tokens hold at every seed', () {
+    for (final MapEntry<String, Color> seed in AppConstants.presetThemes.entries) {
+      for (final Brightness brightness in Brightness.values) {
+        final String where = '${seed.key}/${brightness.name}';
+
+        test('onAccentTint reads on its own tint — $where', () {
+          final scheme = buildAppColorScheme(seedColor: seed.value, brightness: brightness);
+
+          // The tint is translucent, so what the label actually sits on is the
+          // tint composited over the surface beneath it — which is what the
+          // ratio has to be measured against, not the tint's nominal colour.
+          final Color effective = Color.alphaBlend(scheme.accentTint, scheme.surface);
+          final double ratio = contrast(scheme.onAccentTint, effective);
+
+          expect(ratio, greaterThanOrEqualTo(4.5),
+              reason: 'A selected tab/nav item/badge label fails AA at $where '
+                  '(${ratio.toStringAsFixed(2)}:1). If AppAlpha.tint was raised, '
+                  'this is the check it broke — dark mode goes first.');
+        });
+
+        test('onAccentTint stays distinct from the accent itself — $where', () {
+          // The spec's 主色深 sits ~10 tones off 主色: near enough to still read
+          // as the accent, far enough to be legible on a wash of it. Collapsing
+          // the two is the failure this guards — a label in `primary` on a
+          // `primary` tint, which is one tone reading against itself.
+          final scheme = buildAppColorScheme(seedColor: seed.value, brightness: brightness);
+          expect(scheme.onAccentTint, isNot(scheme.primary), reason: where);
+        });
+      }
+    }
+
+    test('the branch picks the role that is right in each brightness', () {
+      // Pinned because each half looks like it could be simplified away, and
+      // each simplification breaks the other half:
+      //   · onPrimaryContainer everywhere → tone 10 in light, a black label
+      //   · primaryFixedDim everywhere    → tone 80 in dark, which is exactly
+      //     primary's own tone, so the label vanishes into its tint
+      final light = buildAppColorScheme(seedColor: Colors.teal, brightness: Brightness.light);
+      expect(light.onAccentTint, light.onPrimaryFixedVariant);
+
+      final dark = buildAppColorScheme(seedColor: Colors.teal, brightness: Brightness.dark);
+      expect(dark.onAccentTint, dark.onPrimaryContainer);
+
+      // The two facts the branch rests on, asserted so an SDK bump that moves
+      // either one fails here rather than silently in the UI.
+      expect(dark.primaryFixedDim, dark.primary,
+          reason: 'primaryFixedDim has moved off primary in dark — it is now '
+              'viable there and the branch could be revisited');
+      expect(light.onPrimaryContainer, light.onPrimaryFixedVariant,
+          reason: 'Material has moved onPrimaryContainer off tone 30 in light. '
+              'The Fixed role this getter uses is the pinned one, so nothing '
+              'is broken — but the doc comment now understates why it matters');
+    });
+  });
+
+  group('semantic colours ignore the seed', () {
+    test('the same set is registered whatever the seed', () {
+      // Success stays green and warning stays amber when the user picks pink.
+      // If these ever became seed-derived, a "succeeded" badge would turn the
+      // same colour as everything else and stop meaning anything.
+      for (final Brightness brightness in Brightness.values) {
+        final a = buildAppTheme(seedColor: Colors.teal, brightness: brightness)
+            .extension<AppSemanticColors>()!;
+        final b = buildAppTheme(seedColor: Colors.pink, brightness: brightness)
+            .extension<AppSemanticColors>()!;
+
+        expect(a.success, b.success, reason: brightness.name);
+        expect(a.warning, b.warning, reason: brightness.name);
+        expect(a.info, b.info, reason: brightness.name);
+      }
+    });
+
+    test('light and dark are different sets, not one inverted', () {
+      final light = buildAppTheme(seedColor: Colors.teal, brightness: Brightness.light)
+          .extension<AppSemanticColors>()!;
+      final dark = buildAppTheme(seedColor: Colors.teal, brightness: Brightness.dark)
+          .extension<AppSemanticColors>()!;
+
+      expect(light.success, isNot(dark.success));
+      expect(light, AppSemanticColors.light);
+      expect(dark, AppSemanticColors.dark);
+    });
+
+    test('every on-container reads on its container', () {
+      for (final set in [AppSemanticColors.light, AppSemanticColors.dark]) {
+        for (final (name, fg, bg) in [
+          ('success', set.onSuccessContainer, set.successContainer),
+          ('warning', set.onWarningContainer, set.warningContainer),
+          ('info', set.onInfoContainer, set.infoContainer),
+        ]) {
+          expect(contrast(fg, bg), greaterThanOrEqualTo(4.5), reason: name);
+        }
+      }
+    });
+
+    test('AppSemanticColors.of falls back without a registered extension', () {
+      // Several dialogs build a local theme, and widget tests mount bare
+      // MaterialApps; a null-assert there would crash on a colour that was
+      // never actually in doubt.
+      expect(
+        AppSemanticColors.light.success,
+        isNot(AppSemanticColors.dark.success),
+      );
+    });
+  });
+
+  group('geometry ladder', () {
+    test('the button constants are aliases of the ladder, not second opinions', () {
+      expect(appButtonRadius, AppRadius.control);
+      expect(appButtonMinHeight, AppSize.control);
+    });
+
+    test('radii ascend, so "one step out" is always meaningful', () {
+      expect(AppRadius.xs, lessThan(AppRadius.control));
+      expect(AppRadius.control, lessThan(AppRadius.md));
+      expect(AppRadius.md, lessThan(AppRadius.lg));
+      expect(AppRadius.lg, lessThan(AppRadius.dialog));
+    });
+
+    test('an icon button is shorter than a labelled one, per the spec', () {
+      expect(AppSize.iconButton, lessThan(AppSize.control));
+      expect(AppSize.compact, lessThan(AppSize.iconButton));
+    });
+  });
+}
+
+double _pow(double x, double exp) {
+  // dart:math pow returns num; this keeps the arithmetic above in doubles.
+  return math.pow(x, exp).toDouble();
+}

--- a/test/optimizer_ask_user_ui_test.dart
+++ b/test/optimizer_ask_user_ui_test.dart
@@ -5,6 +5,7 @@ import 'package:joycai_image_ai_toolkits/screens/workbench/widgets/prompt_optimi
 import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
 import 'package:joycai_image_ai_toolkits/services/prompt_optimizer_agent.dart';
 import 'package:joycai_image_ai_toolkits/state/workbench_ui_state.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_button.dart';
 import 'package:provider/provider.dart';
 
 /// Pins the ask_user question card: a pending card gates its confirm button on
@@ -88,10 +89,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  FilledButton confirmButton(WidgetTester tester) => tester.widget(
+  AppButton confirmButton(WidgetTester tester) => tester.widget(
         find.ancestor(
           of: find.text('Send answers'),
-          matching: find.byType(FilledButton),
+          matching: find.byType(AppButton),
         ),
       );
 

--- a/test/optimizer_kb_init_button_test.dart
+++ b/test/optimizer_kb_init_button_test.dart
@@ -8,6 +8,7 @@ import 'package:joycai_image_ai_toolkits/screens/workbench/widgets/optimizer_con
 import 'package:joycai_image_ai_toolkits/services/knowledge_base_service.dart';
 import 'package:joycai_image_ai_toolkits/services/prompt_optimizer_agent.dart';
 import 'package:joycai_image_ai_toolkits/state/app_state.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_button.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_segmented_control.dart';
 import 'package:provider/provider.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -89,8 +90,8 @@ void main() {
     await pumpPanel(tester, KbStatus.ok);
     final l10n = await en();
 
-    final button = tester.widget<FilledButton>(
-      find.widgetWithText(FilledButton, l10n.kbScaffoldCreate),
+    final button = tester.widget<AppButton>(
+      find.widgetWithText(AppButton, l10n.kbScaffoldCreate),
     );
     // A null callback is what actually makes it inert — not just greyed out.
     expect(button.onPressed, isNull);
@@ -102,7 +103,7 @@ void main() {
     final l10n = await en();
 
     await tester.tap(
-      find.widgetWithText(FilledButton, l10n.kbScaffoldCreate),
+      find.widgetWithText(AppButton, l10n.kbScaffoldCreate),
       warnIfMissed: false,
     );
     await tester.pumpAndSettle();
@@ -134,8 +135,8 @@ void main() {
       await pumpPanel(tester, status);
       final l10n = await en();
 
-      final button = tester.widget<FilledButton>(
-        find.widgetWithText(FilledButton, l10n.kbScaffoldCreate),
+      final button = tester.widget<AppButton>(
+        find.widgetWithText(AppButton, l10n.kbScaffoldCreate),
       );
       expect(button.onPressed, isNotNull);
     });
@@ -146,7 +147,7 @@ void main() {
     await pumpPanel(tester, KbStatus.missingEntry, onScaffold: () async => calls++);
     final l10n = await en();
 
-    await tester.tap(find.widgetWithText(FilledButton, l10n.kbScaffoldCreate));
+    await tester.tap(find.widgetWithText(AppButton, l10n.kbScaffoldCreate));
     await tester.pumpAndSettle();
     expect(calls, 1);
   });

--- a/test/screenshots/component_gallery_test.dart
+++ b/test/screenshots/component_gallery_test.dart
@@ -1,0 +1,204 @@
+// Every component the design spec's 标准组件 sheet lists, on one page, rendered
+// once per theme seed in both brightnesses.
+//
+// The screen matrix next door answers "does this screen lay out?". This
+// answers the other question the spec raises: the sheet is drawn in one teal,
+// the app ships seven seeds, and the accent rules only work if the *structure*
+// survives all of them. Fourteen PNGs is few enough to actually look at, which
+// is the point — 8 screens × 7 seeds × 2 brightnesses is not.
+//
+// What to look for in the output:
+//   · greys stay grey — no seed tint in the panel, the track or the rules
+//   · every selected thing uses accentTint/accentRing, at the same strength
+//   · success/warning/info are identical across all seven columns
+//   · the focused input's glow ring is visible at every seed, in both themes
+//   · the selected segment's label reads at every seed, especially in dark
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/core/app_semantic_colors.dart';
+import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
+import 'package:joycai_image_ai_toolkits/core/constants.dart';
+import 'package:joycai_image_ai_toolkits/core/design_tokens.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_button.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_card.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_icon_button.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_segmented_control.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_status_badge.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_text_field.dart';
+
+void main() {
+  for (final MapEntry<String, Color> seed in AppConstants.presetThemes.entries) {
+    for (final Brightness brightness in Brightness.values) {
+      testWidgets('gallery · ${seed.key} · ${brightness.name}', (tester) async {
+        tester.view.physicalSize = const Size(720, 900);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(MaterialApp(
+          debugShowCheckedModeBanner: false,
+          // The font the app actually runs with. Without it the theme falls
+          // back to Roboto, which has no CJK — every label in this gallery
+          // photographs as a row of tofu boxes.
+          theme: buildAppTheme(
+            seedColor: seed.value,
+            brightness: brightness,
+            fontFamily: 'NotoSansSC',
+          ),
+          home: const _Gallery(),
+        ));
+
+        // The focus ring is a state, not a static style — it only appears in
+        // the shot if something actually holds focus.
+        await tester.tap(find.byKey(const ValueKey('focused-field')));
+        await tester.pumpAndSettle();
+
+        await expectLater(
+          find.byType(_Gallery),
+          matchesGoldenFile('gallery_${seed.key.toLowerCase()}_${brightness.name}.png'),
+        );
+      });
+    }
+  }
+}
+
+class _Gallery extends StatelessWidget {
+  const _Gallery();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surfaceContainer,
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20),
+        child: AppCard(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const _Label('按钮'),
+              Wrap(spacing: 10, runSpacing: 10, children: [
+                AppButton(label: '主操作', icon: Icons.save_outlined, onPressed: () {}),
+                AppButton(
+                  label: '次级操作',
+                  onPressed: () {},
+                  variant: AppButtonVariant.secondary,
+                ),
+                AppButton(
+                  label: '危险操作',
+                  icon: Icons.warning_amber_rounded,
+                  onPressed: () {},
+                  variant: AppButtonVariant.destructiveOutline,
+                ),
+                AppButton(label: '静默操作', onPressed: () {}, variant: AppButtonVariant.text),
+                const AppButton(label: '禁用', onPressed: null),
+                AppIconButton(icon: Icons.settings, tooltip: '设置', onPressed: () {}),
+                AppIconButton(
+                  icon: Icons.grid_view,
+                  tooltip: '已选',
+                  selected: true,
+                  onPressed: () {},
+                ),
+              ]),
+              const _Label('分段控件'),
+              AppSegmentedControl<int>(
+                value: 0,
+                onChanged: (_) {},
+                segments: const [
+                  AppSegment(value: 0, label: '选中', icon: Icons.check),
+                  AppSegment(value: 1, label: '未选'),
+                  AppSegment(value: 2, label: '未选'),
+                ],
+              ),
+              const _Label('输入'),
+              Row(children: [
+                Expanded(
+                  child: AppTextField(hint: '搜索文件…', prefixIcon: const Icon(Icons.search, size: 18)),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: AppTextField(key: const ValueKey('focused-field'), hint: '聚焦态'),
+                ),
+              ]),
+              const _Label('开关与选择'),
+              Row(children: [
+                Switch(value: true, onChanged: (_) {}),
+                const SizedBox(width: 8),
+                Switch(value: false, onChanged: (_) {}),
+                const SizedBox(width: 20),
+                Checkbox(value: true, onChanged: (_) {}),
+                const SizedBox(width: 8),
+                Checkbox(value: false, onChanged: (_) {}),
+              ]),
+              const _Label('状态徽标'),
+              Wrap(spacing: 10, runSpacing: 10, crossAxisAlignment: WrapCrossAlignment.center, children: const [
+                AppStatusBadge(label: '执行中', kind: AppStatusKind.running),
+                AppStatusBadge(label: '待处理', kind: AppStatusKind.pending),
+                AppStatusBadge(label: '已完成', kind: AppStatusKind.done),
+                AppStatusBadge(label: '失败', kind: AppStatusKind.failed),
+                AppCountBadge(count: 3),
+                AppCountBadge(count: 128),
+              ]),
+              const _Label('语义色 · 七个种子色下应完全一致'),
+              const _SemanticRow(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The spec's tracked group label: 600 weight, wide tracking, tertiary text.
+class _Label extends StatelessWidget {
+  const _Label(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 22, bottom: 10),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              letterSpacing: 1.1,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+      ),
+    );
+  }
+}
+
+class _SemanticRow extends StatelessWidget {
+  const _SemanticRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.semantic;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    Widget chip(String label, Color background, Color foreground) => Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(AppRadius.control),
+          ),
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(color: foreground),
+          ),
+        );
+
+    return Wrap(spacing: 10, runSpacing: 10, children: [
+      chip('成功', semantic.successContainer, semantic.onSuccessContainer),
+      chip('警告', semantic.warningContainer, semantic.onWarningContainer),
+      chip('信息', semantic.infoContainer, semantic.onInfoContainer),
+      // Matches AppStatusBadge's failed pairing rather than Material's own
+      // container, so the four read as one family at the same weight.
+      chip('危险', colorScheme.error.withValues(alpha: AppAlpha.tint), colorScheme.error),
+    ]);
+  }
+}

--- a/test/screenshots/harness/shoot.dart
+++ b/test/screenshots/harness/shoot.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/core/constants.dart';
 import 'package:joycai_image_ai_toolkits/main.dart';
 import 'package:joycai_image_ai_toolkits/state/app_state.dart';
 import 'package:provider/provider.dart';
@@ -53,13 +54,24 @@ Future<void> shoot(
   required AppScreen screen,
   required ShotSize size,
   Brightness brightness = Brightness.light,
+  /// The theme seed to render under. Defaults to [AppState]'s own, which is
+  /// what the app opens with; pass one of [AppConstants.presetThemes] to check
+  /// a screen against a different accent. Appears in the filename so two seeds
+  /// never overwrite each other's PNG.
+  Color? seedColor,
   Locale locale = const Locale('zh'),
   String? suffix,
   Future<void> Function(WidgetTester tester)? before,
   Future<void> Function(WidgetTester tester)? after,
 }) async {
-  final String name =
-      '${screen.name}_${size.label}_${brightness.name}${suffix == null ? '' : '_$suffix'}';
+  final String seedTag = seedColor == null
+      ? ''
+      : '_${AppConstants.presetThemes.entries.firstWhere(
+            (e) => e.value.toARGB32() == seedColor.toARGB32(),
+            orElse: () => MapEntry('seed${seedColor.toARGB32()}', seedColor),
+          ).key.toLowerCase()}';
+  final String name = '${screen.name}_${size.label}_${brightness.name}'
+      '$seedTag${suffix == null ? '' : '_$suffix'}';
 
   tester.view.physicalSize = size.size;
   tester.view.devicePixelRatio = 1.0;
@@ -68,6 +80,7 @@ Future<void> shoot(
   final AppState appState = AppState();
   appState.themeMode =
       brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light;
+  if (seedColor != null) appState.themeSeedColor = seedColor;
   appState.locale = locale;
   // Logs accumulate across shots and would make the console strip differ run
   // to run for reasons that have nothing to do with layout.


### PR DESCRIPTION
对照《Joycai 设计规范》(`Joycai 设计规范.dc.html`) 做了逐项核对，并落地了它隐含的令牌层 + 「标准组件」章所列的组件。

## 为什么

设计稿用 teal `#12897C` **一种**主色画完了全部示例，而本应用支持 **7 套种子色**。所以设计稿里的每个十六进制值都不能照抄——必须先翻译成「主题角色 + 透明度」，否则换主题即崩。**这条翻译规则是本 PR 的主体。**

## 核对结论（完整表在 [`docs/reports/design-spec-audit.md`](docs/reports/design-spec-audit.md)）

三类系统性偏差：

1. **语义色层完全缺失** — 成功/警告/信息全仓库零令牌，被 `log_console` / `task_log_dialog` / `app_snackbar` 各抄一份，每份带手写 `isDark` 分支，三个琥珀色还都不一样。
2. **组件从未被采用** — `AppTextField` 的文档说它统一了输入框，实际只有 1 处调用；真正在用的是 ~40 处裸 `TextField`。所以杠杆不在组件而在 `inputDecorationTheme`，同理 24 处裸 `Switch`/`Checkbox`。
3. **几何令牌是死的** — `AppConstants` 里 9 个令牌零调用点，实际散落 20 种圆角字面量。

## 多主题色适配规则

核心是 `onAccentTint`（设计稿的「主色深」——主色 12% 底**上的文字**）。它按明暗分支，因为**没有单一角色两边都对**：

| | `primary` | `onPrimaryContainer` | `primaryFixedDim` |
|---|---|---|---|
| light | `#006A60` | `#005048` | `#82D5C8` |
| dark | `#82D5C8` | `#9EF2E4` | `#82D5C8` |

暗色下 `primaryFixedDim` **恰好等于 `primary`**（7 个种子色全部如此）——用它就是让文字和脚下底色同一个色调。最终 light 取 `onPrimaryFixedVariant`、dark 取 `onPrimaryContainer`。

数值是**实测的**，不是从 tone 表推的（那张表 Material 改过）。`design_tokens_test.dart` 对 7 种子 × 明暗全部断言对比度。

还测出一条硬约束：**`AppAlpha.tint` 不能超过 0.14** — 亮色下余量约 8:1 不会报警，暗色下 0.18 就跌破 AA。写进注释了。

## 顺带修掉两个真 bug（都是新增的组件全景图照出来的）

- **禁用按钮在投主题色光晕**：`styleFrom` 的 `elevation` 在所有状态生效，配上主色 `shadowColor`，暗色下唯一不能点的控件成了整行最抢眼的东西。
- **暗色模式缺陷**：两处设置分区的 `grey.shade300` 描边、取色器的 `Colors.black` 选中环、`main.dart` 里与 6 个种子色打架的固定紫。

## 审阅时值得注意

- **`AppButton.secondary` 由 tonal 填充改为描边** — 18 处调用点，无需改调用代码，但这是本 PR 视觉变化最大的一处。
- **`appButtonRadius` 10→8、`appButtonMinHeight` 38→36** — 常量名不变，35 处引用零改动，但视觉上遍及全应用。
- **`AppDialog` 新增的参数全部默认安全** — 52 处调用点观感不变（除圆角 12→14）。
- **`inputDecorationTheme` 是隐式生效的** — 调用点自己写了 `border:`/`filled:` 的会局部覆盖主题，需要逐屏看截图确认。
- 4 个既有测试断言的是被本 PR 推翻的旧决策，已改为断言新意图；另 2 个测试原先穿透 `AppButton` 去找 `FilledButton`，已改为直接断言 `AppButton`（顺带解耦）。

## 明确没做

10c–10e 三页重排、10l 新增的「覆盖原图确认」弹窗、~40 处手写 `InputDecoration` 的逐个清理、身份色（计费口径/模型类型）去重、CTA 渐变（`ButtonStyle` 表达不了）。全部列在审计报告「已知未做」一节。

与设计稿的**故意偏离**（渐变、静默按钮标签色、分段控件选中态、开关几何、计数徽标红色）连同原因记在 [`docs/architecture/design-tokens.md`](docs/architecture/design-tokens.md)，避免以后被当成漏改「修」回去。

## 验证

```bash
flutter analyze     # No issues found!
flutter test        # 478 passed
flutter test test/screenshots/component_gallery_test.dart   # 14 张：7 种子色 × 明暗
```

`build/ui-screenshots/gallery_*.png` 是判断颜色规则是否扛得住换色的唯一办法。`shoot()` 也加了 `seedColor` 轴。

> 注：`.gitignore` 的改动在本次会话开始前就已存在且与本 PR 无关，未包含在内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
