### PR TITLE
feat(workbench): 覆盖原图确认弹窗对齐 10l + 副本命名与 service 层拦截

### DIFF
--- a/docs/reports/design-spec-audit.md
+++ b/docs/reports/design-spec-audit.md
@@ -45,7 +45,7 @@
 | | 结论 |
 |---|---|
 | 10j 添加费率组 / 10k 编辑费率组 | 设计稿是 `PricingGroupManager` 的**重设计**：fieldset 式浮起图例标签、46px 图标底板、11px 字段框。`AppDialog` 的新外壳（底板 / 分隔线 / 圆角）已把骨架对齐；字段级重设计未做 |
-| 10l 覆盖原图确认 | 标注「**新增**」——应用中尚不存在这个确认弹窗。未实现。`AppDialog(icon:, iconColor: colorScheme.error, onClose:, divided:)` 已经能直接搭出设计稿的形状，实现成本很低 |
+| 10l 覆盖原图确认 | **设计稿标注「新增」，但应用里其实早就有**（`crop_resize_toolbar.dart`，三个按钮与尺寸行俱全）。本报告初版照搬了设计稿的标注而没查代码，是错的。已按 10l 重做外观：危险色图标底板、副标题、关闭按钮、带边框的文件行（含 尺寸→尺寸 箭头，新尺寸用 `error` 色）、提示改存副本的信息框 |
 
 ## 四、顺带修掉的既有缺陷
 
@@ -57,6 +57,8 @@
 | `main.dart:391` | `Color(0xFFB794F6)` 固定紫与 `colorScheme.primary` 组渐变，与 7 个种子色中的 6 个打架 → `primaryContainer` |
 | `log_console.dart` ↔ `task_log_dialog.dart` ↔ `app_snackbar.dart` | 同一组日志级别 / 警告色抄了三份，各带手写 isDark 分支 → 统一读 `AppSemanticColors` |
 | `constants.dart:68-78` | 9 个零调用点的死令牌（`cardRadius` / `smallRadius` / `defaultPadding` / `opacityLow`…）→ 删除，几何统一到 `design_tokens.dart` |
+| `crop_resize_view.dart:447` | 输出条宣称副本存到 `临时工作区 / crop_photo.jpg`，实际写的是 `<temp>/joycai/processed/crop_photo_<时间戳>.png`——文件名、扩展名、目录三处都不符。→ 抽出 `ImageProcessingService.resolveCropCopyTarget()`，输出条 / 覆盖弹窗 / 实际写入共用同一个解析器，命名改为确定性的 `<name>_crop.png`（冲突时加数字后缀） |
+| `image_processing_service.dart` `saveImage()` | 裸 `writeAsBytes`，复制和覆盖走同一行、只差调用方拼出的路径字符串。→ 新增必填的 `allowOverwrite`，为 false 且目标已存在时抛异常。破坏性操作在 UI 与 service 两层都要拦 |
 
 ## 五、已知未做
 
@@ -65,7 +67,8 @@
 | 42 处裸 `TextField` 的手写 `InputDecoration` | `inputDecorationTheme` 已给出描边式基线，但调用点自己写了 `border:`/`filled:` 的会局部覆盖主题。逐个清掉是 25 个文件的机械改动，建议按屏单独推进 |
 | 身份色去重 | `usage_summary.dart` ↔ `pricing_group_manager.dart`（计费口径 5 色）、`models_screen.dart` ↔ `discovery_dialog.dart` ↔ `model_edit_dialog.dart`（模型类型 5 色）仍各自硬编码。它们是身份色不是语义色，应仿 `core/fee_group_palette.dart` 各抽一个调色板模块 |
 | `data_section.dart:319-407` ↔ `wizard_import.dart:97-187` | 近乎逐行重复，含各自的 `Colors.grey` |
-| 10c–10e 页面重排、10l 新弹窗、10j/10k 字段级重设计 | 见上 |
+| 10c–10e 页面重排、10j/10k 字段级重设计 | 见上 |
+| 覆盖原图写入 PNG 字节到 `.jpg` | `_runImageProcess` 恒用 `img.encodePng`（`image_processing_service.dart:73`），所以覆盖一个 `.jpg` 会把 PNG 字节写进 `.jpg` 文件——内容与扩展名不符。修法是按目标扩展名选编码器（并为 JPEG 定质量参数），属于保存行为变更，单独一轮 |
 | 分组小标题组件 | 目前只在组件全景图里表达，未抽成共享组件 |
 
 ## 验证方式

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -961,6 +961,8 @@
   "overwriteConfirmTitle": "Overwrite Original File?",
   "overwriteConfirmMessage": "This action will permanently replace the original file. Are you sure?",
   "overwriteConfirmSaveCopyInstead": "Save Copy Instead",
+  "overwriteConfirmSubtitle": "This action cannot be undone.",
+  "overwriteConfirmKeepOriginalHint": "To keep the original, use Save Copy instead.",
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -821,6 +821,8 @@
   "overwriteConfirmTitle": "元のファイルを上書きしますか？",
   "overwriteConfirmMessage": "この操作により、元のファイルが完全に置き換えられます。よろしいですか？",
   "overwriteConfirmSaveCopyInstead": "代わりにコピーを保存",
+  "overwriteConfirmSubtitle": "この操作は取り消せません",
+  "overwriteConfirmKeepOriginalHint": "元の画像を残す場合は「コピーを保存」をご利用ください。",
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3629,6 +3629,18 @@ abstract class AppLocalizations {
   /// **'Save Copy Instead'**
   String get overwriteConfirmSaveCopyInstead;
 
+  /// No description provided for @overwriteConfirmSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'This action cannot be undone.'**
+  String get overwriteConfirmSubtitle;
+
+  /// No description provided for @overwriteConfirmKeepOriginalHint.
+  ///
+  /// In en, this message translates to:
+  /// **'To keep the original, use Save Copy instead.'**
+  String get overwriteConfirmKeepOriginalHint;
+
   /// No description provided for @saveToTempSuccess.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1943,6 +1943,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get overwriteConfirmSaveCopyInstead => 'Save Copy Instead';
 
   @override
+  String get overwriteConfirmSubtitle => 'This action cannot be undone.';
+
+  @override
+  String get overwriteConfirmKeepOriginalHint =>
+      'To keep the original, use Save Copy instead.';
+
+  @override
   String get saveToTempSuccess => 'Image saved to temporary workspace';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1899,6 +1899,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get overwriteConfirmSaveCopyInstead => '代わりにコピーを保存';
 
   @override
+  String get overwriteConfirmSubtitle => 'この操作は取り消せません';
+
+  @override
+  String get overwriteConfirmKeepOriginalHint => '元の画像を残す場合は「コピーを保存」をご利用ください。';
+
+  @override
   String get saveToTempSuccess => '画像が一時ワークスペースに保存されました';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1885,6 +1885,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get overwriteConfirmSaveCopyInstead => '改为保存副本';
 
   @override
+  String get overwriteConfirmSubtitle => '此操作无法撤销';
+
+  @override
+  String get overwriteConfirmKeepOriginalHint => '如需保留原图，可改用「保存副本」。';
+
+  @override
   String get saveToTempSuccess => '已保存至临时工作区';
 
   @override
@@ -4326,6 +4332,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get overwriteConfirmSaveCopyInstead => '改為儲存副本';
+
+  @override
+  String get overwriteConfirmSubtitle => '此操作無法復原';
+
+  @override
+  String get overwriteConfirmKeepOriginalHint => '如需保留原圖，可改用「儲存副本」。';
 
   @override
   String get saveToTempSuccess => '圖片已儲存至臨時工作區';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -947,6 +947,8 @@
   "overwriteConfirmTitle": "确定覆盖原图？",
   "overwriteConfirmMessage": "此操作将永久修改原始文件，确定要继续吗？",
   "overwriteConfirmSaveCopyInstead": "改为保存副本",
+  "overwriteConfirmSubtitle": "此操作无法撤销",
+  "overwriteConfirmKeepOriginalHint": "如需保留原图，可改用「保存副本」。",
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -821,6 +821,8 @@
   "overwriteConfirmTitle": "覆蓋原始檔案？",
   "overwriteConfirmMessage": "此操作將永久替換原始檔案。您確定嗎？",
   "overwriteConfirmSaveCopyInstead": "改為儲存副本",
+  "overwriteConfirmSubtitle": "此操作無法復原",
+  "overwriteConfirmKeepOriginalHint": "如需保留原圖，可改用「儲存副本」。",
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -152,6 +152,8 @@
   "overwriteConfirmTitle": "Overwrite Original File?",
   "overwriteConfirmMessage": "This action will permanently replace the original file. Are you sure?",
   "overwriteConfirmSaveCopyInstead": "Save Copy Instead",
+  "overwriteConfirmSubtitle": "This action cannot be undone.",
+  "overwriteConfirmKeepOriginalHint": "To keep the original, use Save Copy instead.",
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -152,6 +152,8 @@
   "overwriteConfirmTitle": "元のファイルを上書きしますか？",
   "overwriteConfirmMessage": "この操作により、元のファイルが完全に置き換えられます。よろしいですか？",
   "overwriteConfirmSaveCopyInstead": "代わりにコピーを保存",
+  "overwriteConfirmSubtitle": "この操作は取り消せません",
+  "overwriteConfirmKeepOriginalHint": "元の画像を残す場合は「コピーを保存」をご利用ください。",
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -152,6 +152,8 @@
   "overwriteConfirmTitle": "确定覆盖原图？",
   "overwriteConfirmMessage": "此操作将永久修改原始文件，确定要继续吗？",
   "overwriteConfirmSaveCopyInstead": "改为保存副本",
+  "overwriteConfirmSubtitle": "此操作无法撤销",
+  "overwriteConfirmKeepOriginalHint": "如需保留原图，可改用「保存副本」。",
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -152,6 +152,8 @@
   "overwriteConfirmTitle": "覆蓋原始檔案？",
   "overwriteConfirmMessage": "此操作將永久替換原始檔案。您確定嗎？",
   "overwriteConfirmSaveCopyInstead": "改為儲存副本",
+  "overwriteConfirmSubtitle": "此操作無法復原",
+  "overwriteConfirmKeepOriginalHint": "如需保留原圖，可改用「儲存副本」。",
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",

--- a/lib/screens/workbench/widgets/crop_resize_toolbar.dart
+++ b/lib/screens/workbench/widgets/crop_resize_toolbar.dart
@@ -1,12 +1,9 @@
-import 'dart:io';
-
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
-import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 
-import '../../../core/app_paths.dart';
 import '../../../core/app_theme.dart';
+import '../../../core/design_tokens.dart';
 import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../models/app_image.dart';
@@ -210,6 +207,125 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
     uiState.setTargetDimensions(null, null);
   }
 
+  /// The last stop before an original is replaced.
+  ///
+  /// Three outcomes, not two: `true` overwrite, `false` save a copy instead,
+  /// `null` cancelled. The middle one is the point of the dialog — a confirm
+  /// that only offers "yes" and "no" leaves someone who wanted to keep the
+  /// original with nothing to do but start over, so the safe alternative is
+  /// offered here, in the moment they are thinking about it.
+  Future<bool?> _confirmOverwrite({
+    required AppLocalizations l10n,
+    required String fileName,
+    required String originalSize,
+    required String outputSize,
+    required String copyDestination,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final mono = textTheme.labelMedium?.copyWith(fontFamily: 'monospace');
+
+    return AppDialog.show<bool>(
+      context,
+      icon: Icons.warning_amber_rounded,
+      // Carries the whole dialog's mood: AppDialog tints the heading's icon
+      // plate from this, so naming the error colour here is what makes the
+      // plate red rather than the accent.
+      iconColor: colorScheme.error,
+      title: l10n.overwriteConfirmTitle,
+      subtitle: l10n.overwriteConfirmSubtitle,
+      maxWidth: 480,
+      onClose: () => Navigator.pop(context, null),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(l10n.overwriteConfirmMessage, style: textTheme.bodyMedium),
+          const SizedBox(height: 12),
+          // What is being replaced, and what it becomes. The old→new pair is
+          // the one fact that makes this decision answerable, so it gets a
+          // surface of its own instead of a line of body text.
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerHigh,
+              borderRadius: BorderRadius.circular(AppRadius.md),
+              border: Border.all(color: colorScheme.outlineVariant),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.image_outlined, size: 18, color: colorScheme.onSurfaceVariant),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    fileName,
+                    style: mono,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Text(originalSize, style: mono?.copyWith(color: colorScheme.onSurfaceVariant)),
+                const SizedBox(width: 7),
+                Icon(Icons.arrow_forward, size: 14, color: colorScheme.onSurfaceVariant),
+                const SizedBox(width: 7),
+                Text(
+                  outputSize,
+                  // The new dimensions in the error colour: this number is the
+                  // irreversible part, and it is what someone scanning the
+                  // dialog should land on.
+                  style: mono?.copyWith(color: colorScheme.error, fontWeight: FontWeight.w600),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+            decoration: BoxDecoration(
+              color: colorScheme.accentTint,
+              borderRadius: BorderRadius.circular(AppRadius.md),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.info_outline, size: 16, color: colorScheme.onAccentTint),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    '${l10n.overwriteConfirmKeepOriginalHint}'
+                    '${l10n.cropResizeWillSaveTo(copyDestination)}',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onAccentTint,
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        AppButton(
+          label: l10n.cancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.pop(context, null),
+        ),
+        AppButton(
+          label: l10n.overwriteConfirmSaveCopyInstead,
+          variant: AppButtonVariant.secondary,
+          onPressed: () => Navigator.pop(context, false),
+        ),
+        AppButton(
+          label: l10n.overwriteSource,
+          variant: AppButtonVariant.destructive,
+          onPressed: () => Navigator.pop(context, true),
+        ),
+      ],
+    );
+  }
+
   Future<void> _handleSave({bool overwrite = false}) async {
     final l10n = AppLocalizations.of(context)!;
     final uiState = Provider.of<WorkbenchUIState>(context, listen: false);
@@ -231,55 +347,19 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
 
     if (overwrite) {
       final originalMeta = await ImageMetadataService().getMetadata(sourceImage.path);
+      // Resolved, not guessed: the hint below names the file the copy would
+      // become, so it asks the same resolver the save will use.
+      final copyTarget = await ImageProcessingService().resolveCropCopyTarget(sourceImage.path);
       if (!mounted) return;
 
-      final colorScheme = Theme.of(context).colorScheme;
-      final originalSize =
-          originalMeta != null ? '${originalMeta.width}×${originalMeta.height}' : '–';
-
-      // true = overwrite, false = save a copy instead, null = cancelled.
-      final confirmed = await AppDialog.show<bool>(
-        context,
-        title: l10n.overwriteConfirmTitle,
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(l10n.overwriteConfirmMessage),
-            const SizedBox(height: 14),
-            Text(
-              sourceImage.name,
-              style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600),
-              overflow: TextOverflow.ellipsis,
-              maxLines: 1,
-            ),
-            const SizedBox(height: 3),
-            Text(
-              '$originalSize → $outputWidth×$outputHeight',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    fontFamily: 'monospace',
-                    color: colorScheme.onSurfaceVariant,
-                  ),
-            ),
-          ],
-        ),
-        actions: [
-          AppButton(
-            label: l10n.cancel,
-            variant: AppButtonVariant.text,
-            onPressed: () => Navigator.pop(context, null),
-          ),
-          AppButton(
-            label: l10n.overwriteConfirmSaveCopyInstead,
-            variant: AppButtonVariant.secondary,
-            onPressed: () => Navigator.pop(context, false),
-          ),
-          AppButton(
-            label: l10n.overwriteSource,
-            variant: AppButtonVariant.destructive,
-            onPressed: () => Navigator.pop(context, true),
-          ),
-        ],
+      final confirmed = await _confirmOverwrite(
+        l10n: l10n,
+        fileName: sourceImage.name,
+        originalSize:
+            originalMeta != null ? '${originalMeta.width}×${originalMeta.height}' : '–',
+        outputSize: '$outputWidth×$outputHeight',
+        copyDestination:
+            '${l10n.cropResizeTempWorkspaceLabel} / ${copyTarget.fileName}',
       );
 
       if (confirmed == null) return;
@@ -317,16 +397,20 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
         targetPath = sourceImage.path;
         targetName = sourceImage.name;
       } else {
-        final tempDir = await AppPaths.getTempDirectory();
-        final outputDir = Directory(p.join(tempDir, 'joycai', 'processed'));
-        if (!outputDir.existsSync()) outputDir.createSync(recursive: true);
-        
-        final timestamp = DateTime.now().millisecondsSinceEpoch;
-        targetName = 'crop_${p.basenameWithoutExtension(sourceImage.path)}_$timestamp.png';
-        targetPath = p.join(outputDir.path, targetName);
+        final target = await ImageProcessingService().resolveCropCopyTarget(sourceImage.path);
+        target.ensureExists();
+        targetName = target.fileName;
+        targetPath = target.path;
       }
 
-      await ImageProcessingService().saveImage(bytes: processedBytes, targetPath: targetPath);
+      await ImageProcessingService().saveImage(
+        bytes: processedBytes,
+        targetPath: targetPath,
+        // The dialog above is the only thing that can produce `overwrite:
+        // true`, so this is where the user's answer reaches the file system.
+        // The service refuses to clobber anything without it.
+        allowOverwrite: overwrite,
+      );
 
       final successMessage = overwrite ? l10n.overwriteSuccess : l10n.saveToTempSuccess;
 

--- a/lib/screens/workbench/widgets/crop_resize_view.dart
+++ b/lib/screens/workbench/widgets/crop_resize_view.dart
@@ -5,9 +5,9 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../../core/app_paths.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/image_metadata_service.dart';
+import '../../../services/image_processing_service.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
 import '../../../widgets/app_button.dart';
@@ -40,7 +40,15 @@ class _CropResizeViewState extends State<CropResizeView> {
 
   ImageMetadata? _meta;
   String? _metaPath;
-  String? _tempWorkspaceDir;
+  /// The name "save a copy" would actually write, resolved rather than
+  /// guessed.
+  ///
+  /// This strip used to build the name itself, and got it wrong three ways at
+  /// once — it printed `crop_photo.jpg` where the save produced
+  /// `<temp>/joycai/processed/crop_photo_1754899200000.png`. It now asks the
+  /// same resolver the save calls, so the strip and the overwrite dialog and
+  /// the file on disk cannot disagree.
+  String? _copyFileName;
 
   /// Wraps the editor so the zoom pill can find its render box and simulate
   /// a mouse-wheel event at its center — extended_image's editor doesn't
@@ -48,19 +56,16 @@ class _CropResizeViewState extends State<CropResizeView> {
   /// takes, so the +/- buttons replay that same path instead of a click.
   final GlobalKey _canvasKey = GlobalKey();
 
-  @override
-  void initState() {
-    super.initState();
-    AppPaths.getTempDirectory().then((dir) {
-      if (mounted) setState(() => _tempWorkspaceDir = dir);
-    });
-  }
-
   void _loadMeta(String path) {
     if (_metaPath == path) return;
     _metaPath = path;
     ImageMetadataService().getMetadata(path).then((meta) {
       if (mounted && _metaPath == path) setState(() => _meta = meta);
+    });
+    // Rides on the same path-changed guard as the metadata: the copy's name is
+    // derived from this path and has to be re-resolved whenever it changes.
+    ImageProcessingService().resolveCropCopyTarget(path).then((target) {
+      if (mounted && _metaPath == path) setState(() => _copyFileName = target.fileName);
     });
   }
 
@@ -120,8 +125,7 @@ class _CropResizeViewState extends State<CropResizeView> {
             targetWidth: null,
             targetHeight: null,
             samplingMethod: uiState.samplingMethod,
-            tempWorkspaceDir: null,
-            sourceName: null,
+            copyFileName: null,
             l10n: l10n,
             colorScheme: colorScheme,
           ),
@@ -190,8 +194,7 @@ class _CropResizeViewState extends State<CropResizeView> {
           targetWidth: uiState.targetWidth,
           targetHeight: uiState.targetHeight,
           samplingMethod: uiState.samplingMethod,
-          tempWorkspaceDir: _tempWorkspaceDir,
-          sourceName: sourceImage.name,
+          copyFileName: _copyFileName,
           l10n: l10n,
           colorScheme: colorScheme,
         ),
@@ -411,8 +414,8 @@ class _OutputPreviewBar extends StatelessWidget {
   final int? targetWidth;
   final int? targetHeight;
   final String samplingMethod;
-  final String? tempWorkspaceDir;
-  final String? sourceName;
+  /// Resolved by the parent from ImageProcessingService, never derived here.
+  final String? copyFileName;
   final AppLocalizations l10n;
   final ColorScheme colorScheme;
 
@@ -422,8 +425,7 @@ class _OutputPreviewBar extends StatelessWidget {
     required this.targetWidth,
     required this.targetHeight,
     required this.samplingMethod,
-    required this.tempWorkspaceDir,
-    required this.sourceName,
+    required this.copyFileName,
     required this.l10n,
     required this.colorScheme,
   });
@@ -443,10 +445,9 @@ class _OutputPreviewBar extends StatelessWidget {
     final operation = isScaling ? l10n.cropResizeCropAndScale(percent) : l10n.cropResizeCropOnly;
     final samplingLabel = _kSamplingLabels[samplingMethod] ?? samplingMethod;
 
-    final name = sourceName;
-    final destination = (name == null || tempWorkspaceDir == null)
+    final destination = copyFileName == null
         ? null
-        : '${l10n.cropResizeTempWorkspaceLabel} / crop_${_baseName(name)}${_extension(name)}';
+        : '${l10n.cropResizeTempWorkspaceLabel} / $copyFileName';
 
     final textTheme = Theme.of(context).textTheme;
     final labelStyle = textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant);
@@ -487,13 +488,4 @@ class _OutputPreviewBar extends StatelessWidget {
     );
   }
 
-  String _baseName(String name) {
-    final dot = name.lastIndexOf('.');
-    return dot > 0 ? name.substring(0, dot) : name;
-  }
-
-  String _extension(String name) {
-    final dot = name.lastIndexOf('.');
-    return dot > 0 ? name.substring(dot) : '';
-  }
 }

--- a/lib/services/image_processing_service.dart
+++ b/lib/services/image_processing_service.dart
@@ -2,6 +2,9 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+
+import '../core/app_paths.dart';
 
 enum SamplingMethod {
   nearest,
@@ -103,11 +106,77 @@ class ImageProcessingService {
     return await compute(_runImageProcess, params);
   }
 
+  /// Writes [bytes] to [targetPath].
+  ///
+  /// [allowOverwrite] is required and has no default on purpose. Replacing a
+  /// file the user already has is the destructive half of this method, and the
+  /// only thing standing between the two behaviours used to be whichever path
+  /// string the caller happened to build — a copy and an overwrite went down
+  /// the same line. A call site now has to state which one it means, and a new
+  /// one cannot silently inherit the destructive reading.
+  ///
+  /// The check lives here rather than only in the dialog that asks the user,
+  /// because a UI guard protects the one path that goes through that UI. This
+  /// protects the file.
   Future<void> saveImage({
     required Uint8List bytes,
     required String targetPath,
+    required bool allowOverwrite,
   }) async {
     final file = File(targetPath);
+
+    if (!allowOverwrite && await file.exists()) {
+      throw FileSystemException(
+        'Refusing to overwrite an existing file: pass allowOverwrite to replace it',
+        targetPath,
+      );
+    }
+
     await file.writeAsBytes(bytes);
+  }
+
+  /// Where a "save a copy" from the crop/resize editor lands, resolved against
+  /// what is actually on disk.
+  ///
+  /// One resolver for three readers — the editor's output strip, the overwrite
+  /// dialog's "save a copy instead" hint, and the save itself. They used to
+  /// derive it separately and disagree: the strip advertised
+  /// `Temporary Workspace / crop_photo.jpg` while the write produced
+  /// `<temp>/joycai/processed/crop_photo_1754899200000.png` — a different
+  /// name, a different extension and a folder it never mentioned. A dialog
+  /// that names the file it is about to write has to be right about it, so
+  /// there is now one place to be right in.
+  ///
+  /// The name is deterministic (`<base>_crop.png`) rather than
+  /// timestamp-stamped, because a name nobody can predict cannot be shown to
+  /// anyone before the fact. Collisions take a numeric suffix instead.
+  Future<CropCopyTarget> resolveCropCopyTarget(String sourcePath) async {
+    final tempDir = await AppPaths.getTempDirectory();
+    final directory = Directory(p.join(tempDir, 'joycai', 'processed'));
+
+    final base = p.basenameWithoutExtension(sourcePath);
+    // Always .png: `_runImageProcess` encodes PNG regardless of the source
+    // format, so this is the extension the bytes will actually be.
+    var name = '${base}_crop.png';
+    for (var n = 2; File(p.join(directory.path, name)).existsSync(); n++) {
+      name = '${base}_crop_$n.png';
+    }
+
+    return CropCopyTarget(directory: directory, fileName: name);
+  }
+}
+
+/// The resolved destination of a crop/resize copy.
+class CropCopyTarget {
+  /// May not exist yet — [ensureExists] creates it.
+  final Directory directory;
+  final String fileName;
+
+  const CropCopyTarget({required this.directory, required this.fileName});
+
+  String get path => p.join(directory.path, fileName);
+
+  void ensureExists() {
+    if (!directory.existsSync()) directory.createSync(recursive: true);
   }
 }

--- a/test/screenshots/component_gallery_test.dart
+++ b/test/screenshots/component_gallery_test.dart
@@ -20,8 +20,10 @@ import 'package:joycai_image_ai_toolkits/core/app_semantic_colors.dart';
 import 'package:joycai_image_ai_toolkits/core/app_theme.dart';
 import 'package:joycai_image_ai_toolkits/core/constants.dart';
 import 'package:joycai_image_ai_toolkits/core/design_tokens.dart';
+import 'package:joycai_image_ai_toolkits/l10n/app_localizations.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_button.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_card.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_dialog.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_icon_button.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_segmented_control.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_status_badge.dart';
@@ -31,12 +33,18 @@ void main() {
   for (final MapEntry<String, Color> seed in AppConstants.presetThemes.entries) {
     for (final Brightness brightness in Brightness.values) {
       testWidgets('gallery · ${seed.key} · ${brightness.name}', (tester) async {
-        tester.view.physicalSize = const Size(720, 900);
+        tester.view.physicalSize = const Size(720, 1080);
         tester.view.devicePixelRatio = 1.0;
         addTearDown(tester.view.reset);
 
         await tester.pumpWidget(MaterialApp(
           debugShowCheckedModeBanner: false,
+          // Not optional: AppDialog's close button reads its tooltip from
+          // AppLocalizations, so a MaterialApp without the delegates throws
+          // rather than degrading. The real app always has them.
+          locale: const Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           // The font the app actually runs with. Without it the theme falls
           // back to Roboto, which has no CJK — every label in this gallery
           // photographs as a row of tofu boxes.
@@ -164,6 +172,24 @@ class _Gallery extends StatelessWidget {
               ]),
               const _Label('语义色 · 七个种子色下应完全一致'),
               const _SemanticRow(),
+              const _Label('对话框外壳 · 危险动作'),
+              // The chrome only, not any one dialog's body: the icon plate
+              // takes its tint from `iconColor`, so this is also the check
+              // that a destructive dialog comes out red at every seed rather
+              // than in the user's accent.
+              AppDialog(
+                icon: Icons.warning_amber_rounded,
+                iconColor: colorScheme.error,
+                title: '覆盖原图？',
+                subtitle: '此操作无法撤销',
+                maxWidth: 460,
+                onClose: () {},
+                content: const Text('原始文件将被裁剪结果永久替换。'),
+                actions: [
+                  AppButton(label: '取消', variant: AppButtonVariant.text, onPressed: () {}),
+                  AppButton(label: '覆盖原图', variant: AppButtonVariant.destructive, onPressed: () {}),
+                ],
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
接 #74 / #75，做设计稿 **10l 覆盖原图确认**。

## 先更正一处审计错误

**这个弹窗早就存在**（`crop_resize_toolbar.dart` 的 `_handleSave`，三个出口：覆盖 / 改存副本 / 取消）。上一版审计报告照搬了设计稿的「新增」标注、没查代码，是错的。本 PR 一并改正了那一行。

所以这是**重做外观**，不是新建功能。

## 弹窗

按 10l 补齐：

- **危险色图标底板**、副标题、关闭按钮、头尾分隔线 —— 全部用 `AppDialog` 已有参数。`iconColor: colorScheme.error` 是让底板变红而不是主题色的关键，已在 Orange 种子色下验证。
- **文件行**独立成一块带边框的面板，写 `1568×2712 → 1200×900`，新尺寸用 `error` 色加粗 —— 这一对数字是让这个决定可回答的唯一事实，不该只是正文里的一行。
- **信息框**报出「改存副本」会写成什么文件。

## 副本命名 —— 被弹窗逼出来的修复

信息框必须报一个文件名，而现有的那个是错的：输出条宣称 `临时工作区 / crop_photo.jpg`，实际写的是 `<temp>/joycai/processed/crop_photo_1754899200000.png` —— 文件名、扩展名、目录三处全不符。

与其在第二个地方把这个谎再说一遍，不如把推导收进 `ImageProcessingService.resolveCropCopyTarget()`，**输出条 / 弹窗 / 实际写入共用它**。

命名从带时间戳改为确定性的 `<base>_crop.png`（冲突时加数字后缀）——**带时间戳的名字没人能提前预告，本质上无法诚实展示。**

## service 层拦截

`saveImage` 新增**必填**的 `allowOverwrite`。刻意不给默认值：复制和覆盖以前走同一句 `writeAsBytes`，唯一的区别是调用方拼出来的路径字符串。现在调用点必须表态，以后新增的调用点也不会默认继承破坏性语义。

> 弹窗保护的是走弹窗的那条路径；这一层保护的是文件本身。

## 审阅要点

- **`saveImage` 的签名是破坏性变更**，但全仓库只有一个调用点（`crop_resize_toolbar.dart`），已改。
- 命名规则变了：以后副本是 `photo_crop.png` 而不是 `crop_photo_1754899200000.png`。**同名冲突时会加 `_2`、`_3` 后缀**，不再靠时间戳去重。
- `_OutputPreviewBar` 的 `tempWorkspaceDir` / `sourceName` 两个参数被 `copyFileName` 取代（前两个只是用来自行拼名字的，现在没有必要了）。
- 组件全景图新增对话框外壳一节。顺带发现 **`AppDialog` 的关闭按钮会在没挂 localization delegates 的 `MaterialApp` 上直接抛异常**（tooltip 走 `AppLocalizations.of(context)!`），全景图已按真实 App 挂上 delegates。
- 两个新 l10n key，四语言齐全。

## 没做

**覆盖 `.jpg` 仍会写入 PNG 字节** —— `_runImageProcess` 恒用 `img.encodePng`（`image_processing_service.dart:73`），所以覆盖一个 JPEG 会得到「内容是 PNG、扩展名是 .jpg」的文件。修法是按目标扩展名选编码器并定 JPEG 质量参数，属于保存行为变更，已记入审计的「已知未做」，留给单独一轮。

## 验证

```bash
flutter analyze     # No issues found!
flutter test        # 478 passed
flutter test test/screenshots/component_gallery_test.dart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
