### PR TITLE
refactor(ui): 六处过滤框归一为 AppSearchField

### DIFF
--- a/docs/reports/design-spec-audit.md
+++ b/docs/reports/design-spec-audit.md
@@ -59,6 +59,7 @@
 | `constants.dart:68-78` | 9 个零调用点的死令牌（`cardRadius` / `smallRadius` / `defaultPadding` / `opacityLow`…）→ 删除，几何统一到 `design_tokens.dart` |
 | 计费口径 5 色 | `usage_summary.dart` 声明为公开常量、注释写着「与费率组价格药丸共用」，`pricing_group_manager.dart` 却又**私有地重抄了 4 个**、注释写着「刻意用与用量页相同的色」——共用的意图一直都在，只是被复制而非导入。→ 抽出 `core/metric_palette.dart` |
 | 模型类型 5 色 | `models_screen.dart` 与 `discovery_dialog.dart` 各有一份**逐字节相同**的 `switch`，`model_edit_dialog.dart` 第三份写成元组表。→ 抽出 `core/model_kind_palette.dart` |
+| 6 处搜索框 | 每个需要过滤的列表各写一个，没有两个一致：圆角 8 / 10 / 12 / 18，图标 14 / 16 / 18 / 20，同一个色调三种填充透明度，外加 5 份只为「该不该显示清除按钮」而存在的状态。→ 抽出 `widgets/app_search_field.dart`。**填充去掉了**——设计稿 10a 的搜索框是描边式，`inputDecorationTheme` 已经把这个给了所有裸 `TextField`，这个组件只加搜索图标与清除键，其余全部继承。（早先的报告把这里记成「9 处填充式搜索框」，那个 9 是 `filled:` 的总数，混进了一个多行文本域、一个回答框、下拉、模型选择器和 Markdown 编辑器。实际是 6 处搜索框，其中 4 处填充。）|
 | `data_section.dart` ↔ `wizard_import.dart` | 导入选项的移动端 sheet / 桌面 dialog / 开关行三个函数**各存一份**，且已开始漂移（一边 `AppButtonSize.large`+`fullWidth`、另一边 `SizedBox` 裹默认尺寸；一边问 `Responsive`、另一边硬写 `MediaQuery…< 600`）。→ 抽出 `widgets/dialogs/import_options_dialog.dart`，两份 `Colors.grey` / `Colors.grey[400]` 一并换成主题角色 |
 | 模型类型 chip 容器 | 颜色已共用，但容器一个圆角 8 带描边、一个圆角 6 无描边，同一个 chip 在两屏长得不一样。→ 抽出 `widgets/models/model_tag_chip.dart`，取带描边那版，圆角走 `AppRadius.control` |
 | 覆盖原图写入 PNG 字节到 `.jpg` | `_runImageProcess` 恒用 `img.encodePng`，覆盖 `.jpg` 会把 PNG 字节写进 `.jpg`。→ 改用 `img.encodeNamedImage(targetPath)` 按扩展名选编码器；无编码器的格式（app 能打开但写不了的 **avif**）**明确抛异常**而非静默回落 PNG，UI 给出可操作的提示。`test/image_encoding_test.dart` 从字节而非文件名去验证格式 |
@@ -70,7 +71,7 @@
 
 | 项 | 说明 |
 |---|---|
-| 仍在自绘的输入框装饰 | 冗余的那批（`border: const OutlineInputBorder()` 与 `isDense: true`，21 个文件 35 处）已删，交还给 `inputDecorationTheme`。**剩下的是刻意的**：5 处 `InputBorder.none`（聊天输入框、Markdown 正文、工具栏内联数字、提示词页头搜索）、9 处填充式搜索框、以及 `AppDropdown` / `ChatModelSelector` / `PricingGroupManager` 自己的描边逻辑。这些**不该**被主题收编——真正剩下的问题是那 9 处填充式搜索框长得几乎一样却各写各的，值得抽个共享组件 |
+| 仍在自绘的输入框装饰 | 冗余的那批已删（见 §四）。**剩下的是刻意的**：聊天输入框、Markdown 正文、裁剪工具栏的内联数字输入三处 `InputBorder.none`，下载器的地址栏，以及 `AppDropdown` / `ChatModelSelector` / `PricingGroupManager` 自己的描边逻辑。这些**不该**被主题收编 |
 | 10c–10e 页面重排、10j/10k 字段级重设计 | 见上 |
 | 分组小标题组件 | 目前只在组件全景图里表达，未抽成共享组件 |
 

--- a/lib/screens/browser/file_browser_screen.dart
+++ b/lib/screens/browser/file_browser_screen.dart
@@ -17,6 +17,7 @@ import '../../state/app_state.dart';
 import '../../state/file_browser_state.dart';
 import '../../state/workbench_ui_state.dart';
 import '../../widgets/app_icon_button.dart';
+import '../../widgets/app_search_field.dart';
 import '../../widgets/app_run_console.dart';
 import '../../widgets/dialogs/file_rename_dialog.dart';
 import '../../widgets/panel_resizer.dart';
@@ -349,37 +350,11 @@ class _FileBrowserScreenState extends State<FileBrowserScreen> {
   Widget _buildSearchField(FileBrowserState state, AppLocalizations l10n, ColorScheme colorScheme) {
     return SizedBox(
       height: 40,
-      child: TextField(
+      child: AppSearchField(
         controller: _searchController,
         focusNode: _searchFocusNode,
-        onChanged: (v) => state.setSearchQuery(v),
-        style: Theme.of(context).textTheme.bodyMedium,
-        decoration: InputDecoration(
-          hintText: l10n.searchFilesHint,
-          hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(color: colorScheme.outline),
-          prefixIcon: Icon(Icons.search, size: 18, color: colorScheme.outline),
-          suffixIcon: state.searchQuery.isEmpty
-              ? null
-              : IconButton(
-                  icon: const Icon(Icons.close, size: 16),
-                  onPressed: () {
-                    _searchController.clear();
-                    state.setSearchQuery('');
-                  },
-                  visualDensity: VisualDensity.compact,
-                ),
-          contentPadding: EdgeInsets.zero,
-          filled: true,
-          fillColor: colorScheme.surfaceContainerHighest.withAlpha(80),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(10),
-            borderSide: BorderSide.none,
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(10),
-            borderSide: BorderSide(color: colorScheme.primary, width: 1.5),
-          ),
-        ),
+        hint: l10n.searchFilesHint,
+        onChanged: state.setSearchQuery,
       ),
     );
   }

--- a/lib/screens/downloader/widgets/downloader_toolbar.dart
+++ b/lib/screens/downloader/widgets/downloader_toolbar.dart
@@ -7,6 +7,7 @@ import '../../../state/app_state.dart';
 import '../../../state/downloader_state.dart';
 import '../../../widgets/api_key_field.dart';
 import '../../../widgets/app_button.dart';
+import '../../../widgets/app_search_field.dart';
 import '../../../widgets/app_dialog.dart';
 import '../../../widgets/app_icon_button.dart';
 import '../../../widgets/chat_model_selector.dart';
@@ -57,10 +58,9 @@ class DownloaderToolbar extends StatelessWidget {
 
     final requirementField = SizedBox(
       height: _controlHeight,
-      child: TextField(
+      child: AppSearchField(
         controller: requirementController,
-        style: Theme.of(context).textTheme.bodyMedium,
-        decoration: _fieldDecoration(context, colorScheme, l10n.whatToFind, Icons.search),
+        hint: l10n.whatToFind,
         onSubmitted: (_) => isAnalyzing ? null : onAnalyze(),
       ),
     );
@@ -149,7 +149,13 @@ class DownloaderToolbar extends StatelessWidget {
   }
 }
 
-/// The filled, unbordered field the app uses for search and address inputs.
+/// The address bar's own decoration.
+///
+/// Was shared with the requirement field beside it, which is now an
+/// [AppSearchField]; this is the only caller left. It keeps its fill rather
+/// than following the theme's outlined input because the URL bar is the one
+/// field that spans the toolbar and reads as a surface of its own, not as a
+/// control in a row of controls.
 InputDecoration _fieldDecoration(
     BuildContext context, ColorScheme colorScheme, String hint, IconData icon) {
   return InputDecoration(

--- a/lib/screens/prompts/prompts_screen.dart
+++ b/lib/screens/prompts/prompts_screen.dart
@@ -8,6 +8,7 @@ import '../../models/tag.dart';
 import '../../services/database_service.dart';
 import '../../state/app_state.dart';
 import '../../widgets/app_button.dart';
+import '../../widgets/app_search_field.dart';
 import '../../widgets/app_icon_button.dart';
 import '../../widgets/app_run_console.dart';
 import '../../widgets/app_segmented_control.dart';
@@ -621,29 +622,14 @@ class _PromptsScreenState extends State<PromptsScreen> with SingleTickerProvider
   /// Fills whatever width it is given. The desktop header caps it; the phone
   /// header hands it the full row.
   Widget _buildSearchField(AppLocalizations l10n) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Container(
+    // The outer Container is gone: it existed to give this field a fill and a
+    // border that InputBorder.none had removed from the field itself, which is
+    // the theme's job now.
+    return SizedBox(
       height: 38,
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
-        // Squared off to the same 10px as the boxed actions beside it. A pill
-        // here made the one field on the header the odd shape out.
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.35)),
-      ),
-      child: TextField(
+      child: AppSearchField(
         controller: _searchCtrl,
-        textAlignVertical: TextAlignVertical.center,
-        decoration: InputDecoration(
-          hintText: l10n.filterPrompts,
-          prefixIcon: const Icon(Icons.search, size: 20),
-          suffixIcon: _searchQuery.isNotEmpty
-              ? IconButton(icon: const Icon(Icons.clear, size: 16), onPressed: () => _searchCtrl.clear())
-              : null,
-          border: InputBorder.none,
-          contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-        ),
+        hint: l10n.filterPrompts,
       ),
     );
   }

--- a/lib/widgets/app_search_field.dart
+++ b/lib/widgets/app_search_field.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+import '../core/design_tokens.dart';
+
+/// A "type to narrow this list" field: search glyph, hint, and a clear button
+/// that appears once there is something to clear.
+///
+/// Six of these existed, one per list that needed filtering, and no two agreed
+/// — corner radii of 8, 10, 12 and 18; glyphs at 14, 16, 18 and 20; fills at
+/// three different alphas of the same tone; and five separate pieces of state
+/// whose only job was to know whether the clear button should be on screen.
+///
+/// **The fill is gone.** These were filled boxes when the rest of the app's
+/// inputs were too; the design spec draws a search field as an outlined one,
+/// and [buildAppTheme]'s `inputDecorationTheme` now gives that to every bare
+/// `TextField`. This widget adds the two things that make a field a *search*
+/// field and inherits everything else, so it cannot drift from the inputs
+/// beside it again.
+///
+/// Takes no height. The four call sites sit in toolbars of 44, 40, 36 and 32
+/// pixels and each has a real reason for its own; this fills whatever it is
+/// given, which is why [compact] governs only the glyph and the type.
+class AppSearchField extends StatefulWidget {
+  const AppSearchField({
+    super.key,
+    required this.controller,
+    required this.hint,
+    this.onChanged,
+    this.onSubmitted,
+    this.onCleared,
+    this.focusNode,
+    this.autofocus = false,
+    this.compact = false,
+  });
+
+  final TextEditingController controller;
+  final String hint;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+
+  /// Runs after the field has been emptied, for call sites whose list is
+  /// driven by something other than [onChanged] — a state object holding the
+  /// query, say, which has to be told separately.
+  ///
+  /// [onChanged] fires on clear as well, so a call site that already handles
+  /// its query there needs nothing here.
+  final VoidCallback? onCleared;
+
+  final FocusNode? focusNode;
+  final bool autofocus;
+
+  /// Tighter glyph and type, for a field sharing a strip with icon buttons —
+  /// the log console's filter, which lives in a 40px bar.
+  final bool compact;
+
+  @override
+  State<AppSearchField> createState() => _AppSearchFieldState();
+}
+
+class _AppSearchFieldState extends State<AppSearchField> {
+  @override
+  void initState() {
+    super.initState();
+    // The clear button's visibility is the field's own business. Every call
+    // site used to carry a `_searchQuery` string or an `isEmpty` check purely
+    // to rebuild for it, which meant six chances to forget.
+    widget.controller.addListener(_onControllerChanged);
+  }
+
+  @override
+  void didUpdateWidget(AppSearchField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_onControllerChanged);
+      widget.controller.addListener(_onControllerChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    // The controller belongs to the caller, so only the listener is ours to
+    // take back.
+    widget.controller.removeListener(_onControllerChanged);
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    if (mounted) setState(() {});
+  }
+
+  void _clear() {
+    widget.controller.clear();
+    widget.onChanged?.call('');
+    widget.onCleared?.call();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final style = widget.compact ? textTheme.bodySmall : textTheme.bodyMedium;
+    final glyph = widget.compact ? 14.0 : AppSize.iconMd;
+
+    return TextField(
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      onChanged: widget.onChanged,
+      onSubmitted: widget.onSubmitted,
+      style: style,
+      textAlignVertical: TextAlignVertical.center,
+      decoration: InputDecoration(
+        hintText: widget.hint,
+        hintStyle: style?.copyWith(color: colorScheme.outline),
+        prefixIcon: Icon(Icons.search, size: glyph, color: colorScheme.outline),
+        suffixIcon: widget.controller.text.isEmpty
+            ? null
+            : IconButton(
+                icon: Icon(Icons.close, size: glyph, color: colorScheme.onSurfaceVariant),
+                onPressed: _clear,
+                visualDensity: VisualDensity.compact,
+                tooltip: MaterialLocalizations.of(context).deleteButtonTooltip,
+              ),
+        // Zero, not the theme's: this field is sized by the toolbar around it
+        // and centres itself in whatever height that is. Everything else —
+        // border, radius, focus treatment — comes from the theme.
+        contentPadding: EdgeInsets.zero,
+        isDense: true,
+      ),
+    );
+  }
+}

--- a/lib/widgets/dialogs/library_dialog.dart
+++ b/lib/widgets/dialogs/library_dialog.dart
@@ -5,6 +5,7 @@ import '../../l10n/app_localizations.dart';
 import '../../models/prompt.dart';
 import '../../models/tag.dart';
 import '../app_button.dart';
+import '../app_search_field.dart';
 import '../app_side_panel.dart';
 
 class PromptLibrarySheet extends StatefulWidget {
@@ -106,25 +107,11 @@ class _PromptLibrarySheetState extends State<PromptLibrarySheet> {
           SizedBox(
             width: isNarrow ? 120 : 180,
             height: 36,
-            child: TextField(
+            child: AppSearchField(
               controller: _searchCtrl,
-              decoration: InputDecoration(
-                hintText: l10n.filterPrompts, 
-                // The muted tone the field supplied on its own before this
-                // style named a scale slot, which brings a colour with it.
-                hintStyle: Theme.of(context)
-                    .textTheme
-                    .bodySmall
-                    ?.copyWith(color: colorScheme.onSurfaceVariant),
-                prefixIcon: const Icon(Icons.search, size: 16),
-                filled: true,
-                fillColor: colorScheme.surfaceContainerHighest.withAlpha(100),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(18),
-                  borderSide: BorderSide.none,
-                ),
-                contentPadding: EdgeInsets.zero,
-              ),
+              hint: l10n.filterPrompts,
+              compact: true,
+              onChanged: (_) => setState(() {}),
             ),
           ),
           IconButton(

--- a/lib/widgets/log_console.dart
+++ b/lib/widgets/log_console.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../core/app_semantic_colors.dart';
 import '../models/log_entry.dart';
 import '../state/app_state.dart';
+import 'app_search_field.dart';
 import 'app_snackbar.dart';
 
 class LogConsoleWidget extends StatefulWidget {
@@ -103,17 +104,26 @@ class _LogConsoleWidgetState extends State<LogConsoleWidget> {
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.symmetric(vertical: 4),
-                child: TextField(
-                  controller: _searchController,
-                  autofocus: true,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
-                  decoration: InputDecoration(
-                    hintText: 'Filter logs...',
-                    hintStyle:
-                        Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
-                    prefixIcon: Icon(Icons.search, size: 14, color: colorScheme.onSurfaceVariant),
-                    suffixIcon: IconButton(
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: AppSearchField(
+                        controller: _searchController,
+                        hint: 'Filter logs...',
+                        compact: true,
+                        autofocus: true,
+                        onChanged: (v) => setState(() => _searchQuery = v),
+                      ),
+                    ),
+                    // A sibling, not the field's suffix. This ✕ closes the
+                    // search rather than clearing it, and it has to stay
+                    // reachable while the field is empty — which is exactly
+                    // when AppSearchField hides its own clear button. Folding
+                    // the two together is what made one glyph mean two things.
+                    IconButton(
                       icon: Icon(Icons.close, size: 14, color: colorScheme.onSurfaceVariant),
+                      visualDensity: VisualDensity.compact,
+                      tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
                       onPressed: () {
                         setState(() {
                           _searchQuery = "";
@@ -122,10 +132,7 @@ class _LogConsoleWidgetState extends State<LogConsoleWidget> {
                         });
                       },
                     ),
-                    contentPadding: EdgeInsets.zero,
-                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(4)),
-                  ),
-                  onChanged: (v) => setState(() => _searchQuery = v),
+                  ],
                 ),
               ),
             )

--- a/lib/widgets/models/discovery_dialog.dart
+++ b/lib/widgets/models/discovery_dialog.dart
@@ -10,6 +10,7 @@ import '../../services/llm/model_family.dart';
 import '../../state/app_state.dart';
 import 'model_tag_chip.dart';
 import '../app_button.dart';
+import '../app_search_field.dart';
 import '../app_dialog.dart';
 
 class DiscoveryDialog extends StatefulWidget {
@@ -166,18 +167,12 @@ class _DiscoveryDialogState extends State<DiscoveryDialog> {
   }
 
   Widget _buildSearchBar(AppLocalizations l10n) {
-    return TextField(
-      controller: _filterCtrl,
-      decoration: InputDecoration(
-        hintText: l10n.searchModels,
-        prefixIcon: const Icon(Icons.search, size: 20),
-        suffixIcon: _filterCtrl.text.isNotEmpty 
-          ? IconButton(icon: const Icon(Icons.clear, size: 18), onPressed: () => _filterCtrl.clear()) 
-          : null,
-        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
-        filled: true,
-        fillColor: Theme.of(context).colorScheme.surfaceContainerHighest.withAlpha(80),
-        contentPadding: const EdgeInsets.symmetric(vertical: 12),
+    return SizedBox(
+      height: 40,
+      child: AppSearchField(
+        controller: _filterCtrl,
+        hint: l10n.searchModels,
+        onChanged: (_) => setState(() {}),
       ),
     );
   }

--- a/test/screenshots/component_gallery_test.dart
+++ b/test/screenshots/component_gallery_test.dart
@@ -25,6 +25,7 @@ import 'package:joycai_image_ai_toolkits/widgets/app_button.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_card.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_dialog.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_icon_button.dart';
+import 'package:joycai_image_ai_toolkits/widgets/app_search_field.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_segmented_control.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_status_badge.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_text_field.dart';
@@ -122,8 +123,17 @@ class _Gallery extends StatelessWidget {
               ),
               const _Label('输入'),
               Row(children: [
+                // The real search component, not an AppTextField wearing a
+                // search icon: it is what six filter fields across the app now
+                // are, and its clear button only exists once there is text.
                 Expanded(
-                  child: AppTextField(hint: '搜索文件…', prefixIcon: const Icon(Icons.search, size: 18)),
+                  child: SizedBox(
+                    height: 40,
+                    child: AppSearchField(
+                      controller: TextEditingController(text: '猫'),
+                      hint: '搜索文件…',
+                    ),
+                  ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(


### PR DESCRIPTION
接 #74 / #75 / #76 / #77 / #78。

## 漂移的规模

每个需要过滤的列表都长出了自己的搜索框，**没有两个一致**：

| | 实际取值 |
|---|---|
| 圆角 | 8 / 10 / 12 / 18 |
| 图标 | 14 / 16 / 18 / 20 |
| 填充 | 同一色调的三种透明度（80 / 100 / 0.4） |

外加 **5 份状态**，唯一职责是「该不该显示清除按钮」。

## 填充去掉了

设计稿 10a 的搜索框是**描边式**。这条在 #74 就作为输入框的通用裁决定下了，#75 又通过 `inputDecorationTheme` 发到了每一个裸 `TextField`。

`AppSearchField` 只加两样让字段成为**搜索**字段的东西——图标与清除键——其余全部继承主题，因此不会再和身边的输入框走散。清除键自己监听 controller，那 5 份 `_searchQuery` / `isEmpty` 重建标志随之退休。

**组件不设高度**：调用点分别在 44 / 40 / 36 / 32 的工具栏里，各有各的理由；`compact` 只管图标与字号。

## 两处刻意保留了自己的东西

- **日志控制台的 ✕ 是「收起搜索」不是「清空」**，而且空查询时也必须能点——正好是组件隐藏清除键的时候。改成字段旁边的独立按钮：清空查询是字段的事，关闭搜索是工具栏的事。把两者叠在一个图标上，正是「一个符号两种含义」的来源。
- **下载器地址栏保留填充**。它横跨工具栏、读作一块独立表面，而非一行控件中的一个。`_fieldDecoration` 现在只剩它一个调用者，注释已改。

## 审阅要点

- **这会改变四个界面的观感**：提示词库页头、文件浏览器、下载器需求框、模型发现对话框、提示词库弹窗的搜索框，从填充无边框变为描边。四个界面明暗两版截图都已核对。
- 提示词库页头那个原本靠**外层 `Container` 提供填充与描边**、内层 `TextField` 用 `InputBorder.none`——外层容器已删，因为那正是主题现在负责的事。
- 组件全景图原本用 `AppTextField` 套个搜索图标假装搜索框，现已换成真组件（带内容以显示清除键）。
- 顺带更正审计里的一个数：原记「9 处填充式搜索框」，那个 9 是 `filled:` 的总数，混进了一个多行文本域、一个回答框、下拉、模型选择器和 Markdown 编辑器。**实际是 6 处搜索框，其中 4 处填充。**

## 验证

```bash
flutter analyze     # No issues found!
flutter test        # 483 passed
flutter test test/screenshots/app_screens_test.dart
flutter test test/screenshots/component_gallery_test.dart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
