### PR TITLE
refactor(core): 身份色去重，各归一个调色板模块

### DIFF
--- a/docs/reports/design-spec-audit.md
+++ b/docs/reports/design-spec-audit.md
@@ -57,6 +57,9 @@
 | `main.dart:391` | `Color(0xFFB794F6)` 固定紫与 `colorScheme.primary` 组渐变，与 7 个种子色中的 6 个打架 → `primaryContainer` |
 | `log_console.dart` ↔ `task_log_dialog.dart` ↔ `app_snackbar.dart` | 同一组日志级别 / 警告色抄了三份，各带手写 isDark 分支 → 统一读 `AppSemanticColors` |
 | `constants.dart:68-78` | 9 个零调用点的死令牌（`cardRadius` / `smallRadius` / `defaultPadding` / `opacityLow`…）→ 删除，几何统一到 `design_tokens.dart` |
+| 计费口径 5 色 | `usage_summary.dart` 声明为公开常量、注释写着「与费率组价格药丸共用」，`pricing_group_manager.dart` 却又**私有地重抄了 4 个**、注释写着「刻意用与用量页相同的色」——共用的意图一直都在，只是被复制而非导入。→ 抽出 `core/metric_palette.dart` |
+| 模型类型 5 色 | `models_screen.dart` 与 `discovery_dialog.dart` 各有一份**逐字节相同**的 `switch`，`model_edit_dialog.dart` 第三份写成元组表。→ 抽出 `core/model_kind_palette.dart` |
+| `settings_screen.dart` | 已有 `_categoryColor()`，但移动端列表把同样的 5 个色值又内联写了一遍，绕过了那个函数。→ 由 `_buildCategoryTile` 内部统一取色 |
 | `crop_resize_view.dart:447` | 输出条宣称副本存到 `临时工作区 / crop_photo.jpg`，实际写的是 `<temp>/joycai/processed/crop_photo_<时间戳>.png`——文件名、扩展名、目录三处都不符。→ 抽出 `ImageProcessingService.resolveCropCopyTarget()`，输出条 / 覆盖弹窗 / 实际写入共用同一个解析器，命名改为确定性的 `<name>_crop.png`（冲突时加数字后缀） |
 | `image_processing_service.dart` `saveImage()` | 裸 `writeAsBytes`，复制和覆盖走同一行、只差调用方拼出的路径字符串。→ 新增必填的 `allowOverwrite`，为 false 且目标已存在时抛异常。破坏性操作在 UI 与 service 两层都要拦 |
 
@@ -65,7 +68,7 @@
 | 项 | 说明 |
 |---|---|
 | 42 处裸 `TextField` 的手写 `InputDecoration` | `inputDecorationTheme` 已给出描边式基线，但调用点自己写了 `border:`/`filled:` 的会局部覆盖主题。逐个清掉是 25 个文件的机械改动，建议按屏单独推进 |
-| 身份色去重 | `usage_summary.dart` ↔ `pricing_group_manager.dart`（计费口径 5 色）、`models_screen.dart` ↔ `discovery_dialog.dart` ↔ `model_edit_dialog.dart`（模型类型 5 色）仍各自硬编码。它们是身份色不是语义色，应仿 `core/fee_group_palette.dart` 各抽一个调色板模块 |
+| 模型类型 chip 组件本身 | `models_screen.dart` 与 `discovery_dialog.dart` 的 `_buildTagChip` 现在共用颜色，但**两个容器仍是各写各的**（圆角 8 + 描边 vs 圆角 6 无描边）。抽成一个共享组件会带来观感变化，本轮只做了颜色去重 |
 | `data_section.dart:319-407` ↔ `wizard_import.dart:97-187` | 近乎逐行重复，含各自的 `Colors.grey` |
 | 10c–10e 页面重排、10j/10k 字段级重设计 | 见上 |
 | 覆盖原图写入 PNG 字节到 `.jpg` | `_runImageProcess` 恒用 `img.encodePng`（`image_processing_service.dart:73`），所以覆盖一个 `.jpg` 会把 PNG 字节写进 `.jpg` 文件——内容与扩展名不符。修法是按目标扩展名选编码器（并为 JPEG 定质量参数），属于保存行为变更，单独一轮 |

--- a/lib/core/metric_palette.dart
+++ b/lib/core/metric_palette.dart
@@ -1,0 +1,27 @@
+/// Identity colours for the five things the usage screens count.
+///
+/// Each hue names one metric and follows it everywhere it appears: a rate in
+/// the fee-group editor, a token count in the usage summary, and a chip in the
+/// record list are the same colour because they are the same quantity. That is
+/// the colour's whole job — it says "input tokens", not "good" or "a lot".
+///
+/// Which is why these are literals rather than roles on the [ColorScheme]:
+/// following the user's seed would make input and output the same hue under
+/// every theme, and the distinction is the entire point. For the same reason
+/// they are not in `AppSemanticColors` — success/warning/info state a
+/// *condition*, these name a *category*. See `core/fee_group_palette.dart`,
+/// which is the same idea for fee groups and deliberately avoids these hues.
+///
+/// Material swatches rather than hand-picked hex, unlike the fee-group
+/// palette: these were already `Colors.blue`/`teal`/… at both of the call
+/// sites this file replaced, and re-picking them here would have been a
+/// silent visual change smuggled into a de-duplication.
+library;
+
+import 'package:flutter/material.dart';
+
+const Color usageInputAccent = Colors.blue;
+const Color usageCacheAccent = Colors.teal;
+const Color usageOutputAccent = Colors.green;
+const Color usageRequestAccent = Colors.purple;
+const Color usageCostAccent = Colors.orange;

--- a/lib/core/model_kind_palette.dart
+++ b/lib/core/model_kind_palette.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import 'constants.dart';
+
+/// Identity colours for what a model *is* — chat, image, video, multimodal.
+///
+/// A kind's hue follows it across the models screen's chips, the discovery
+/// dialog's list and the type picker in the model editor, so a user scanning
+/// a long list can find every video model without reading a word. Like
+/// `core/fee_group_palette.dart` and `core/metric_palette.dart`, these name a
+/// category rather than state a condition, which is why they are literals and
+/// not roles on the [ColorScheme]: seeded hues would collapse four categories
+/// into four shades of one colour.
+///
+/// This existed three times before — as two byte-identical `switch` statements
+/// in `models_screen.dart` and `discovery_dialog.dart`, and again as a tuple
+/// list in `model_edit_dialog.dart`. They happened to agree; nothing made them.
+
+/// The colour belonging to [tag], matched against [ModelTag]'s string values.
+///
+/// Falls back to blue for anything unrecognised, which is also where
+/// [ModelTag.refiner] lands. That is inherited rather than chosen — all three
+/// of the original copies omitted refiner too — so a refiner model shows the
+/// same neutral blue as an unknown tag. Worth giving its own hue if refiners
+/// ever need to be picked out of a list; noted rather than done here, because
+/// this file is a de-duplication and inventing a colour is not.
+Color modelTagAccent(String tag) {
+  switch (tag.toLowerCase()) {
+    case 'image':
+      return Colors.purple;
+    case 'video':
+      return Colors.red;
+    case 'multimodal':
+      return Colors.orange;
+    case 'chat':
+      return Colors.green;
+    default:
+      return Colors.blue;
+  }
+}

--- a/lib/screens/metrics/widgets/usage_list.dart
+++ b/lib/screens/metrics/widgets/usage_list.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../../core/metric_palette.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/database_service.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
 import 'usage_stats.dart';
-import 'usage_summary.dart';
 
 /// Table of token-usage records, grouped by day. Meant to be hosted in a card
 /// inside a scroll view — it lays every row out at once rather than scrolling

--- a/lib/screens/metrics/widgets/usage_summary.dart
+++ b/lib/screens/metrics/widgets/usage_summary.dart
@@ -1,17 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../../../core/metric_palette.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../widgets/panel_resizer.dart';
 import 'usage_stats.dart';
-
-/// Accent per metric. Shared with the fee-group price pills and the record
-/// list, so a rate, a token count and a cost keep one colour across the app.
-const Color usageInputAccent = Colors.blue;
-const Color usageCacheAccent = Colors.teal;
-const Color usageOutputAccent = Colors.green;
-const Color usageRequestAccent = Colors.purple;
-const Color usageCostAccent = Colors.orange;
 
 /// The summary block above the usage records, shared by every breakpoint.
 ///

--- a/lib/screens/models/models_screen.dart
+++ b/lib/screens/models/models_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../core/app_theme.dart';
+import '../../core/model_kind_palette.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/llm_channel.dart';
@@ -606,8 +607,12 @@ class _ModelsScreenState extends State<ModelsScreen> {
               },
             ),
             ListTile(
-              leading: const Icon(Icons.delete_outline, color: Colors.red),
-              title: Text(l10n.delete, style: const TextStyle(color: Colors.red)),
+              // `error`, not a red literal: destructive is a semantic role and
+              // Material derives it independently of the seed, so this stays
+              // red at every theme without being written as one.
+              leading: Icon(Icons.delete_outline, color: Theme.of(context).colorScheme.error),
+              title: Text(l10n.delete,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error)),
               onTap: () {
                 Navigator.pop(context);
                 _confirmDeleteModel(l10n, model, appState);
@@ -620,14 +625,7 @@ class _ModelsScreenState extends State<ModelsScreen> {
   }
 
   Widget _buildTagChip(String tag) {
-    Color color;
-    switch (tag.toLowerCase()) {
-      case 'image': color = Colors.purple; break;
-      case 'video': color = Colors.red; break;
-      case 'multimodal': color = Colors.orange; break;
-      case 'chat': color = Colors.green; break;
-      default: color = Colors.blue;
-    }
+    final color = modelTagAccent(tag);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       decoration: BoxDecoration(

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -87,11 +87,14 @@ class _SettingsMobileView extends StatelessWidget {
           SliverAppBar.large(title: Text(l10n.settings)),
           SliverList(
             delegate: SliverChildListDelegate([
-              _buildCategoryTile(context, SettingsCategory.appearance, Icons.palette_outlined, l10n.appearance, Colors.blue),
-              _buildCategoryTile(context, SettingsCategory.connectivity, Icons.lan_outlined, l10n.connectivity, Colors.green),
-              _buildCategoryTile(context, SettingsCategory.application, Icons.settings_applications_outlined, l10n.application, Colors.orange),
-              _buildCategoryTile(context, SettingsCategory.data, Icons.storage_outlined, l10n.dataManagement, Colors.purple),
-              _buildCategoryTile(context, SettingsCategory.about, Icons.info_outline, l10n.about, Colors.teal),
+              // Colours come from _categoryColor, not repeated here: this list
+              // used to restate all five inline, so the desktop rail and the
+              // mobile list were two independent copies of the same mapping.
+              _buildCategoryTile(context, SettingsCategory.appearance, Icons.palette_outlined, l10n.appearance),
+              _buildCategoryTile(context, SettingsCategory.connectivity, Icons.lan_outlined, l10n.connectivity),
+              _buildCategoryTile(context, SettingsCategory.application, Icons.settings_applications_outlined, l10n.application),
+              _buildCategoryTile(context, SettingsCategory.data, Icons.storage_outlined, l10n.dataManagement),
+              _buildCategoryTile(context, SettingsCategory.about, Icons.info_outline, l10n.about),
             ]),
           ),
         ],
@@ -99,7 +102,8 @@ class _SettingsMobileView extends StatelessWidget {
     );
   }
 
-  Widget _buildCategoryTile(BuildContext context, SettingsCategory category, IconData icon, String label, Color color) {
+  Widget _buildCategoryTile(BuildContext context, SettingsCategory category, IconData icon, String label) {
+    final color = _categoryColor(category);
     return ListTile(
       leading: Container(
         padding: const EdgeInsets.all(8),

--- a/lib/widgets/models/discovery_dialog.dart
+++ b/lib/widgets/models/discovery_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/app_semantic_colors.dart';
+import '../../core/model_kind_palette.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/llm_channel.dart';
@@ -306,9 +308,12 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
                   },
                 )
               else
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 12),
-                  child: Icon(Icons.check_circle, color: Colors.green, size: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  // Success is a condition, not a category — it comes from the
+                  // semantic set rather than from this file's own green.
+                  child: Icon(Icons.check_circle,
+                      color: context.semantic.success, size: 20),
                 ),
               const SizedBox(width: 8),
               Expanded(
@@ -334,14 +339,7 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
   }
 
   Widget _buildTagChip(String tag) {
-    Color color;
-    switch (tag.toLowerCase()) {
-      case 'image': color = Colors.purple; break;
-      case 'video': color = Colors.red; break;
-      case 'multimodal': color = Colors.orange; break;
-      case 'chat': color = Colors.green; break;
-      default: color = Colors.blue;
-    }
+    final color = modelTagAccent(tag);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       decoration: BoxDecoration(

--- a/lib/widgets/models/model_edit_dialog.dart
+++ b/lib/widgets/models/model_edit_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/model_kind_palette.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/llm_model.dart';
@@ -46,12 +47,44 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
   late ContextWindowMode contextMode;
   late double contextSizeIdx;
 
-  /// Tag palette mirrors the chips on the models screen.
-  static const List<(String, String, Color)> _tagOptions = [
-    ('chat', 'Chat', Colors.green),
-    ('image', 'Image', Colors.purple),
-    ('video', 'Video', Colors.red),
-    ('multimodal', 'Multimodal', Colors.orange),
+  /// One kind chip. A method rather than an inline `ChoiceChip` in the
+  /// collection-for because the kind's colour has to be looked up once and
+  /// then used five times over — inline, that is five `modelTagAccent` calls
+  /// per chip per build, or a local the collection-for has nowhere to put.
+  Widget _buildTagChoice(
+    String value,
+    String label,
+    TextTheme textTheme,
+    ColorScheme colorScheme,
+  ) {
+    final color = modelTagAccent(value);
+    final selected = tag == value;
+
+    return ChoiceChip(
+      selected: selected,
+      onSelected: (_) => setState(() => tag = value),
+      label: Text(label),
+      labelStyle: textTheme.bodySmall?.copyWith(
+        fontWeight: FontWeight.w600,
+        color: selected ? color : colorScheme.onSurfaceVariant,
+      ),
+      avatar: CircleAvatar(backgroundColor: color, radius: 4),
+      selectedColor: color.withAlpha(30),
+      side: BorderSide(
+        color: selected ? color.withAlpha(150) : colorScheme.outlineVariant,
+      ),
+      showCheckmark: false,
+    );
+  }
+
+  /// The selectable model kinds, in the order they are offered. Colours are
+  /// not repeated here — [modelTagAccent] is the one place they live, so this
+  /// picker cannot drift away from the chips it is choosing between.
+  static const List<(String, String)> _tagOptions = [
+    ('chat', 'Chat'),
+    ('image', 'Image'),
+    ('video', 'Video'),
+    ('multimodal', 'Multimodal'),
   ];
 
   @override
@@ -260,22 +293,8 @@ class _ModelEditDialogState extends State<ModelEditDialog> {
           spacing: 8,
           runSpacing: 8,
           children: [
-            for (final (value, label, color) in _tagOptions)
-              ChoiceChip(
-                selected: tag == value,
-                onSelected: (_) => setState(() => tag = value),
-                label: Text(label),
-                labelStyle: textTheme.bodySmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: tag == value ? color : colorScheme.onSurfaceVariant,
-                ),
-                avatar: CircleAvatar(backgroundColor: color, radius: 4),
-                selectedColor: color.withAlpha(30),
-                side: BorderSide(
-                  color: tag == value ? color.withAlpha(150) : colorScheme.outlineVariant,
-                ),
-                showCheckmark: false,
-              ),
+            for (final (value, label) in _tagOptions)
+              _buildTagChoice(value, label, textTheme, colorScheme),
           ],
         ),
 

--- a/lib/widgets/pricing_group_manager.dart
+++ b/lib/widgets/pricing_group_manager.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../core/fee_group_palette.dart';
+import '../core/metric_palette.dart';
 import '../core/responsive.dart';
 import '../l10n/app_localizations.dart';
 import '../models/pricing_group.dart';
@@ -15,15 +16,6 @@ enum PricingGroupManagerMode {
   section,
   fullPage
 }
-
-/// Accent colors for the three token price kinds, used by the editor's price
-/// fields. Deliberately the same hues the usage screens use for their input /
-/// cache / output stats, so a rate here and a token count there read as the
-/// same thing.
-const Color _inputAccent = Colors.blue;
-const Color _cacheAccent = Colors.teal;
-const Color _outputAccent = Colors.green;
-const Color _requestAccent = Colors.purple;
 
 /// Narrowest a group card gets before its name starts truncating.
 const double _minCardWidth = 320;
@@ -848,9 +840,9 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Expanded(child: _buildPriceField(inputPriceCtrl, l10n.priceLabelInput, '\$/M', _inputAccent, Icons.input)),
+              Expanded(child: _buildPriceField(inputPriceCtrl, l10n.priceLabelInput, '\$/M', usageInputAccent, Icons.input)),
               const SizedBox(width: 12),
-              Expanded(child: _buildPriceField(outputPriceCtrl, l10n.priceLabelOutput, '\$/M', _outputAccent, Icons.output)),
+              Expanded(child: _buildPriceField(outputPriceCtrl, l10n.priceLabelOutput, '\$/M', usageOutputAccent, Icons.output)),
             ],
           ),
           const SizedBox(height: 16),
@@ -860,13 +852,13 @@ class _PricingGroupEditorState extends State<_PricingGroupEditor> {
             cacheInputPriceCtrl,
             l10n.priceLabelCache,
             '\$/M',
-            _cacheAccent,
+            usageCacheAccent,
             Icons.bolt,
             hintText: inputPriceCtrl.text.trim().isEmpty ? null : inputPriceCtrl.text.trim(),
             helperText: l10n.cacheInputPriceHint,
           ),
         ] else
-          _buildPriceField(requestPriceCtrl, l10n.priceLabelRequest, '\$/Req', _requestAccent, Icons.repeat),
+          _buildPriceField(requestPriceCtrl, l10n.priceLabelRequest, '\$/Req', usageRequestAccent, Icons.repeat),
       ],
     );
   }


### PR DESCRIPTION
接 #74 / #75 / #76，做审计「已知未做」里的**身份色去重**。

## 发现的比预期多一处

原本记的是两处重复，实际是**两个映射的四份拷贝，外加一个没人调用的函数**：

| | 情况 |
|---|---|
| **计费口径 5 色** | `usage_summary.dart` 把它们声明成**公开**常量，注释写着「与费率组价格药丸共用」；`pricing_group_manager.dart` 又**私有地重抄了 4 个**，注释写着「刻意用与用量页相同的色」。**共用的意图两个文件都白纸黑字写了，缺的只是一行 import。** |
| **模型类型 5 色** | `models_screen.dart` 和 `discovery_dialog.dart` 各有一份**逐字节相同**的 `switch`，`model_edit_dialog.dart` 第三份写成元组表。它们碰巧一致，但没有任何机制保证。 |
| **设置分类 5 色**（新发现） | `_categoryColor()` 函数早就存在，**移动端列表却把 5 个色值又内联写了一遍**，完全绕过它。桌面栏和移动列表是两份独立的映射。 |

## 落到哪

新建 `core/metric_palette.dart` 与 `core/model_kind_palette.dart`，沿用 `core/fee_group_palette.dart` 的写法——那个文件的注释其实早就提到了这批色（*「orange is cost, and the blue/teal/green trio belongs to input/cache/output」*），只是当时没有可以指过去的地方。

两个模块都写清了**为什么这些是字面量而不是 `ColorScheme` 角色**：它们标的是**类别**，跟着种子色走会让四个类别塌成同一个色的四种深浅。这也是它们不进 `AppSemanticColors` 的原因——那里放的是**状态**（成功/警告/信息），不是类别。

## 审阅要点

- **色值一个没动。** Material swatch 原样搬过去，没有借去重之机改成 hex 重新挑色。已用用量页和模型页截图核对：计费口径配色与类型 chip 渲染完全一致。
- `REFINER` 落在默认蓝上——三份原始拷贝都没给 refiner 配色，这是**继承来的行为不是新决定**，已在 `modelTagAccent` 注释里写明，将来要给它单独配色时有据可查。
- `model_edit_dialog` 的元组表从 `(String, String, Color)` 减为 `(String, String)`，同时抽了 `_buildTagChoice` 方法：那个 `ChoiceChip` 要用五次颜色，而 collection-for 里没地方放局部变量。
- 顺手带走两行**语义色**（本来就在审计的漂移清单上）：删除菜单的 `Colors.red` → `colorScheme.error`，发现对话框勾选图标的 `Colors.green` → `context.semantic.success`。

## 没做

`models_screen` 与 `discovery_dialog` 的 `_buildTagChip` 现在共用颜色了，但**两个容器仍各写各的**（圆角 8 + 描边 vs 圆角 6 无描边）。抽成共享组件会改变 discovery 那边的观感，超出「颜色去重」的范围，已记入审计的「已知未做」。

## 验证

```bash
flutter analyze     # No issues found!
flutter test        # 478 passed
flutter test test/screenshots/app_screens_test.dart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
