### PR TITLE
refactor: 导入弹窗与类型 chip 去重 + 按目标格式编码

### DIFF
--- a/docs/reports/design-spec-audit.md
+++ b/docs/reports/design-spec-audit.md
@@ -59,6 +59,9 @@
 | `constants.dart:68-78` | 9 个零调用点的死令牌（`cardRadius` / `smallRadius` / `defaultPadding` / `opacityLow`…）→ 删除，几何统一到 `design_tokens.dart` |
 | 计费口径 5 色 | `usage_summary.dart` 声明为公开常量、注释写着「与费率组价格药丸共用」，`pricing_group_manager.dart` 却又**私有地重抄了 4 个**、注释写着「刻意用与用量页相同的色」——共用的意图一直都在，只是被复制而非导入。→ 抽出 `core/metric_palette.dart` |
 | 模型类型 5 色 | `models_screen.dart` 与 `discovery_dialog.dart` 各有一份**逐字节相同**的 `switch`，`model_edit_dialog.dart` 第三份写成元组表。→ 抽出 `core/model_kind_palette.dart` |
+| `data_section.dart` ↔ `wizard_import.dart` | 导入选项的移动端 sheet / 桌面 dialog / 开关行三个函数**各存一份**，且已开始漂移（一边 `AppButtonSize.large`+`fullWidth`、另一边 `SizedBox` 裹默认尺寸；一边问 `Responsive`、另一边硬写 `MediaQuery…< 600`）。→ 抽出 `widgets/dialogs/import_options_dialog.dart`，两份 `Colors.grey` / `Colors.grey[400]` 一并换成主题角色 |
+| 模型类型 chip 容器 | 颜色已共用，但容器一个圆角 8 带描边、一个圆角 6 无描边，同一个 chip 在两屏长得不一样。→ 抽出 `widgets/models/model_tag_chip.dart`，取带描边那版，圆角走 `AppRadius.control` |
+| 覆盖原图写入 PNG 字节到 `.jpg` | `_runImageProcess` 恒用 `img.encodePng`，覆盖 `.jpg` 会把 PNG 字节写进 `.jpg`。→ 改用 `img.encodeNamedImage(targetPath)` 按扩展名选编码器；无编码器的格式（app 能打开但写不了的 **avif**）**明确抛异常**而非静默回落 PNG，UI 给出可操作的提示。`test/image_encoding_test.dart` 从字节而非文件名去验证格式 |
 | `settings_screen.dart` | 已有 `_categoryColor()`，但移动端列表把同样的 5 个色值又内联写了一遍，绕过了那个函数。→ 由 `_buildCategoryTile` 内部统一取色 |
 | `crop_resize_view.dart:447` | 输出条宣称副本存到 `临时工作区 / crop_photo.jpg`，实际写的是 `<temp>/joycai/processed/crop_photo_<时间戳>.png`——文件名、扩展名、目录三处都不符。→ 抽出 `ImageProcessingService.resolveCropCopyTarget()`，输出条 / 覆盖弹窗 / 实际写入共用同一个解析器，命名改为确定性的 `<name>_crop.png`（冲突时加数字后缀） |
 | `image_processing_service.dart` `saveImage()` | 裸 `writeAsBytes`，复制和覆盖走同一行、只差调用方拼出的路径字符串。→ 新增必填的 `allowOverwrite`，为 false 且目标已存在时抛异常。破坏性操作在 UI 与 service 两层都要拦 |
@@ -67,11 +70,8 @@
 
 | 项 | 说明 |
 |---|---|
-| 42 处裸 `TextField` 的手写 `InputDecoration` | `inputDecorationTheme` 已给出描边式基线，但调用点自己写了 `border:`/`filled:` 的会局部覆盖主题。逐个清掉是 25 个文件的机械改动，建议按屏单独推进 |
-| 模型类型 chip 组件本身 | `models_screen.dart` 与 `discovery_dialog.dart` 的 `_buildTagChip` 现在共用颜色，但**两个容器仍是各写各的**（圆角 8 + 描边 vs 圆角 6 无描边）。抽成一个共享组件会带来观感变化，本轮只做了颜色去重 |
-| `data_section.dart:319-407` ↔ `wizard_import.dart:97-187` | 近乎逐行重复，含各自的 `Colors.grey` |
+| 仍在自绘的输入框装饰 | 冗余的那批（`border: const OutlineInputBorder()` 与 `isDense: true`，21 个文件 35 处）已删，交还给 `inputDecorationTheme`。**剩下的是刻意的**：5 处 `InputBorder.none`（聊天输入框、Markdown 正文、工具栏内联数字、提示词页头搜索）、9 处填充式搜索框、以及 `AppDropdown` / `ChatModelSelector` / `PricingGroupManager` 自己的描边逻辑。这些**不该**被主题收编——真正剩下的问题是那 9 处填充式搜索框长得几乎一样却各写各的，值得抽个共享组件 |
 | 10c–10e 页面重排、10j/10k 字段级重设计 | 见上 |
-| 覆盖原图写入 PNG 字节到 `.jpg` | `_runImageProcess` 恒用 `img.encodePng`（`image_processing_service.dart:73`），所以覆盖一个 `.jpg` 会把 PNG 字节写进 `.jpg` 文件——内容与扩展名不符。修法是按目标扩展名选编码器（并为 JPEG 定质量参数），属于保存行为变更，单独一轮 |
 | 分组小标题组件 | 目前只在组件全景图里表达，未抽成共享组件 |
 
 ## 验证方式

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -963,6 +963,14 @@
   "overwriteConfirmSaveCopyInstead": "Save Copy Instead",
   "overwriteConfirmSubtitle": "This action cannot be undone.",
   "overwriteConfirmKeepOriginalHint": "To keep the original, use Save Copy instead.",
+  "overwriteUnsupportedFormat": "Cannot overwrite a {format} file — this format can be opened but not written. Use Save Copy instead.",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -823,6 +823,14 @@
   "overwriteConfirmSaveCopyInstead": "代わりにコピーを保存",
   "overwriteConfirmSubtitle": "この操作は取り消せません",
   "overwriteConfirmKeepOriginalHint": "元の画像を残す場合は「コピーを保存」をご利用ください。",
+  "overwriteUnsupportedFormat": "{format} ファイルは上書きできません。この形式は読み込み専用です。「コピーを保存」をご利用ください。",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3641,6 +3641,12 @@ abstract class AppLocalizations {
   /// **'To keep the original, use Save Copy instead.'**
   String get overwriteConfirmKeepOriginalHint;
 
+  /// No description provided for @overwriteUnsupportedFormat.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot overwrite a {format} file — this format can be opened but not written. Use Save Copy instead.'**
+  String overwriteUnsupportedFormat(String format);
+
   /// No description provided for @saveToTempSuccess.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1950,6 +1950,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'To keep the original, use Save Copy instead.';
 
   @override
+  String overwriteUnsupportedFormat(String format) {
+    return 'Cannot overwrite a $format file — this format can be opened but not written. Use Save Copy instead.';
+  }
+
+  @override
   String get saveToTempSuccess => 'Image saved to temporary workspace';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1905,6 +1905,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get overwriteConfirmKeepOriginalHint => '元の画像を残す場合は「コピーを保存」をご利用ください。';
 
   @override
+  String overwriteUnsupportedFormat(String format) {
+    return '$format ファイルは上書きできません。この形式は読み込み専用です。「コピーを保存」をご利用ください。';
+  }
+
+  @override
   String get saveToTempSuccess => '画像が一時ワークスペースに保存されました';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1891,6 +1891,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get overwriteConfirmKeepOriginalHint => '如需保留原图，可改用「保存副本」。';
 
   @override
+  String overwriteUnsupportedFormat(String format) {
+    return '无法覆盖 $format 文件——该格式只能读取、不能写入。请改用「保存副本」。';
+  }
+
+  @override
   String get saveToTempSuccess => '已保存至临时工作区';
 
   @override
@@ -4338,6 +4343,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get overwriteConfirmKeepOriginalHint => '如需保留原圖，可改用「儲存副本」。';
+
+  @override
+  String overwriteUnsupportedFormat(String format) {
+    return '無法覆蓋 $format 檔案——此格式只能讀取、不能寫入。請改用「儲存副本」。';
+  }
 
   @override
   String get saveToTempSuccess => '圖片已儲存至臨時工作區';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -949,6 +949,14 @@
   "overwriteConfirmSaveCopyInstead": "改为保存副本",
   "overwriteConfirmSubtitle": "此操作无法撤销",
   "overwriteConfirmKeepOriginalHint": "如需保留原图，可改用「保存副本」。",
+  "overwriteUnsupportedFormat": "无法覆盖 {format} 文件——该格式只能读取、不能写入。请改用「保存副本」。",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -823,6 +823,14 @@
   "overwriteConfirmSaveCopyInstead": "改為儲存副本",
   "overwriteConfirmSubtitle": "此操作無法復原",
   "overwriteConfirmKeepOriginalHint": "如需保留原圖，可改用「儲存副本」。",
+  "overwriteUnsupportedFormat": "無法覆蓋 {format} 檔案——此格式只能讀取、不能寫入。請改用「儲存副本」。",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -154,6 +154,14 @@
   "overwriteConfirmSaveCopyInstead": "Save Copy Instead",
   "overwriteConfirmSubtitle": "This action cannot be undone.",
   "overwriteConfirmKeepOriginalHint": "To keep the original, use Save Copy instead.",
+  "overwriteUnsupportedFormat": "Cannot overwrite a {format} file — this format can be opened but not written. Use Save Copy instead.",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "Image saved to temporary workspace",
   "overwriteSuccess": "Original file updated",
   "custom": "Custom",

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -154,6 +154,14 @@
   "overwriteConfirmSaveCopyInstead": "代わりにコピーを保存",
   "overwriteConfirmSubtitle": "この操作は取り消せません",
   "overwriteConfirmKeepOriginalHint": "元の画像を残す場合は「コピーを保存」をご利用ください。",
+  "overwriteUnsupportedFormat": "{format} ファイルは上書きできません。この形式は読み込み専用です。「コピーを保存」をご利用ください。",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "画像が一時ワークスペースに保存されました",
   "overwriteSuccess": "元のファイルが更新されました",
   "custom": "カスタム",

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -154,6 +154,14 @@
   "overwriteConfirmSaveCopyInstead": "改为保存副本",
   "overwriteConfirmSubtitle": "此操作无法撤销",
   "overwriteConfirmKeepOriginalHint": "如需保留原图，可改用「保存副本」。",
+  "overwriteUnsupportedFormat": "无法覆盖 {format} 文件——该格式只能读取、不能写入。请改用「保存副本」。",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "已保存至临时工作区",
   "overwriteSuccess": "原图已更新",
   "custom": "自定义",

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -154,6 +154,14 @@
   "overwriteConfirmSaveCopyInstead": "改為儲存副本",
   "overwriteConfirmSubtitle": "此操作無法復原",
   "overwriteConfirmKeepOriginalHint": "如需保留原圖，可改用「儲存副本」。",
+  "overwriteUnsupportedFormat": "無法覆蓋 {format} 檔案——此格式只能讀取、不能寫入。請改用「儲存副本」。",
+  "@overwriteUnsupportedFormat": {
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
   "saveToTempSuccess": "圖片已儲存至臨時工作區",
   "overwriteSuccess": "原始檔案已更新",
   "custom": "自訂",

--- a/lib/screens/models/models_screen.dart
+++ b/lib/screens/models/models_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../core/app_theme.dart';
-import '../../core/model_kind_palette.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/llm_channel.dart';
@@ -11,6 +10,7 @@ import '../../services/database_service.dart';
 import '../../services/llm/channel_dialect.dart';
 import '../../services/llm/llm_types.dart';
 import '../../state/app_state.dart';
+import '../../widgets/models/model_tag_chip.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/app_dialog.dart';
 import '../../widgets/models/channel_edit_dialog.dart';
@@ -446,7 +446,7 @@ class _ModelsScreenState extends State<ModelsScreen> {
                   ],
                 ),
               ),
-              _buildTagChip(model.tag),
+              ModelTagChip(model.tag),
               const SizedBox(width: 4),
               IconButton(
                 icon: const Icon(Icons.more_vert, size: 20),
@@ -527,7 +527,7 @@ class _ModelsScreenState extends State<ModelsScreen> {
                         .labelMedium
                         ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
                   ),
-                  trailing: _buildTagChip(m.tag),
+                  trailing: ModelTagChip(m.tag),
                   onTap: () => _showModelDialog(l10n, appState, model: m),
                 )),
               Padding(
@@ -620,25 +620,6 @@ class _ModelsScreenState extends State<ModelsScreen> {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildTagChip(String tag) {
-    final color = modelTagAccent(tag);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: color.withAlpha(30),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withAlpha(100)),
-      ),
-      child: Text(
-        tag.toUpperCase(),
-        style: Theme.of(context)
-            .textTheme
-            .labelSmall
-            ?.copyWith(color: color, fontWeight: FontWeight.bold),
       ),
     );
   }

--- a/lib/screens/settings/widgets/data_section.dart
+++ b/lib/screens/settings/widgets/data_section.dart
@@ -12,6 +12,7 @@ import '../../../services/database_service.dart';
 import '../../../state/app_state.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
+import '../../../widgets/dialogs/import_options_dialog.dart';
 import '../../../widgets/app_section.dart';
 import '../../../widgets/app_snackbar.dart';
 import '../../wizard/setup_wizard.dart';
@@ -264,13 +265,17 @@ class DataSection extends StatelessWidget {
       bool includePrompts = hasPrompts;
       bool includeUsage = hasUsage;
 
-      final bool? confirmed = await (isMobile 
-        ? _showMobileImportOptions(context, l10n, hasDirs, hasPrompts, hasUsage, (d, p, u) {
-            includeDirs = d; includePrompts = p; includeUsage = u;
-          })
-        : _showDesktopImportOptions(context, l10n, hasDirs, hasPrompts, hasUsage, (d, p, u) {
-            includeDirs = d; includePrompts = p; includeUsage = u;
-          }));
+      final bool? confirmed = await showImportOptionsDialog(
+        context,
+        l10n: l10n,
+        hasDirs: hasDirs,
+        hasPrompts: hasPrompts,
+        hasUsage: hasUsage,
+        isMobile: isMobile,
+        onUpdate: (d, p, u) {
+          includeDirs = d; includePrompts = p; includeUsage = u;
+        },
+      );
 
       if (confirmed != true || !context.mounted) return;
 
@@ -291,123 +296,6 @@ class DataSection extends StatelessWidget {
       if (!context.mounted) return;
       AppSnackBar.error(context, backupImportErrorText(l10n, e));
     }
-  }
-
-  Future<bool?> _showMobileImportOptions(
-    BuildContext context, 
-    AppLocalizations l10n, 
-    bool hasDirs, bool hasPrompts, bool hasUsage,
-    Function(bool, bool, bool) onUpdate
-  ) async {
-    bool d = hasDirs;
-    bool p = hasPrompts;
-    bool u = hasUsage;
-
-    return await showModalBottomSheet<bool>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) => Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(l10n.importOptions, style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold)),
-              const SizedBox(height: 8),
-              Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
-              const SizedBox(height: 24),
-              _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
-              const Divider(height: 32),
-              _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
-              const Divider(height: 32),
-              _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
-              const SizedBox(height: 48),
-              AppButton(
-                label: l10n.importNow,
-                variant: AppButtonVariant.destructive,
-                size: AppButtonSize.large,
-                fullWidth: true,
-                onPressed: () {
-                  onUpdate(d, p, u);
-                  Navigator.pop(context, true);
-                },
-              ),
-              const SizedBox(height: 12),
-              AppButton(
-                label: l10n.cancel,
-                variant: AppButtonVariant.text,
-                size: AppButtonSize.large,
-                fullWidth: true,
-                onPressed: () => Navigator.pop(context, false),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Future<bool?> _showDesktopImportOptions(
-    BuildContext context, 
-    AppLocalizations l10n, 
-    bool hasDirs, bool hasPrompts, bool hasUsage,
-    Function(bool, bool, bool) onUpdate
-  ) async {
-    bool d = hasDirs;
-    bool p = hasPrompts;
-    bool u = hasUsage;
-
-    return await AppDialog.show<bool>(
-      context,
-      title: l10n.importOptions,
-      maxWidth: 450,
-      content: StatefulBuilder(
-        builder: (context, setState) => Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
-            const SizedBox(height: 20),
-            _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
-            const SizedBox(height: 12),
-            _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
-            const SizedBox(height: 12),
-            _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
-          ],
-        ),
-      ),
-      actions: [
-        AppButton(
-          label: l10n.cancel,
-          variant: AppButtonVariant.text,
-          onPressed: () => Navigator.pop(context, false),
-        ),
-        AppButton(
-          label: l10n.importNow,
-          variant: AppButtonVariant.destructive,
-          onPressed: () {
-            onUpdate(d, p, u);
-            Navigator.pop(context, true);
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget _buildImportOption(BuildContext context, String title, String desc, bool value, bool enabled,
-      AppLocalizations l10n, Function(bool) onChanged) {
-    final textTheme = Theme.of(context).textTheme;
-    return SwitchListTile(
-      value: value && enabled,
-      onChanged: enabled ? onChanged : null,
-      title: Text(title, style: textTheme.titleMedium?.copyWith(color: enabled ? null : Colors.grey)),
-      subtitle: Text(
-        enabled ? desc : l10n.notInBackup,
-        style: textTheme.bodySmall?.copyWith(color: enabled ? null : Colors.grey[400]),
-      ),
-      contentPadding: EdgeInsets.zero,
-    );
   }
 
   void _resetSettings(BuildContext context, AppLocalizations l10n) {

--- a/lib/screens/wizard/wizard_import.dart
+++ b/lib/screens/wizard/wizard_import.dart
@@ -9,9 +9,8 @@ import '../../core/backup_error_text.dart';
 import '../../l10n/app_localizations.dart';
 import '../../services/database_service.dart';
 import '../../state/app_state.dart';
-import '../../widgets/app_button.dart';
-import '../../widgets/app_dialog.dart';
 import '../../widgets/app_snackbar.dart';
+import '../../widgets/dialogs/import_options_dialog.dart';
 
 /// Backup-import flow for the setup wizard.
 ///
@@ -22,7 +21,6 @@ import '../../widgets/app_snackbar.dart';
 /// Pick a backup file, confirm what to import, restore it and finish setup.
 Future<void> importBackupSettings(BuildContext context, AppLocalizations l10n) async {
   final appState = Provider.of<AppState>(context, listen: false);
-  final isMobile = MediaQuery.of(context).size.width < 600;
 
   FilePickerResult? result = await FilePicker.pickFiles(type: FileType.custom, allowedExtensions: ['json']);
   if (!context.mounted || result == null) return;
@@ -42,13 +40,16 @@ Future<void> importBackupSettings(BuildContext context, AppLocalizations l10n) a
     bool includePrompts = hasPrompts;
     bool includeUsage = hasUsage;
 
-    final bool? confirmed = await (isMobile
-      ? _showMobileImportOptions(context, l10n, hasDirs, hasPrompts, hasUsage, (d, p, u) {
-          includeDirs = d; includePrompts = p; includeUsage = u;
-        })
-      : _showDesktopImportOptions(context, l10n, hasDirs, hasPrompts, hasUsage, (d, p, u) {
-          includeDirs = d; includePrompts = p; includeUsage = u;
-        }));
+    final bool? confirmed = await showImportOptionsDialog(
+      context,
+      l10n: l10n,
+      hasDirs: hasDirs,
+      hasPrompts: hasPrompts,
+      hasUsage: hasUsage,
+      onUpdate: (d, p, u) {
+        includeDirs = d; includePrompts = p; includeUsage = u;
+      },
+    );
 
     if (confirmed != true || !context.mounted) return;
 
@@ -69,123 +70,4 @@ Future<void> importBackupSettings(BuildContext context, AppLocalizations l10n) a
     if (!context.mounted) return;
     AppSnackBar.error(context, backupImportErrorText(l10n, e));
   }
-}
-
-Future<bool?> _showMobileImportOptions(
-  BuildContext context,
-  AppLocalizations l10n,
-  bool hasDirs, bool hasPrompts, bool hasUsage,
-  Function(bool, bool, bool) onUpdate
-) async {
-  bool d = hasDirs;
-  bool p = hasPrompts;
-  bool u = hasUsage;
-
-  return await showModalBottomSheet<bool>(
-    context: context,
-    isScrollControlled: true,
-    useSafeArea: true,
-    builder: (context) => StatefulBuilder(
-      builder: (context, setState) => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(l10n.importOptions, style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold)),
-            const SizedBox(height: 8),
-            Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
-            const SizedBox(height: 24),
-            _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
-            const Divider(height: 32),
-            _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
-            const Divider(height: 32),
-            _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
-            const SizedBox(height: 48),
-            SizedBox(
-              width: double.infinity,
-              child: AppButton(
-                label: l10n.importNow,
-                variant: AppButtonVariant.destructive,
-                onPressed: () {
-                  onUpdate(d, p, u);
-                  Navigator.pop(context, true);
-                },
-              ),
-            ),
-            const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: AppButton(
-                label: l10n.cancel,
-                variant: AppButtonVariant.text,
-                onPressed: () => Navigator.pop(context, false),
-              ),
-            ),
-          ],
-        ),
-      ),
-    ),
-  );
-}
-
-Future<bool?> _showDesktopImportOptions(
-  BuildContext context,
-  AppLocalizations l10n,
-  bool hasDirs, bool hasPrompts, bool hasUsage,
-  Function(bool, bool, bool) onUpdate
-) async {
-  bool d = hasDirs;
-  bool p = hasPrompts;
-  bool u = hasUsage;
-
-  return await AppDialog.show<bool>(
-    context,
-    title: l10n.importOptions,
-    maxWidth: 450,
-    content: StatefulBuilder(
-      builder: (context, setState) => Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(l10n.importSettingsConfirm, style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.grey)),
-          const SizedBox(height: 20),
-          _buildImportOption(context, l10n.includeDirectories, l10n.includeDirectoriesDesc, d, hasDirs, l10n, (v) => setState(() => d = v)),
-          const SizedBox(height: 12),
-          _buildImportOption(context, l10n.includePrompts, l10n.includePromptsDesc, p, hasPrompts, l10n, (v) => setState(() => p = v)),
-          const SizedBox(height: 12),
-          _buildImportOption(context, l10n.includeUsage, l10n.includeUsageDesc, u, hasUsage, l10n, (v) => setState(() => u = v)),
-        ],
-      ),
-    ),
-    actions: [
-      AppButton(
-        label: l10n.cancel,
-        variant: AppButtonVariant.text,
-        onPressed: () => Navigator.pop(context, false),
-      ),
-      AppButton(
-        label: l10n.importNow,
-        variant: AppButtonVariant.destructive,
-        onPressed: () {
-          onUpdate(d, p, u);
-          Navigator.pop(context, true);
-        },
-      ),
-    ],
-  );
-}
-
-Widget _buildImportOption(BuildContext context, String title, String desc, bool value, bool enabled,
-    AppLocalizations l10n, Function(bool) onChanged) {
-  final textTheme = Theme.of(context).textTheme;
-  return SwitchListTile(
-    value: value && enabled,
-    onChanged: enabled ? onChanged : null,
-    title: Text(title, style: textTheme.titleMedium?.copyWith(color: enabled ? null : Colors.grey)),
-    subtitle: Text(
-      enabled ? desc : l10n.notInBackup,
-      style: textTheme.bodySmall?.copyWith(color: enabled ? null : Colors.grey[400]),
-    ),
-    contentPadding: EdgeInsets.zero,
-  );
 }

--- a/lib/screens/workbench/widgets/crop_resize_toolbar.dart
+++ b/lib/screens/workbench/widgets/crop_resize_toolbar.dart
@@ -1,5 +1,6 @@
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 
 import '../../../core/app_theme.dart';
@@ -378,18 +379,9 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
         default: sampling = SamplingMethod.lanczos;
       }
 
-      final processedBytes = await ImageProcessingService().processImage(
-        sourcePath: sourceImage.path,
-        cropX: cropRect.left.toInt(),
-        cropY: cropRect.top.toInt(),
-        cropWidth: cropRect.width.toInt(),
-        cropHeight: cropRect.height.toInt(),
-        width: w,
-        height: h,
-        maintainAspectRatio: uiState.maintainAspectRatio,
-        sampling: sampling,
-      );
-
+      // Resolved before the work, not after: the encoder is chosen from the
+      // target's extension, so the destination has to be known by the time
+      // the bytes are produced.
       String targetPath;
       String targetName;
 
@@ -402,6 +394,19 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
         targetName = target.fileName;
         targetPath = target.path;
       }
+
+      final processedBytes = await ImageProcessingService().processImage(
+        sourcePath: sourceImage.path,
+        targetPath: targetPath,
+        cropX: cropRect.left.toInt(),
+        cropY: cropRect.top.toInt(),
+        cropWidth: cropRect.width.toInt(),
+        cropHeight: cropRect.height.toInt(),
+        width: w,
+        height: h,
+        maintainAspectRatio: uiState.maintainAspectRatio,
+        sampling: sampling,
+      );
 
       await ImageProcessingService().saveImage(
         bytes: processedBytes,
@@ -425,6 +430,14 @@ class _CropResizeToolbarState extends State<CropResizeToolbar> {
 
       appState.galleryState.refreshImages();
       appState.setWorkbenchTab(0);
+    } on UnsupportedImageFormatException {
+      // Named separately from the generic catch: this one is not a failure the
+      // user can retry, it is a fact about their file, and the message has to
+      // point them at the copy path that does work.
+      if (mounted) {
+        final ext = p.extension(sourceImage.path).replaceFirst('.', '').toUpperCase();
+        AppSnackBar.error(context, l10n.overwriteUnsupportedFormat(ext));
+      }
     } catch (e) {
       if (mounted) {
         AppSnackBar.error(context, "Error: $e");

--- a/lib/services/image_processing_service.dart
+++ b/lib/services/image_processing_service.dart
@@ -24,6 +24,10 @@ class _ImageProcessParams {
   final bool maintainAspectRatio;
   final SamplingMethod sampling;
 
+  /// Where the result is headed. Only its extension is used, and only to pick
+  /// the encoder — the isolate never touches the path.
+  final String targetPath;
+
   _ImageProcessParams({
     required this.sourcePath,
     this.cropX,
@@ -34,6 +38,7 @@ class _ImageProcessParams {
     this.height,
     required this.maintainAspectRatio,
     required this.sampling,
+    required this.targetPath,
   });
 }
 
@@ -73,7 +78,33 @@ Uint8List _runImageProcess(_ImageProcessParams params) {
     );
   }
 
-  return Uint8List.fromList(img.encodePng(image));
+  // Encoded for wherever it is going, not always PNG.
+  //
+  // This used to `encodePng` unconditionally, which is fine for the copy path
+  // (always `.png`) and silently wrong for an overwrite: replacing `photo.jpg`
+  // wrote PNG bytes into a file still named `.jpg`. Most viewers sniff the
+  // magic bytes and cope, so it looked like it worked — until something that
+  // trusts the extension does not.
+  //
+  // `encodeNamedImage` picks by extension and returns null for a format it
+  // cannot write. That is thrown rather than quietly falling back to PNG,
+  // because a silent fallback is the bug this replaces. AVIF is the one format
+  // the app opens and cannot write, so an AVIF overwrite now fails loudly
+  // instead of producing a mislabelled file; "save a copy" still works, since
+  // copies are PNG.
+  final encoded = img.encodeNamedImage(params.targetPath, image);
+  if (encoded == null) {
+    throw const UnsupportedImageFormatException();
+  }
+  return encoded;
+}
+
+/// The target's extension names a format `image` can decode but not encode.
+class UnsupportedImageFormatException implements Exception {
+  const UnsupportedImageFormatException();
+
+  @override
+  String toString() => 'UnsupportedImageFormatException';
 }
 
 class ImageProcessingService {
@@ -91,6 +122,7 @@ class ImageProcessingService {
     int? height,
     bool maintainAspectRatio = true,
     SamplingMethod sampling = SamplingMethod.lanczos,
+    required String targetPath,
   }) async {
     final params = _ImageProcessParams(
       sourcePath: sourcePath,
@@ -102,6 +134,7 @@ class ImageProcessingService {
       height: height,
       maintainAspectRatio: maintainAspectRatio,
       sampling: sampling,
+      targetPath: targetPath,
     );
     return await compute(_runImageProcess, params);
   }
@@ -155,8 +188,9 @@ class ImageProcessingService {
     final directory = Directory(p.join(tempDir, 'joycai', 'processed'));
 
     final base = p.basenameWithoutExtension(sourcePath);
-    // Always .png: `_runImageProcess` encodes PNG regardless of the source
-    // format, so this is the extension the bytes will actually be.
+    // PNG regardless of the source format. A copy is a new file, so it is
+    // free to pick the lossless option; only an overwrite is obliged to keep
+    // whatever format the file it replaces already was.
     var name = '${base}_crop.png';
     for (var n = 2; File(p.join(directory.path, name)).existsSync(); n++) {
       name = '${base}_crop_$n.png';

--- a/lib/widgets/dialogs/import_options_dialog.dart
+++ b/lib/widgets/dialogs/import_options_dialog.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+
+import '../../core/responsive.dart';
+import '../../l10n/app_localizations.dart';
+import '../app_button.dart';
+import '../app_dialog.dart';
+
+/// Asks which parts of a backup to restore.
+///
+/// Two presentations of one question: a dialog on desktop, a bottom sheet on
+/// a phone — the sheet because this is a list of switches, and a phone-width
+/// dialog would put them behind a scrim with barely room for their
+/// descriptions.
+///
+/// This lived twice, in `settings/widgets/data_section.dart` and
+/// `wizard/wizard_import.dart`, as three near-identical functions each. They
+/// had already started to drift: one used [AppButtonSize.large] with
+/// `fullWidth`, the other a `SizedBox` around a default-sized button; one
+/// asked [Responsive] which layout to use, the other hard-coded
+/// `MediaQuery.of(context).size.width < 600`.
+///
+/// [onUpdate] reports the chosen flags before the future completes, because
+/// both call sites already hold their own `includeX` locals and restore from
+/// those. Returns true if the user confirmed.
+Future<bool?> showImportOptionsDialog(
+  BuildContext context, {
+  required AppLocalizations l10n,
+  required bool hasDirs,
+  required bool hasPrompts,
+  required bool hasUsage,
+  required void Function(bool dirs, bool prompts, bool usage) onUpdate,
+
+  /// Overrides the [Responsive] check. The settings screen knows which of its
+  /// two routes is mounted and passes that instead — the mobile route can be
+  /// reached at a width the breakpoint would call something else, and it
+  /// should still get the sheet.
+  bool? isMobile,
+}) {
+  // Seeded from what the backup actually contains: a section that isn't in
+  // the file is shown switched off and disabled, so the list doubles as a
+  // description of the backup rather than offering something that cannot
+  // happen.
+  bool dirs = hasDirs;
+  bool prompts = hasPrompts;
+  bool usage = hasUsage;
+
+  List<Widget> options(StateSetter setState, {required double gap}) => [
+        _ImportOption(
+          title: l10n.includeDirectories,
+          description: l10n.includeDirectoriesDesc,
+          value: dirs,
+          enabled: hasDirs,
+          l10n: l10n,
+          onChanged: (v) => setState(() => dirs = v),
+        ),
+        SizedBox(height: gap),
+        _ImportOption(
+          title: l10n.includePrompts,
+          description: l10n.includePromptsDesc,
+          value: prompts,
+          enabled: hasPrompts,
+          l10n: l10n,
+          onChanged: (v) => setState(() => prompts = v),
+        ),
+        SizedBox(height: gap),
+        _ImportOption(
+          title: l10n.includeUsage,
+          description: l10n.includeUsageDesc,
+          value: usage,
+          enabled: hasUsage,
+          l10n: l10n,
+          onChanged: (v) => setState(() => usage = v),
+        ),
+      ];
+
+  void confirm() {
+    onUpdate(dirs, prompts, usage);
+    Navigator.pop(context, true);
+  }
+
+  if (isMobile ?? Responsive.isMobile(context)) {
+    return showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (sheetContext) => StatefulBuilder(
+        builder: (sheetContext, setState) => Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.importOptions,
+                style: Theme.of(sheetContext)
+                    .textTheme
+                    .headlineSmall
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              _Caption(l10n.importSettingsConfirm),
+              const SizedBox(height: 24),
+              ...options(setState, gap: 20),
+              const SizedBox(height: 48),
+              AppButton(
+                label: l10n.importNow,
+                variant: AppButtonVariant.destructive,
+                size: AppButtonSize.large,
+                fullWidth: true,
+                onPressed: () {
+                  onUpdate(dirs, prompts, usage);
+                  Navigator.pop(sheetContext, true);
+                },
+              ),
+              const SizedBox(height: 12),
+              AppButton(
+                label: l10n.cancel,
+                variant: AppButtonVariant.text,
+                size: AppButtonSize.large,
+                fullWidth: true,
+                onPressed: () => Navigator.pop(sheetContext, false),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  return AppDialog.show<bool>(
+    context,
+    title: l10n.importOptions,
+    maxWidth: 450,
+    content: StatefulBuilder(
+      builder: (_, setState) => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _Caption(l10n.importSettingsConfirm),
+          const SizedBox(height: 20),
+          ...options(setState, gap: 12),
+        ],
+      ),
+    ),
+    actions: [
+      AppButton(
+        label: l10n.cancel,
+        variant: AppButtonVariant.text,
+        onPressed: () => Navigator.pop(context, false),
+      ),
+      AppButton(
+        label: l10n.importNow,
+        variant: AppButtonVariant.destructive,
+        onPressed: confirm,
+      ),
+    ],
+  );
+}
+
+class _Caption extends StatelessWidget {
+  const _Caption(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      // Was `Colors.grey` in both copies, which is the same grey in dark mode
+      // as in light and so lost most of its contrast against the sheet.
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+    );
+  }
+}
+
+/// One switch row: what it restores, and what it means when it can't.
+class _ImportOption extends StatelessWidget {
+  const _ImportOption({
+    required this.title,
+    required this.description,
+    required this.value,
+    required this.enabled,
+    required this.l10n,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String description;
+  final bool value;
+
+  /// False when the backup has no such section. The row stays visible and
+  /// explains itself rather than disappearing, so the list tells the user
+  /// what the file contains.
+  final bool enabled;
+
+  final AppLocalizations l10n;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    // Both copies reached for Colors.grey / Colors.grey[400] here, which do
+    // not follow the theme — a disabled row was the same mid-grey on a white
+    // sheet and on a near-black one.
+    final disabledTitle = colorScheme.onSurface.withValues(alpha: 0.38);
+    final disabledBody = colorScheme.onSurface.withValues(alpha: 0.30);
+
+    return SwitchListTile(
+      value: value && enabled,
+      onChanged: enabled ? onChanged : null,
+      title: Text(
+        title,
+        style: textTheme.titleMedium?.copyWith(color: enabled ? null : disabledTitle),
+      ),
+      subtitle: Text(
+        enabled ? description : l10n.notInBackup,
+        style: textTheme.bodySmall?.copyWith(
+          color: enabled ? colorScheme.onSurfaceVariant : disabledBody,
+        ),
+      ),
+      contentPadding: EdgeInsets.zero,
+    );
+  }
+}

--- a/lib/widgets/models/discovery_dialog.dart
+++ b/lib/widgets/models/discovery_dialog.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../core/app_semantic_colors.dart';
-import '../../core/model_kind_palette.dart';
 import '../../core/responsive.dart';
 import '../../l10n/app_localizations.dart';
 import '../../models/llm_channel.dart';
@@ -9,6 +8,7 @@ import '../../services/llm/llm_types.dart';
 import '../../services/llm/model_discovery_service.dart';
 import '../../services/llm/model_family.dart';
 import '../../state/app_state.dart';
+import 'model_tag_chip.dart';
 import '../app_button.dart';
 import '../app_dialog.dart';
 
@@ -330,27 +330,11 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
                     style: textTheme.labelSmall
                         ?.copyWith(color: colorScheme.outline, fontWeight: FontWeight.bold))
               else
-                _buildTagChip(_inferTag(m)),
+                ModelTagChip(_inferTag(m)),
             ],
           ),
         ),
       ),
-    );
-  }
-
-  Widget _buildTagChip(String tag) {
-    final color = modelTagAccent(tag);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: color.withAlpha(30),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(tag.toUpperCase(),
-          style: Theme.of(context)
-              .textTheme
-              .labelSmall
-              ?.copyWith(color: color, fontWeight: FontWeight.bold)),
     );
   }
 

--- a/lib/widgets/models/model_tag_chip.dart
+++ b/lib/widgets/models/model_tag_chip.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import '../../core/design_tokens.dart';
+import '../../core/model_kind_palette.dart';
+
+/// A small badge naming what a model is — CHAT, IMAGE, VIDEO, MULTIMODAL.
+///
+/// The models screen and the discovery dialog each drew their own. They had
+/// already agreed on the colour (via [modelTagAccent]) but not on the box:
+/// one used an 8px radius with a hairline border, the other 6px with none, so
+/// the same chip looked like two different components depending on which
+/// screen you opened. The bordered form wins — it is the one on the screen a
+/// user spends time in, and its radius is the app's control radius rather
+/// than a number of its own.
+class ModelTagChip extends StatelessWidget {
+  const ModelTagChip(this.tag, {super.key});
+
+  /// A [ModelTag] string value. Unrecognised tags take the palette's fallback
+  /// rather than being hidden — a model with an odd tag should still say so.
+  final String tag;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = modelTagAccent(tag);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        // The accent ladder, even though this is an identity colour rather
+        // than the theme accent: "a tint to sit on, a ring to be edged with"
+        // is the same relationship, and a second set of alphas for the same
+        // job is how the first set stopped being followed.
+        color: color.withValues(alpha: AppAlpha.tint),
+        borderRadius: BorderRadius.circular(AppRadius.control),
+        border: Border.all(color: color.withValues(alpha: AppAlpha.ring)),
+      ),
+      child: Text(
+        tag.toUpperCase(),
+        style: Theme.of(context)
+            .textTheme
+            .labelSmall
+            ?.copyWith(color: color, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+}

--- a/test/image_encoding_test.dart
+++ b/test/image_encoding_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:joycai_image_ai_toolkits/services/image_processing_service.dart';
+import 'package:path/path.dart' as p;
+
+/// Pins the format of what a crop/resize actually writes.
+///
+/// The bug this guards: `_runImageProcess` used to `encodePng` unconditionally,
+/// so overwriting `photo.jpg` put PNG bytes in a file still named `.jpg`.
+/// Viewers that sniff magic bytes hid it, which is exactly why it needs a test
+/// rather than an eyeball.
+void main() {
+  late Directory tmp;
+
+  setUp(() => tmp = Directory.systemTemp.createTempSync('joycai_enc'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  /// A real 8×8 image on disk, in [format].
+  String writeSource(String format) {
+    final image = img.Image(width: 8, height: 8);
+    img.fill(image, color: img.ColorRgb8(200, 100, 50));
+    final path = p.join(tmp.path, 'src.$format');
+    File(path).writeAsBytesSync(img.encodeNamedImage(path, image)!);
+    return path;
+  }
+
+  for (final format in ['png', 'jpg', 'bmp']) {
+    test('a $format target is encoded as $format', () async {
+      final source = writeSource(format);
+      final target = p.join(tmp.path, 'out.$format');
+
+      final bytes = await ImageProcessingService().processImage(
+        sourcePath: source,
+        targetPath: target,
+        width: 4,
+        height: 4,
+      );
+
+      // Identified from the bytes, not from the name we gave it.
+      final decoded = img.findFormatForData(bytes);
+      expect(decoded, img.findFormatForData(File(source).readAsBytesSync()),
+          reason: 'a .$format target must contain $format bytes');
+      expect(img.decodeImage(bytes)?.width, 4);
+    });
+  }
+
+  test('a format that cannot be encoded fails loudly instead of writing PNG',
+      () async {
+    // .avif is the case that actually occurs: AppConstants.isImageFile accepts
+    // it, and `image` decodes but cannot encode it.
+    final source = writeSource('png');
+
+    expect(
+      () => ImageProcessingService().processImage(
+        sourcePath: source,
+        targetPath: p.join(tmp.path, 'out.avif'),
+        width: 4,
+        height: 4,
+      ),
+      throwsA(isA<UnsupportedImageFormatException>()),
+    );
+  });
+
+  test('saveImage refuses to clobber without being told to', () async {
+    final target = p.join(tmp.path, 'existing.png');
+    File(target).writeAsBytesSync([1, 2, 3]);
+
+    expect(
+      () => ImageProcessingService()
+          .saveImage(bytes: img.encodePng(img.Image(width: 1, height: 1)),
+              targetPath: target, allowOverwrite: false),
+      throwsA(isA<FileSystemException>()),
+    );
+
+    // …and does when it is.
+    await ImageProcessingService().saveImage(
+      bytes: img.encodePng(img.Image(width: 1, height: 1)),
+      targetPath: target,
+      allowOverwrite: true,
+    );
+    expect(File(target).lengthSync(), greaterThan(3));
+  });
+}


### PR DESCRIPTION
接 #74 / #75 / #76 / #77，一次做掉审计「已知未做」里的三项。

---

## 1 · 导入选项弹窗去重

`data_section.dart` 与 `wizard_import.dart` **各存一份**同样的三个函数（移动端 sheet / 桌面 dialog / 开关行），而且**已经开始漂移**：

| | data_section | wizard_import |
|---|---|---|
| 移动端按钮 | `AppButtonSize.large` + `fullWidth` | `SizedBox` 裹默认尺寸 |
| 断点判断 | 走 `Responsive` | 硬写 `MediaQuery…< 600` |

抽到 `widgets/dialogs/import_options_dialog.dart`。

> **注意**：`DataSection` 的 `isMobile` 来自 widget 参数（跟的是**设置页哪条路由被挂载**，不是断点），所以共享函数收了个可选的 `isMobile` 覆盖参数，行为一字不差。

两份 `Colors.grey` / `Colors.grey[400]` 一并换成主题角色。`wizard_import.dart` **191 行 → 73 行**。

## 2 · 模型类型 chip 容器

颜色 #77 已经共用，但**盒子没有**：一屏圆角 8 带描边、一屏圆角 6 无描边，同一个 chip 在两个界面像两个组件。

抽出 `widgets/models/model_tag_chip.dart`，取带描边那版，圆角走 `AppRadius.control`。alpha 挪到 accent 阶梯上：tint 实际不变（0.118 → 0.12），ring 略柔（0.39 → 0.32）——与之前分段控件的同类改动一致。

## 3 · 按目标扩展名选编码器

`_runImageProcess` 恒用 `encodePng`。对副本路径（永远 `.png`）没问题，对**覆盖**则是静默错误：替换 `photo.jpg` 会把 PNG 字节写进一个仍叫 `.jpg` 的文件。

**看图工具嗅探 magic bytes、照样能打开，所以这个 bug 活了很久** —— 也正因如此，新测试是**从字节而非文件名**去判定格式的。

改用 `img.encodeNamedImage(targetPath, image)`。这要求把目标路径的解析**挪到处理之前**：编码器要从扩展名选，所以下笔前得先知道写去哪。

**没有静默回落。** 写不了的格式抛 `UnsupportedImageFormatException`——静默回落 PNG 正是要修的那个 bug。实际会碰到的只有 **avif**（`isImageFile` 收它，`image` 包只能解不能编），现在明确报错并指向「保存副本」（仍可用）。JPEG 用编码器默认 quality 100，对编辑器替换用户原图来说是对的取舍。

新增 1 个 l10n key ×4 语言。

---

## 审阅要点

- **这是本轮唯一会改变磁盘上文件内容的改动**：以后覆盖 `.jpg` 得到的是真 JPEG（有损重压，quality 100）而不是伪装成 jpg 的 PNG。覆盖 `.avif` 从「静默产出错文件」变成「明确报错」。
- 导入弹窗那个 `isMobile` 覆盖参数是刻意保留的，不是冗余——直接换成 `Responsive` 会改变设置页移动路由的行为。
- 顺带更正审计里一处**过期记录**：「42 处裸 TextField 的手写 InputDecoration」被列为待办，但 #75 已经做了。已改成实际状态——剩下的 5 处 `InputBorder.none` 与 9 处填充式搜索框是**刻意的、不该被主题收编**；真正剩下的问题是那 9 处搜索框几乎一样却各写各的。

## 验证

```bash
flutter analyze     # No issues found!
flutter test        # 483 passed（新增 5 个）
flutter test test/screenshots/app_screens_test.dart
```

`test/image_encoding_test.dart` 覆盖：png/jpg/bmp 三种目标各自编出对应格式（按字节校验）、无编码器格式抛异常、`saveImage` 不带 `allowOverwrite` 拒绝覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
