### PR TITLE
refactor(ui): rebuild the comparator and the mask editor to the design spec

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -946,8 +946,6 @@
   "compareLayoutSideBySide": "Side by Side",
   "compareLayoutStacked": "Stacked",
   "compareLayoutSlider": "Slider",
-  "compareModeSync": "Sync Mode",
-  "compareModeSwap": "Swap Mode",
   "compareSyncTransform": "Sync Zoom & Pan",
   "comparatorEmptyHint": "Send images from the file browser or a task result, or pick two from the library",
   "comparatorPickRaw": "Choose Before",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -837,6 +837,7 @@
   "clearTempWorkspace": "Clear Workspace",
   "dropFilesHere": "Drop images here to add them to temporary workspace",
   "noImagesSelected": "No images selected",
+  "imageLoadFailed": "Failed to load image",
   "selectSourceDirectory": "Select Source Directory",
   "removeFolderTooltip": "Remove folder",
   "removeFolderConfirmTitle": "Remove Folder?",
@@ -942,8 +943,48 @@
   "compressReferenceImagesDesc": "Re-encode images over 3MB to JPEG before sending, to reduce request size",
   "taskSubmitted": "Task submitted to queue",
   "comparator": "Comparator",
+  "compareLayoutSideBySide": "Side by Side",
+  "compareLayoutStacked": "Stacked",
+  "compareLayoutSlider": "Slider",
   "compareModeSync": "Sync Mode",
   "compareModeSwap": "Swap Mode",
+  "compareSyncTransform": "Sync Zoom & Pan",
+  "comparatorEmptyHint": "Send images from the file browser or a task result, or pick two from the library",
+  "comparatorPickRaw": "Choose Before",
+  "comparatorPickAfter": "Choose Result",
+  "comparatorZoomSynced": "Zoom {percent}% · Synced",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "Zoom {percent}% · Independent",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "Size reduced {percent}",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "Size increased {percent}",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "File Size",
   "sendToComparator": "Send to Comparator",
   "sendToComparatorRaw": "Set as Before (RAW)",
   "sendToComparatorAfter": "Set as After (Result)",
@@ -1053,6 +1094,61 @@
   "saveToTemp": "Save to Workspace",
   "saveMaskToTemp": "Save Mask to Workspace",
   "binaryMode": "Binary Mode",
+  "maskSourceCaption": "Mask {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color} brush · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "Output",
+  "maskOutputSummary": "Mask {width}×{height} · PNG (black & white)",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "Composite {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "Mask will save to {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "Save Composite",
+  "maskSaveMask": "Save Mask",
   "maskSaved": "Mask saved to workspace",
   "maskSaveError": "Error saving mask: {error}",
   "@maskSaveError": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -697,6 +697,7 @@
   "clearTempWorkspace": "ワークスペースをクリア",
   "dropFilesHere": "ここに画像をドロップして一時ワークスペースに追加",
   "noImagesSelected": "画像が選択されていません",
+  "imageLoadFailed": "画像の読み込みに失敗しました",
   "selectSourceDirectory": "ソースディレクトリを選択",
   "removeFolderTooltip": "フォルダを削除",
   "removeFolderConfirmTitle": "フォルダを削除しますか？",
@@ -802,8 +803,48 @@
   "compressReferenceImagesDesc": "送信前に3MBを超える画像をJPEGに再エンコードし、リクエストサイズを削減します",
   "taskSubmitted": "タスクがキューに送信されました",
   "comparator": "比較ツール",
+  "compareLayoutSideBySide": "左右に並べる",
+  "compareLayoutStacked": "上下に並べる",
+  "compareLayoutSlider": "スライダー比較",
   "compareModeSync": "同期モード",
   "compareModeSwap": "スワップモード",
+  "compareSyncTransform": "ズーム・パンを同期",
+  "comparatorEmptyHint": "ファイルブラウザやタスク結果から送信するか、ライブラリから2枚選択してください",
+  "comparatorPickRaw": "元画像を選択",
+  "comparatorPickAfter": "結果画像を選択",
+  "comparatorZoomSynced": "ズーム {percent}% · 同期中",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "ズーム {percent}% · 個別",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "サイズ {percent} 削減",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "サイズ {percent} 増加",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "ファイルサイズ",
   "sendToComparator": "比較ツールに送信",
   "sendToComparatorRaw": "Before (RAW) として設定",
   "sendToComparatorAfter": "After (結果) として設定",
@@ -913,6 +954,61 @@
   "saveToTemp": "ワークスペースに保存",
   "saveMaskToTemp": "マスクをワークスペースに保存",
   "binaryMode": "バイナリモード",
+  "maskSourceCaption": "マスク {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color}のブラシ · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "出力",
+  "maskOutputSummary": "マスク {width}×{height} · PNG（白黒）",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "合成画像 {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "マスクの保存先 {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "合成画像を保存",
+  "maskSaveMask": "マスクを保存",
   "maskSaved": "マスクがワークスペースに保存されました",
   "maskSaveError": "マスク保存エラー: {error}",
   "@maskSaveError": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -806,8 +806,6 @@
   "compareLayoutSideBySide": "左右に並べる",
   "compareLayoutStacked": "上下に並べる",
   "compareLayoutSlider": "スライダー比較",
-  "compareModeSync": "同期モード",
-  "compareModeSwap": "スワップモード",
   "compareSyncTransform": "ズーム・パンを同期",
   "comparatorEmptyHint": "ファイルブラウザやタスク結果から送信するか、ライブラリから2枚選択してください",
   "comparatorPickRaw": "元画像を選択",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3539,18 +3539,6 @@ abstract class AppLocalizations {
   /// **'Slider'**
   String get compareLayoutSlider;
 
-  /// No description provided for @compareModeSync.
-  ///
-  /// In en, this message translates to:
-  /// **'Sync Mode'**
-  String get compareModeSync;
-
-  /// No description provided for @compareModeSwap.
-  ///
-  /// In en, this message translates to:
-  /// **'Swap Mode'**
-  String get compareModeSwap;
-
   /// No description provided for @compareSyncTransform.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3221,6 +3221,12 @@ abstract class AppLocalizations {
   /// **'No images selected'**
   String get noImagesSelected;
 
+  /// No description provided for @imageLoadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to load image'**
+  String get imageLoadFailed;
+
   /// No description provided for @selectSourceDirectory.
   ///
   /// In en, this message translates to:
@@ -3515,6 +3521,24 @@ abstract class AppLocalizations {
   /// **'Comparator'**
   String get comparator;
 
+  /// No description provided for @compareLayoutSideBySide.
+  ///
+  /// In en, this message translates to:
+  /// **'Side by Side'**
+  String get compareLayoutSideBySide;
+
+  /// No description provided for @compareLayoutStacked.
+  ///
+  /// In en, this message translates to:
+  /// **'Stacked'**
+  String get compareLayoutStacked;
+
+  /// No description provided for @compareLayoutSlider.
+  ///
+  /// In en, this message translates to:
+  /// **'Slider'**
+  String get compareLayoutSlider;
+
   /// No description provided for @compareModeSync.
   ///
   /// In en, this message translates to:
@@ -3526,6 +3550,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Swap Mode'**
   String get compareModeSwap;
+
+  /// No description provided for @compareSyncTransform.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync Zoom & Pan'**
+  String get compareSyncTransform;
+
+  /// No description provided for @comparatorEmptyHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Send images from the file browser or a task result, or pick two from the library'**
+  String get comparatorEmptyHint;
+
+  /// No description provided for @comparatorPickRaw.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose Before'**
+  String get comparatorPickRaw;
+
+  /// No description provided for @comparatorPickAfter.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose Result'**
+  String get comparatorPickAfter;
+
+  /// No description provided for @comparatorZoomSynced.
+  ///
+  /// In en, this message translates to:
+  /// **'Zoom {percent}% · Synced'**
+  String comparatorZoomSynced(int percent);
+
+  /// No description provided for @comparatorZoomIndependent.
+  ///
+  /// In en, this message translates to:
+  /// **'Zoom {percent}% · Independent'**
+  String comparatorZoomIndependent(int percent);
+
+  /// No description provided for @comparatorSizeReduction.
+  ///
+  /// In en, this message translates to:
+  /// **'Size reduced {percent}'**
+  String comparatorSizeReduction(String percent);
+
+  /// No description provided for @comparatorSizeIncrease.
+  ///
+  /// In en, this message translates to:
+  /// **'Size increased {percent}'**
+  String comparatorSizeIncrease(String percent);
+
+  /// No description provided for @fileSize.
+  ///
+  /// In en, this message translates to:
+  /// **'File Size'**
+  String get fileSize;
 
   /// No description provided for @sendToComparator.
   ///
@@ -3843,6 +3921,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Binary Mode'**
   String get binaryMode;
+
+  /// No description provided for @maskSourceCaption.
+  ///
+  /// In en, this message translates to:
+  /// **'Mask {width}×{height}'**
+  String maskSourceCaption(int width, int height);
+
+  /// No description provided for @maskBrushBadge.
+  ///
+  /// In en, this message translates to:
+  /// **'{color} brush · {size} px'**
+  String maskBrushBadge(String color, int size);
+
+  /// No description provided for @maskOutputLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Output'**
+  String get maskOutputLabel;
+
+  /// No description provided for @maskOutputSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Mask {width}×{height} · PNG (black & white)'**
+  String maskOutputSummary(int width, int height);
+
+  /// No description provided for @maskCompositeOutputSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Composite {width}×{height} · PNG'**
+  String maskCompositeOutputSummary(int width, int height);
+
+  /// No description provided for @maskWillSaveTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Mask will save to {path}'**
+  String maskWillSaveTo(String path);
+
+  /// No description provided for @maskSaveComposite.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Composite'**
+  String get maskSaveComposite;
+
+  /// No description provided for @maskSaveMask.
+  ///
+  /// In en, this message translates to:
+  /// **'Save Mask'**
+  String get maskSaveMask;
 
   /// No description provided for @maskSaved.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1719,6 +1719,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noImagesSelected => 'No images selected';
 
   @override
+  String get imageLoadFailed => 'Failed to load image';
+
+  @override
   String get selectSourceDirectory => 'Select Source Directory';
 
   @override
@@ -1886,10 +1889,55 @@ class AppLocalizationsEn extends AppLocalizations {
   String get comparator => 'Comparator';
 
   @override
+  String get compareLayoutSideBySide => 'Side by Side';
+
+  @override
+  String get compareLayoutStacked => 'Stacked';
+
+  @override
+  String get compareLayoutSlider => 'Slider';
+
+  @override
   String get compareModeSync => 'Sync Mode';
 
   @override
   String get compareModeSwap => 'Swap Mode';
+
+  @override
+  String get compareSyncTransform => 'Sync Zoom & Pan';
+
+  @override
+  String get comparatorEmptyHint =>
+      'Send images from the file browser or a task result, or pick two from the library';
+
+  @override
+  String get comparatorPickRaw => 'Choose Before';
+
+  @override
+  String get comparatorPickAfter => 'Choose Result';
+
+  @override
+  String comparatorZoomSynced(int percent) {
+    return 'Zoom $percent% · Synced';
+  }
+
+  @override
+  String comparatorZoomIndependent(int percent) {
+    return 'Zoom $percent% · Independent';
+  }
+
+  @override
+  String comparatorSizeReduction(String percent) {
+    return 'Size reduced $percent';
+  }
+
+  @override
+  String comparatorSizeIncrease(String percent) {
+    return 'Size increased $percent';
+  }
+
+  @override
+  String get fileSize => 'File Size';
 
   @override
   String get sendToComparator => 'Send to Comparator';
@@ -2065,6 +2113,40 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get binaryMode => 'Binary Mode';
+
+  @override
+  String maskSourceCaption(int width, int height) {
+    return 'Mask $width×$height';
+  }
+
+  @override
+  String maskBrushBadge(String color, int size) {
+    return '$color brush · $size px';
+  }
+
+  @override
+  String get maskOutputLabel => 'Output';
+
+  @override
+  String maskOutputSummary(int width, int height) {
+    return 'Mask $width×$height · PNG (black & white)';
+  }
+
+  @override
+  String maskCompositeOutputSummary(int width, int height) {
+    return 'Composite $width×$height · PNG';
+  }
+
+  @override
+  String maskWillSaveTo(String path) {
+    return 'Mask will save to $path';
+  }
+
+  @override
+  String get maskSaveComposite => 'Save Composite';
+
+  @override
+  String get maskSaveMask => 'Save Mask';
 
   @override
   String get maskSaved => 'Mask saved to workspace';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1898,12 +1898,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get compareLayoutSlider => 'Slider';
 
   @override
-  String get compareModeSync => 'Sync Mode';
-
-  @override
-  String get compareModeSwap => 'Swap Mode';
-
-  @override
   String get compareSyncTransform => 'Sync Zoom & Pan';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1854,12 +1854,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get compareLayoutSlider => 'スライダー比較';
 
   @override
-  String get compareModeSync => '同期モード';
-
-  @override
-  String get compareModeSwap => 'スワップモード';
-
-  @override
   String get compareSyncTransform => 'ズーム・パンを同期';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1677,6 +1677,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get noImagesSelected => '画像が選択されていません';
 
   @override
+  String get imageLoadFailed => '画像の読み込みに失敗しました';
+
+  @override
   String get selectSourceDirectory => 'ソースディレクトリを選択';
 
   @override
@@ -1842,10 +1845,54 @@ class AppLocalizationsJa extends AppLocalizations {
   String get comparator => '比較ツール';
 
   @override
+  String get compareLayoutSideBySide => '左右に並べる';
+
+  @override
+  String get compareLayoutStacked => '上下に並べる';
+
+  @override
+  String get compareLayoutSlider => 'スライダー比較';
+
+  @override
   String get compareModeSync => '同期モード';
 
   @override
   String get compareModeSwap => 'スワップモード';
+
+  @override
+  String get compareSyncTransform => 'ズーム・パンを同期';
+
+  @override
+  String get comparatorEmptyHint => 'ファイルブラウザやタスク結果から送信するか、ライブラリから2枚選択してください';
+
+  @override
+  String get comparatorPickRaw => '元画像を選択';
+
+  @override
+  String get comparatorPickAfter => '結果画像を選択';
+
+  @override
+  String comparatorZoomSynced(int percent) {
+    return 'ズーム $percent% · 同期中';
+  }
+
+  @override
+  String comparatorZoomIndependent(int percent) {
+    return 'ズーム $percent% · 個別';
+  }
+
+  @override
+  String comparatorSizeReduction(String percent) {
+    return 'サイズ $percent 削減';
+  }
+
+  @override
+  String comparatorSizeIncrease(String percent) {
+    return 'サイズ $percent 増加';
+  }
+
+  @override
+  String get fileSize => 'ファイルサイズ';
 
   @override
   String get sendToComparator => '比較ツールに送信';
@@ -2019,6 +2066,40 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get binaryMode => 'バイナリモード';
+
+  @override
+  String maskSourceCaption(int width, int height) {
+    return 'マスク $width×$height';
+  }
+
+  @override
+  String maskBrushBadge(String color, int size) {
+    return '$colorのブラシ · $size px';
+  }
+
+  @override
+  String get maskOutputLabel => '出力';
+
+  @override
+  String maskOutputSummary(int width, int height) {
+    return 'マスク $width×$height · PNG（白黒）';
+  }
+
+  @override
+  String maskCompositeOutputSummary(int width, int height) {
+    return '合成画像 $width×$height · PNG';
+  }
+
+  @override
+  String maskWillSaveTo(String path) {
+    return 'マスクの保存先 $path';
+  }
+
+  @override
+  String get maskSaveComposite => '合成画像を保存';
+
+  @override
+  String get maskSaveMask => 'マスクを保存';
 
   @override
   String get maskSaved => 'マスクがワークスペースに保存されました';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1840,12 +1840,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get compareLayoutSlider => '滑动对比';
 
   @override
-  String get compareModeSync => '同步模式';
-
-  @override
-  String get compareModeSwap => '切换模式';
-
-  @override
   String get compareSyncTransform => '同步缩放平移';
 
   @override
@@ -4376,12 +4370,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get compareLayoutSlider => '滑動對比';
-
-  @override
-  String get compareModeSync => '同步模式';
-
-  @override
-  String get compareModeSwap => '交換模式';
 
   @override
   String get compareSyncTransform => '同步縮放平移';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1665,6 +1665,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get noImagesSelected => '未选择图像';
 
   @override
+  String get imageLoadFailed => '图像加载失败';
+
+  @override
   String get selectSourceDirectory => '选择源目录';
 
   @override
@@ -1828,10 +1831,54 @@ class AppLocalizationsZh extends AppLocalizations {
   String get comparator => '对比器';
 
   @override
+  String get compareLayoutSideBySide => '左右并排';
+
+  @override
+  String get compareLayoutStacked => '上下并排';
+
+  @override
+  String get compareLayoutSlider => '滑动对比';
+
+  @override
   String get compareModeSync => '同步模式';
 
   @override
   String get compareModeSwap => '切换模式';
+
+  @override
+  String get compareSyncTransform => '同步缩放平移';
+
+  @override
+  String get comparatorEmptyHint => '从文件浏览器或任务结果发送，也可以直接从库中选择两张图';
+
+  @override
+  String get comparatorPickRaw => '选择原图';
+
+  @override
+  String get comparatorPickAfter => '选择效果图';
+
+  @override
+  String comparatorZoomSynced(int percent) {
+    return '缩放 $percent% · 已同步';
+  }
+
+  @override
+  String comparatorZoomIndependent(int percent) {
+    return '缩放 $percent% · 独立';
+  }
+
+  @override
+  String comparatorSizeReduction(String percent) {
+    return '体积减少 $percent';
+  }
+
+  @override
+  String comparatorSizeIncrease(String percent) {
+    return '体积增加 $percent';
+  }
+
+  @override
+  String get fileSize => '文件大小';
 
   @override
   String get sendToComparator => '发送至对比器';
@@ -2005,6 +2052,40 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get binaryMode => '二值化模式';
+
+  @override
+  String maskSourceCaption(int width, int height) {
+    return '蒙版 $width×$height';
+  }
+
+  @override
+  String maskBrushBadge(String color, int size) {
+    return '$color笔刷 · $size px';
+  }
+
+  @override
+  String get maskOutputLabel => '输出';
+
+  @override
+  String maskOutputSummary(int width, int height) {
+    return '遮罩 $width×$height · PNG（黑白）';
+  }
+
+  @override
+  String maskCompositeOutputSummary(int width, int height) {
+    return '合成图 $width×$height · PNG';
+  }
+
+  @override
+  String maskWillSaveTo(String path) {
+    return '遮罩将存入 $path';
+  }
+
+  @override
+  String get maskSaveComposite => '保存合成图';
+
+  @override
+  String get maskSaveMask => '保存遮罩';
 
   @override
   String get maskSaved => '蒙版已保存至工作区';
@@ -4122,6 +4203,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get noImagesSelected => '未選取圖片';
 
   @override
+  String get imageLoadFailed => '圖片載入失敗';
+
+  @override
   String get selectSourceDirectory => '選取來源目錄';
 
   @override
@@ -4285,10 +4369,54 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get comparator => '比較器';
 
   @override
+  String get compareLayoutSideBySide => '左右並排';
+
+  @override
+  String get compareLayoutStacked => '上下並排';
+
+  @override
+  String get compareLayoutSlider => '滑動對比';
+
+  @override
   String get compareModeSync => '同步模式';
 
   @override
   String get compareModeSwap => '交換模式';
+
+  @override
+  String get compareSyncTransform => '同步縮放平移';
+
+  @override
+  String get comparatorEmptyHint => '從檔案瀏覽器或任務結果傳送，也可以直接從庫中選取兩張圖';
+
+  @override
+  String get comparatorPickRaw => '選取原圖';
+
+  @override
+  String get comparatorPickAfter => '選取效果圖';
+
+  @override
+  String comparatorZoomSynced(int percent) {
+    return '縮放 $percent% · 已同步';
+  }
+
+  @override
+  String comparatorZoomIndependent(int percent) {
+    return '縮放 $percent% · 獨立';
+  }
+
+  @override
+  String comparatorSizeReduction(String percent) {
+    return '體積減少 $percent';
+  }
+
+  @override
+  String comparatorSizeIncrease(String percent) {
+    return '體積增加 $percent';
+  }
+
+  @override
+  String get fileSize => '檔案大小';
 
   @override
   String get sendToComparator => '發送到比較器';
@@ -4462,6 +4590,40 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get binaryMode => '二進制模式';
+
+  @override
+  String maskSourceCaption(int width, int height) {
+    return '遮罩 $width×$height';
+  }
+
+  @override
+  String maskBrushBadge(String color, int size) {
+    return '$color筆刷 · $size px';
+  }
+
+  @override
+  String get maskOutputLabel => '輸出';
+
+  @override
+  String maskOutputSummary(int width, int height) {
+    return '遮罩 $width×$height · PNG（黑白）';
+  }
+
+  @override
+  String maskCompositeOutputSummary(int width, int height) {
+    return '合成圖 $width×$height · PNG';
+  }
+
+  @override
+  String maskWillSaveTo(String path) {
+    return '遮罩將存入 $path';
+  }
+
+  @override
+  String get maskSaveComposite => '儲存合成圖';
+
+  @override
+  String get maskSaveMask => '儲存遮罩';
 
   @override
   String get maskSaved => '遮罩已儲存到工作區';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -823,6 +823,7 @@
   "clearTempWorkspace": "清空工作区",
   "dropFilesHere": "将图片拖放到此处以添加到临时工作区",
   "noImagesSelected": "未选择图像",
+  "imageLoadFailed": "图像加载失败",
   "selectSourceDirectory": "选择源目录",
   "removeFolderTooltip": "移除文件夹",
   "removeFolderConfirmTitle": "移除文件夹？",
@@ -928,8 +929,48 @@
   "compressReferenceImagesDesc": "发送前将超过 3MB 的图片重新编码为 JPEG，以减小请求体积",
   "taskSubmitted": "任务已提交至队列",
   "comparator": "对比器",
+  "compareLayoutSideBySide": "左右并排",
+  "compareLayoutStacked": "上下并排",
+  "compareLayoutSlider": "滑动对比",
   "compareModeSync": "同步模式",
   "compareModeSwap": "切换模式",
+  "compareSyncTransform": "同步缩放平移",
+  "comparatorEmptyHint": "从文件浏览器或任务结果发送，也可以直接从库中选择两张图",
+  "comparatorPickRaw": "选择原图",
+  "comparatorPickAfter": "选择效果图",
+  "comparatorZoomSynced": "缩放 {percent}% · 已同步",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "缩放 {percent}% · 独立",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "体积减少 {percent}",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "体积增加 {percent}",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "文件大小",
   "sendToComparator": "发送至对比器",
   "sendToComparatorRaw": "设置为对比原图",
   "sendToComparatorAfter": "设置为对比效果图",
@@ -1039,6 +1080,61 @@
   "saveToTemp": "保存至工作区",
   "saveMaskToTemp": "保存遮罩至工作区",
   "binaryMode": "二值化模式",
+  "maskSourceCaption": "蒙版 {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color}笔刷 · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "输出",
+  "maskOutputSummary": "遮罩 {width}×{height} · PNG（黑白）",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "合成图 {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "遮罩将存入 {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "保存合成图",
+  "maskSaveMask": "保存遮罩",
   "maskSaved": "蒙版已保存至工作区",
   "maskSaveError": "保存蒙版失败: {error}",
   "@maskSaveError": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -932,8 +932,6 @@
   "compareLayoutSideBySide": "左右并排",
   "compareLayoutStacked": "上下并排",
   "compareLayoutSlider": "滑动对比",
-  "compareModeSync": "同步模式",
-  "compareModeSwap": "切换模式",
   "compareSyncTransform": "同步缩放平移",
   "comparatorEmptyHint": "从文件浏览器或任务结果发送，也可以直接从库中选择两张图",
   "comparatorPickRaw": "选择原图",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -806,8 +806,6 @@
   "compareLayoutSideBySide": "左右並排",
   "compareLayoutStacked": "上下並排",
   "compareLayoutSlider": "滑動對比",
-  "compareModeSync": "同步模式",
-  "compareModeSwap": "交換模式",
   "compareSyncTransform": "同步縮放平移",
   "comparatorEmptyHint": "從檔案瀏覽器或任務結果傳送，也可以直接從庫中選取兩張圖",
   "comparatorPickRaw": "選取原圖",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -697,6 +697,7 @@
   "clearTempWorkspace": "清除工作區",
   "dropFilesHere": "將圖片拖放到此處以新增到臨時工作區",
   "noImagesSelected": "未選取圖片",
+  "imageLoadFailed": "圖片載入失敗",
   "selectSourceDirectory": "選取來源目錄",
   "removeFolderTooltip": "移除資料夾",
   "removeFolderConfirmTitle": "移除資料夾？",
@@ -802,8 +803,48 @@
   "compressReferenceImagesDesc": "傳送前將超過 3MB 的圖片重新編碼為 JPEG，以縮小請求體積",
   "taskSubmitted": "任務已提交至佇列",
   "comparator": "比較器",
+  "compareLayoutSideBySide": "左右並排",
+  "compareLayoutStacked": "上下並排",
+  "compareLayoutSlider": "滑動對比",
   "compareModeSync": "同步模式",
   "compareModeSwap": "交換模式",
+  "compareSyncTransform": "同步縮放平移",
+  "comparatorEmptyHint": "從檔案瀏覽器或任務結果傳送，也可以直接從庫中選取兩張圖",
+  "comparatorPickRaw": "選取原圖",
+  "comparatorPickAfter": "選取效果圖",
+  "comparatorZoomSynced": "縮放 {percent}% · 已同步",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "縮放 {percent}% · 獨立",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "體積減少 {percent}",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "體積增加 {percent}",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "檔案大小",
   "sendToComparator": "發送到比較器",
   "sendToComparatorRaw": "設為原始圖 (RAW)",
   "sendToComparatorAfter": "設為處理後 (Result)",
@@ -913,6 +954,61 @@
   "saveToTemp": "儲存到工作區",
   "saveMaskToTemp": "儲存遮罩到工作區",
   "binaryMode": "二進制模式",
+  "maskSourceCaption": "遮罩 {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color}筆刷 · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "輸出",
+  "maskOutputSummary": "遮罩 {width}×{height} · PNG（黑白）",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "合成圖 {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "遮罩將存入 {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "儲存合成圖",
+  "maskSaveMask": "儲存遮罩",
   "maskSaved": "遮罩已儲存到工作區",
   "maskSaveError": "儲存遮罩出錯：{error}",
   "@maskSaveError": {

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -136,8 +136,6 @@
   "compareLayoutSideBySide": "Side by Side",
   "compareLayoutStacked": "Stacked",
   "compareLayoutSlider": "Slider",
-  "compareModeSync": "Sync Mode",
-  "compareModeSwap": "Swap Mode",
   "compareSyncTransform": "Sync Zoom & Pan",
   "comparatorEmptyHint": "Send images from the file browser or a task result, or pick two from the library",
   "comparatorPickRaw": "Choose Before",

--- a/lib/l10n/src/en/workbench.arb
+++ b/lib/l10n/src/en/workbench.arb
@@ -27,6 +27,7 @@
   "clearTempWorkspace": "Clear Workspace",
   "dropFilesHere": "Drop images here to add them to temporary workspace",
   "noImagesSelected": "No images selected",
+  "imageLoadFailed": "Failed to load image",
   "selectSourceDirectory": "Select Source Directory",
   "removeFolderTooltip": "Remove folder",
   "removeFolderConfirmTitle": "Remove Folder?",
@@ -132,8 +133,48 @@
   "compressReferenceImagesDesc": "Re-encode images over 3MB to JPEG before sending, to reduce request size",
   "taskSubmitted": "Task submitted to queue",
   "comparator": "Comparator",
+  "compareLayoutSideBySide": "Side by Side",
+  "compareLayoutStacked": "Stacked",
+  "compareLayoutSlider": "Slider",
   "compareModeSync": "Sync Mode",
   "compareModeSwap": "Swap Mode",
+  "compareSyncTransform": "Sync Zoom & Pan",
+  "comparatorEmptyHint": "Send images from the file browser or a task result, or pick two from the library",
+  "comparatorPickRaw": "Choose Before",
+  "comparatorPickAfter": "Choose Result",
+  "comparatorZoomSynced": "Zoom {percent}% · Synced",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "Zoom {percent}% · Independent",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "Size reduced {percent}",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "Size increased {percent}",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "File Size",
   "sendToComparator": "Send to Comparator",
   "sendToComparatorRaw": "Set as Before (RAW)",
   "sendToComparatorAfter": "Set as After (Result)",
@@ -243,6 +284,61 @@
   "saveToTemp": "Save to Workspace",
   "saveMaskToTemp": "Save Mask to Workspace",
   "binaryMode": "Binary Mode",
+  "maskSourceCaption": "Mask {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color} brush · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "Output",
+  "maskOutputSummary": "Mask {width}×{height} · PNG (black & white)",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "Composite {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "Mask will save to {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "Save Composite",
+  "maskSaveMask": "Save Mask",
   "maskSaved": "Mask saved to workspace",
   "maskSaveError": "Error saving mask: {error}",
   "@maskSaveError": {

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -27,6 +27,7 @@
   "clearTempWorkspace": "ワークスペースをクリア",
   "dropFilesHere": "ここに画像をドロップして一時ワークスペースに追加",
   "noImagesSelected": "画像が選択されていません",
+  "imageLoadFailed": "画像の読み込みに失敗しました",
   "selectSourceDirectory": "ソースディレクトリを選択",
   "removeFolderTooltip": "フォルダを削除",
   "removeFolderConfirmTitle": "フォルダを削除しますか？",
@@ -132,8 +133,48 @@
   "compressReferenceImagesDesc": "送信前に3MBを超える画像をJPEGに再エンコードし、リクエストサイズを削減します",
   "taskSubmitted": "タスクがキューに送信されました",
   "comparator": "比較ツール",
+  "compareLayoutSideBySide": "左右に並べる",
+  "compareLayoutStacked": "上下に並べる",
+  "compareLayoutSlider": "スライダー比較",
   "compareModeSync": "同期モード",
   "compareModeSwap": "スワップモード",
+  "compareSyncTransform": "ズーム・パンを同期",
+  "comparatorEmptyHint": "ファイルブラウザやタスク結果から送信するか、ライブラリから2枚選択してください",
+  "comparatorPickRaw": "元画像を選択",
+  "comparatorPickAfter": "結果画像を選択",
+  "comparatorZoomSynced": "ズーム {percent}% · 同期中",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "ズーム {percent}% · 個別",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "サイズ {percent} 削減",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "サイズ {percent} 増加",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "ファイルサイズ",
   "sendToComparator": "比較ツールに送信",
   "sendToComparatorRaw": "Before (RAW) として設定",
   "sendToComparatorAfter": "After (結果) として設定",
@@ -243,6 +284,61 @@
   "saveToTemp": "ワークスペースに保存",
   "saveMaskToTemp": "マスクをワークスペースに保存",
   "binaryMode": "バイナリモード",
+  "maskSourceCaption": "マスク {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color}のブラシ · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "出力",
+  "maskOutputSummary": "マスク {width}×{height} · PNG（白黒）",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "合成画像 {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "マスクの保存先 {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "合成画像を保存",
+  "maskSaveMask": "マスクを保存",
   "maskSaved": "マスクがワークスペースに保存されました",
   "maskSaveError": "マスク保存エラー: {error}",
   "@maskSaveError": {

--- a/lib/l10n/src/ja/workbench.arb
+++ b/lib/l10n/src/ja/workbench.arb
@@ -136,8 +136,6 @@
   "compareLayoutSideBySide": "左右に並べる",
   "compareLayoutStacked": "上下に並べる",
   "compareLayoutSlider": "スライダー比較",
-  "compareModeSync": "同期モード",
-  "compareModeSwap": "スワップモード",
   "compareSyncTransform": "ズーム・パンを同期",
   "comparatorEmptyHint": "ファイルブラウザやタスク結果から送信するか、ライブラリから2枚選択してください",
   "comparatorPickRaw": "元画像を選択",

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -27,6 +27,7 @@
   "clearTempWorkspace": "清空工作区",
   "dropFilesHere": "将图片拖放到此处以添加到临时工作区",
   "noImagesSelected": "未选择图像",
+  "imageLoadFailed": "图像加载失败",
   "selectSourceDirectory": "选择源目录",
   "removeFolderTooltip": "移除文件夹",
   "removeFolderConfirmTitle": "移除文件夹？",
@@ -132,8 +133,48 @@
   "compressReferenceImagesDesc": "发送前将超过 3MB 的图片重新编码为 JPEG，以减小请求体积",
   "taskSubmitted": "任务已提交至队列",
   "comparator": "对比器",
+  "compareLayoutSideBySide": "左右并排",
+  "compareLayoutStacked": "上下并排",
+  "compareLayoutSlider": "滑动对比",
   "compareModeSync": "同步模式",
   "compareModeSwap": "切换模式",
+  "compareSyncTransform": "同步缩放平移",
+  "comparatorEmptyHint": "从文件浏览器或任务结果发送，也可以直接从库中选择两张图",
+  "comparatorPickRaw": "选择原图",
+  "comparatorPickAfter": "选择效果图",
+  "comparatorZoomSynced": "缩放 {percent}% · 已同步",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "缩放 {percent}% · 独立",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "体积减少 {percent}",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "体积增加 {percent}",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "文件大小",
   "sendToComparator": "发送至对比器",
   "sendToComparatorRaw": "设置为对比原图",
   "sendToComparatorAfter": "设置为对比效果图",
@@ -243,6 +284,61 @@
   "saveToTemp": "保存至工作区",
   "saveMaskToTemp": "保存遮罩至工作区",
   "binaryMode": "二值化模式",
+  "maskSourceCaption": "蒙版 {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color}笔刷 · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "输出",
+  "maskOutputSummary": "遮罩 {width}×{height} · PNG（黑白）",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "合成图 {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "遮罩将存入 {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "保存合成图",
+  "maskSaveMask": "保存遮罩",
   "maskSaved": "蒙版已保存至工作区",
   "maskSaveError": "保存蒙版失败: {error}",
   "@maskSaveError": {

--- a/lib/l10n/src/zh/workbench.arb
+++ b/lib/l10n/src/zh/workbench.arb
@@ -136,8 +136,6 @@
   "compareLayoutSideBySide": "左右并排",
   "compareLayoutStacked": "上下并排",
   "compareLayoutSlider": "滑动对比",
-  "compareModeSync": "同步模式",
-  "compareModeSwap": "切换模式",
   "compareSyncTransform": "同步缩放平移",
   "comparatorEmptyHint": "从文件浏览器或任务结果发送，也可以直接从库中选择两张图",
   "comparatorPickRaw": "选择原图",

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -27,6 +27,7 @@
   "clearTempWorkspace": "清除工作區",
   "dropFilesHere": "將圖片拖放到此處以新增到臨時工作區",
   "noImagesSelected": "未選取圖片",
+  "imageLoadFailed": "圖片載入失敗",
   "selectSourceDirectory": "選取來源目錄",
   "removeFolderTooltip": "移除資料夾",
   "removeFolderConfirmTitle": "移除資料夾？",
@@ -132,8 +133,48 @@
   "compressReferenceImagesDesc": "傳送前將超過 3MB 的圖片重新編碼為 JPEG，以縮小請求體積",
   "taskSubmitted": "任務已提交至佇列",
   "comparator": "比較器",
+  "compareLayoutSideBySide": "左右並排",
+  "compareLayoutStacked": "上下並排",
+  "compareLayoutSlider": "滑動對比",
   "compareModeSync": "同步模式",
   "compareModeSwap": "交換模式",
+  "compareSyncTransform": "同步縮放平移",
+  "comparatorEmptyHint": "從檔案瀏覽器或任務結果傳送，也可以直接從庫中選取兩張圖",
+  "comparatorPickRaw": "選取原圖",
+  "comparatorPickAfter": "選取效果圖",
+  "comparatorZoomSynced": "縮放 {percent}% · 已同步",
+  "@comparatorZoomSynced": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorZoomIndependent": "縮放 {percent}% · 獨立",
+  "@comparatorZoomIndependent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "comparatorSizeReduction": "體積減少 {percent}",
+  "@comparatorSizeReduction": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "comparatorSizeIncrease": "體積增加 {percent}",
+  "@comparatorSizeIncrease": {
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
+  },
+  "fileSize": "檔案大小",
   "sendToComparator": "發送到比較器",
   "sendToComparatorRaw": "設為原始圖 (RAW)",
   "sendToComparatorAfter": "設為處理後 (Result)",
@@ -243,6 +284,61 @@
   "saveToTemp": "儲存到工作區",
   "saveMaskToTemp": "儲存遮罩到工作區",
   "binaryMode": "二進制模式",
+  "maskSourceCaption": "遮罩 {width}×{height}",
+  "@maskSourceCaption": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskBrushBadge": "{color}筆刷 · {size} px",
+  "@maskBrushBadge": {
+    "placeholders": {
+      "color": {
+        "type": "String"
+      },
+      "size": {
+        "type": "int"
+      }
+    }
+  },
+  "maskOutputLabel": "輸出",
+  "maskOutputSummary": "遮罩 {width}×{height} · PNG（黑白）",
+  "@maskOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskCompositeOutputSummary": "合成圖 {width}×{height} · PNG",
+  "@maskCompositeOutputSummary": {
+    "placeholders": {
+      "width": {
+        "type": "int"
+      },
+      "height": {
+        "type": "int"
+      }
+    }
+  },
+  "maskWillSaveTo": "遮罩將存入 {path}",
+  "@maskWillSaveTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "maskSaveComposite": "儲存合成圖",
+  "maskSaveMask": "儲存遮罩",
   "maskSaved": "遮罩已儲存到工作區",
   "maskSaveError": "儲存遮罩出錯：{error}",
   "@maskSaveError": {

--- a/lib/l10n/src/zh_Hant/workbench.arb
+++ b/lib/l10n/src/zh_Hant/workbench.arb
@@ -136,8 +136,6 @@
   "compareLayoutSideBySide": "左右並排",
   "compareLayoutStacked": "上下並排",
   "compareLayoutSlider": "滑動對比",
-  "compareModeSync": "同步模式",
-  "compareModeSwap": "交換模式",
   "compareSyncTransform": "同步縮放平移",
   "comparatorEmptyHint": "從檔案瀏覽器或任務結果傳送，也可以直接從庫中選取兩張圖",
   "comparatorPickRaw": "選取原圖",

--- a/lib/screens/workbench/widgets/comparator_toolbar.dart
+++ b/lib/screens/workbench/widgets/comparator_toolbar.dart
@@ -1,21 +1,40 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_icon_button.dart';
+import '../../../widgets/app_segmented_control.dart';
+import '../../../widgets/app_tool_button.dart';
 import '../workbench_layout.dart';
 
+/// The comparator's header: leave, choose an arrangement, decide whether the
+/// two panes move together, clear, and show or hide the metadata panel.
+///
+/// Built to the design spec's tool-toolbar shape — back button, hairline
+/// divider, a raised segmented track for the arrangement, then the switches —
+/// which is the same row the crop editor already draws, so switching between
+/// the two workbench tools doesn't move the furniture.
 class ComparatorToolbar extends StatelessWidget {
   const ComparatorToolbar({super.key});
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final workbenchUIState = Provider.of<WorkbenchUIState>(context);
+    final uiState = Provider.of<WorkbenchUIState>(context);
     final colorScheme = Theme.of(context).colorScheme;
+    final isNarrow = Responsive.isNarrow(context);
+
+    final hasImages =
+        uiState.comparatorRawPath != null || uiState.comparatorAfterPath != null;
+    // The curtain layers both images through one transform, so there is
+    // nothing left for a sync switch to decide.
+    final syncApplies = uiState.comparatorLayout != ComparatorLayout.slider;
 
     return Container(
-      height: 52,
+      height: 58,
       padding: const EdgeInsets.symmetric(horizontal: 16),
       decoration: BoxDecoration(
         color: colorScheme.surface,
@@ -23,42 +42,93 @@ class ComparatorToolbar extends StatelessWidget {
       ),
       child: Row(
         children: [
-          // Comparator Controls
-          ToggleButtons(
-            isSelected: [workbenchUIState.isComparatorSyncMode, !workbenchUIState.isComparatorSyncMode],
-            onPressed: (index) {
-              if (workbenchUIState.isComparatorSyncMode != (index == 0)) {
-                workbenchUIState.toggleComparatorMode();
+          AppIconButton(
+            icon: Icons.arrow_back,
+            tooltip: l10n.back,
+            onPressed: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
+          ),
+          _divider(colorScheme),
+
+          // The arrangement and the switches share one scroller: a narrow
+          // window scrolls them out of reach rather than clipping them.
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  AppSegmentedControl<ComparatorLayout>(
+                    value: uiState.comparatorLayout,
+                    onChanged: uiState.setComparatorLayout,
+                    style: AppSegmentStyle.raised,
+                    compact: true,
+                    // A phone has room for the three arrangements or for their
+                    // names, not both.
+                    iconOnly: isNarrow,
+                    segments: [
+                      AppSegment(
+                        value: ComparatorLayout.sideBySide,
+                        label: l10n.compareLayoutSideBySide,
+                        icon: Icons.vertical_split,
+                      ),
+                      AppSegment(
+                        value: ComparatorLayout.stacked,
+                        label: l10n.compareLayoutStacked,
+                        icon: Icons.horizontal_split,
+                      ),
+                      AppSegment(
+                        value: ComparatorLayout.slider,
+                        label: l10n.compareLayoutSlider,
+                        icon: Icons.compare,
+                      ),
+                    ],
+                  ),
+                  _divider(colorScheme),
+                  AppToolButton(
+                    icon: Icons.link,
+                    label: l10n.compareSyncTransform,
+                    showLabel: !isNarrow,
+                    active: syncApplies && uiState.comparatorSyncTransform,
+                    onPressed: syncApplies ? uiState.toggleComparatorSyncTransform : null,
+                  ),
+                  const SizedBox(width: 4),
+                  AppToolButton(
+                    icon: Icons.delete_outline,
+                    label: l10n.clear,
+                    showLabel: !isNarrow,
+                    onPressed: hasImages ? uiState.clearComparator : null,
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(width: 12),
+          AppIconButton(
+            icon: Icons.info_outline,
+            tooltip: l10n.metadata,
+            // On desktop the panel is part of the layout and this switches it;
+            // on narrow it is a drawer, which is opened rather than toggled —
+            // so "on" is only ever claimed where it is true.
+            selected: !isNarrow && uiState.comparatorShowMetadata,
+            onPressed: () {
+              if (isNarrow) {
+                context.read<WorkbenchLayoutState>().openRightPanel();
+              } else {
+                uiState.toggleComparatorMetadata();
               }
             },
-            borderRadius: BorderRadius.circular(8),
-            constraints: const BoxConstraints(minHeight: 32, minWidth: 48),
-            children: [
-              Tooltip(message: l10n.compareModeSync, child: const Icon(Icons.view_column, size: 18)),
-              Tooltip(message: l10n.compareModeSwap, child: const Icon(Icons.view_stream, size: 18)),
-            ],
-          ),
-          const SizedBox(width: 16),
-          
-          // Clear Button
-          IconButton(
-            icon: const Icon(Icons.cleaning_services_outlined, size: 20),
-            onPressed: () => workbenchUIState.clearComparator(),
-            tooltip: l10n.clear,
-            visualDensity: VisualDensity.compact,
-          ),
-          
-          const Spacer(),
-
-          // Right Panel Trigger (if needed, but usually panel state is handled elsewhere)
-          IconButton(
-            icon: const Icon(Icons.info_outline),
-            onPressed: () => context.read<WorkbenchLayoutState>().openRightPanel(),
-            tooltip: l10n.metadata,
-            visualDensity: VisualDensity.compact,
           ),
         ],
       ),
     );
   }
+
+  Widget _divider(ColorScheme colorScheme) => Container(
+        width: 1,
+        height: 26,
+        margin: const EdgeInsets.symmetric(horizontal: 12),
+        // An explicit box rather than VerticalDivider, which collapses to
+        // nothing under a Row's loose height constraint.
+        color: colorScheme.outlineVariant.withValues(alpha: 0.7),
+      );
 }

--- a/lib/screens/workbench/widgets/comparator_view.dart
+++ b/lib/screens/workbench/widgets/comparator_view.dart
@@ -3,8 +3,15 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../core/design_tokens.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+
+/// Radius of a pane inside the canvas. Deliberately the smallest step on the
+/// ladder: the panes sit 2px apart on a flat ground and read as one surface
+/// split in two, not as two cards.
+const double _kPaneRadius = AppRadius.xs;
 
 class ComparatorView extends StatefulWidget {
   const ComparatorView({super.key});
@@ -14,315 +21,635 @@ class ComparatorView extends StatefulWidget {
 }
 
 class _ComparatorViewState extends State<ComparatorView> {
-  final TransformationController _controller1 = TransformationController();
-  final TransformationController _controller2 = TransformationController();
+  final TransformationController _rawController = TransformationController();
+  final TransformationController _afterController = TransformationController();
+
+  /// Mirrors [WorkbenchUIState.comparatorSyncTransform], read in `build` so
+  /// the listeners below know whether to copy a transform across.
+  bool _sync = true;
+
+  /// Guards the mirror against the write it just made coming back the other
+  /// way.
+  bool _mirroring = false;
+
   double _scanRatio = 0.5;
 
   @override
   void initState() {
     super.initState();
-    _controller1.addListener(_syncControllers);
+    _rawController.addListener(_mirrorFromRaw);
+    _afterController.addListener(_mirrorFromAfter);
   }
 
-  void _syncControllers() {
-    if (_controller1.value != _controller2.value) {
-      _controller2.value = _controller1.value;
-    }
+  void _mirrorFromRaw() => _mirror(_rawController, _afterController);
+  void _mirrorFromAfter() => _mirror(_afterController, _rawController);
+
+  /// Copies one pane's zoom/pan onto the other while sync is on.
+  ///
+  /// Two-way rather than the old one-way copy: with a controller on each pane
+  /// both are interactive, and mirroring only the left one meant panning the
+  /// right pane silently broke the alignment the mode exists to hold.
+  void _mirror(TransformationController from, TransformationController to) {
+    if (!_sync || _mirroring || from.value == to.value) return;
+    _mirroring = true;
+    to.value = from.value;
+    _mirroring = false;
   }
 
   @override
   void dispose() {
-    _controller1.removeListener(_syncControllers);
-    _controller1.dispose();
-    _controller2.dispose();
+    _rawController.removeListener(_mirrorFromRaw);
+    _afterController.removeListener(_mirrorFromAfter);
+    _rawController.dispose();
+    _afterController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final workbenchUIState = Provider.of<WorkbenchUIState>(context);
+    final uiState = Provider.of<WorkbenchUIState>(context);
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
 
-    if (workbenchUIState.comparatorRawPath == null && workbenchUIState.comparatorAfterPath == null) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.compare, size: 64, color: colorScheme.outline),
-            const SizedBox(height: 16),
-            Text(
-              l10n.sendToComparator,
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: colorScheme.onSurfaceVariant),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              l10n.selectFromLibrary,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(color: colorScheme.outline),
-            ),
-            const SizedBox(height: 20),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _buildDropHintCard(l10n.labelRaw, colorScheme.primaryContainer, colorScheme.onPrimaryContainer, Icons.photo_outlined),
-                const SizedBox(width: 16),
-                _buildDropHintCard(l10n.labelAfter, colorScheme.tertiaryContainer, colorScheme.onTertiaryContainer, Icons.auto_fix_high),
-              ],
-            ),
-          ],
-        ),
-      );
+    if (_sync != uiState.comparatorSyncTransform) {
+      _sync = uiState.comparatorSyncTransform;
+      // Turning sync back on has to bring the panes together again; doing it
+      // now would mutate a controller mid-build, so it waits for the frame.
+      if (_sync) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _mirror(_rawController, _afterController);
+        });
+      }
+    }
+
+    if (uiState.comparatorRawPath == null && uiState.comparatorAfterPath == null) {
+      return _EmptyState(l10n: l10n, colorScheme: colorScheme);
     }
 
     return Column(
       children: [
-        // Content
         Expanded(
           child: Container(
-            color: Colors.black,
-            child: workbenchUIState.isComparatorSyncMode 
-              ? _buildSyncView(workbenchUIState) 
-              : _buildSwapView(workbenchUIState),
+            color: colorScheme.surfaceContainerHigh,
+            padding: const EdgeInsets.all(2),
+            child: switch (uiState.comparatorLayout) {
+              ComparatorLayout.sideBySide => _buildSplit(uiState, l10n, Axis.horizontal),
+              ComparatorLayout.stacked => _buildSplit(uiState, l10n, Axis.vertical),
+              ComparatorLayout.slider => _buildSlider(uiState, l10n),
+            },
           ),
         ),
-        
-        // Footer
-        Container(
-          height: 24,
-          padding: const EdgeInsets.symmetric(horizontal: 8),
-          color: colorScheme.surfaceContainer,
-          child: Row(
-            children: [
-              _buildFooterLabel(l10n.labelRaw, colorScheme.primary),
-              const SizedBox(width: 4),
-              Expanded(
-                child: Text(
-                  workbenchUIState.comparatorRawPath?.split(Platform.pathSeparator).last ?? '—',
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.onSurfaceVariant),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              const SizedBox(width: 8),
-              _buildFooterLabel(l10n.labelAfter, colorScheme.tertiary),
-              const SizedBox(width: 4),
-              Expanded(
-                child: Text(
-                  workbenchUIState.comparatorAfterPath?.split(Platform.pathSeparator).last ?? '—',
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.onSurfaceVariant),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
-          ),
-        ),
+        _buildFooter(uiState, l10n, colorScheme),
       ],
     );
   }
 
-  Widget _buildSyncView(WorkbenchUIState workbenchUIState) {
+  /// Two panes across or down, each with its own badge and filename caption.
+  Widget _buildSplit(WorkbenchUIState uiState, AppLocalizations l10n, Axis axis) {
+    final panes = [
+      Expanded(
+        child: _buildPane(uiState.comparatorRawPath, l10n.labelRaw, l10n, _rawController, isAfter: false),
+      ),
+      const SizedBox(width: 2, height: 2),
+      Expanded(
+        child: _buildPane(uiState.comparatorAfterPath, l10n.labelAfter, l10n, _afterController, isAfter: true),
+      ),
+    ];
+
+    return axis == Axis.horizontal ? Row(children: panes) : Column(children: panes);
+  }
+
+  Widget _buildPane(
+    String? path,
+    String label,
+    AppLocalizations l10n,
+    TransformationController controller, {
+    required bool isAfter,
+  }) {
     final colorScheme = Theme.of(context).colorScheme;
-    return Row(
-      children: [
-        Expanded(
-          child: _buildViewer(
-            workbenchUIState.comparatorRawPath,
-            "RAW",
-            _controller1,
-            borderColor: colorScheme.primary,
-          ),
-        ),
-        const VerticalDivider(width: 1, color: Colors.white24),
-        Expanded(
-          child: _buildViewer(
-            workbenchUIState.comparatorAfterPath,
-            "AFTER",
-            _controller2,
-            borderColor: colorScheme.tertiary,
-          ),
-        ),
-      ],
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(_kPaneRadius),
+      child: Container(
+        color: colorScheme.surfaceContainerHighest,
+        child: path == null
+            ? Center(
+                child: Text(
+                  l10n.noImagesSelected,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.outline),
+                ),
+              )
+            : Stack(
+                fit: StackFit.expand,
+                children: [
+                  InteractiveViewer(
+                    transformationController: controller,
+                    minScale: 0.1,
+                    maxScale: 10.0,
+                    child: Center(child: Image.file(File(path), fit: BoxFit.contain)),
+                  ),
+                  Positioned(
+                    top: 10,
+                    left: 10,
+                    child: IgnorePointer(child: _RoleBadge(label: label, isAfter: isAfter)),
+                  ),
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    child: IgnorePointer(child: _FileNameOverlay(path: path)),
+                  ),
+                ],
+              ),
+      ),
     );
   }
 
-  Widget _buildSwapView(WorkbenchUIState workbenchUIState) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        // Handle mouse movement for scan line
-        return MouseRegion(
-          onHover: (event) {
-            setState(() {
-              _scanRatio = (event.localPosition.dx / constraints.maxWidth).clamp(0.0, 1.0);
-            });
-          },
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              // Bottom Layer: After
-              _buildViewer(workbenchUIState.comparatorAfterPath, "AFTER", _controller1, showLabel: false),
-              
-              // Top Layer: Raw (Clipped)
-              ClipRect(
-                clipper: _CurtainClipper(_scanRatio),
-                child: _buildViewer(workbenchUIState.comparatorRawPath, "RAW", _controller1, showLabel: false), // Share controller for perfect sync
-              ),
+  /// One image over the other, revealed by a draggable curtain. Both layers
+  /// ride the same controller — the reveal is only meaningful if the two are
+  /// registered pixel for pixel.
+  Widget _buildSlider(WorkbenchUIState uiState, AppLocalizations l10n) {
+    final colorScheme = Theme.of(context).colorScheme;
 
-              // Scanning Line & Handle
-              Positioned(
-                top: 0,
-                bottom: 0,
-                left: constraints.maxWidth * _scanRatio - 20, // Wider hit area
-                child: GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onHorizontalDragUpdate: (details) {
-                    setState(() {
-                      double newPos = constraints.maxWidth * _scanRatio + details.delta.dx;
-                      _scanRatio = (newPos / constraints.maxWidth).clamp(0.0, 1.0);
-                    });
-                  },
-                  child: Container(
-                    width: 40,
-                    color: Colors.transparent,
-                    child: Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        Container(
-                          width: 2,
-                          decoration: BoxDecoration(
-                            color: Colors.white70,
-                            boxShadow: [
-                              BoxShadow(color: Colors.black.withAlpha(100), blurRadius: 4),
-                            ],
-                          ),
-                        ),
-                        // Handle icon for touch
-                        Container(
-                          padding: const EdgeInsets.all(4),
-                          decoration: BoxDecoration(
-                            color: Colors.white.withAlpha(200),
-                            shape: BoxShape.circle,
-                            boxShadow: [
-                              BoxShadow(color: Colors.black.withAlpha(50), blurRadius: 4),
-                            ],
-                          ),
-                          child: const RotatedBox(
-                            quarterTurns: 1,
-                            child: Icon(Icons.unfold_more, size: 16, color: Colors.black87),
-                          ),
-                        ),
-                      ],
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(_kPaneRadius),
+      child: Container(
+        color: colorScheme.surfaceContainerHighest,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return MouseRegion(
+              onHover: (event) {
+                setState(() {
+                  _scanRatio = (event.localPosition.dx / constraints.maxWidth).clamp(0.0, 1.0);
+                });
+              },
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  _buildLayer(uiState.comparatorAfterPath, l10n),
+                  ClipRect(
+                    clipper: _CurtainClipper(_scanRatio),
+                    child: _buildLayer(uiState.comparatorRawPath, l10n),
+                  ),
+                  Positioned(
+                    top: 0,
+                    bottom: 0,
+                    left: constraints.maxWidth * _scanRatio - 20, // wider hit area
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onHorizontalDragUpdate: (details) {
+                        setState(() {
+                          final newPos = constraints.maxWidth * _scanRatio + details.delta.dx;
+                          _scanRatio = (newPos / constraints.maxWidth).clamp(0.0, 1.0);
+                        });
+                      },
+                      child: _CurtainHandle(colorScheme: colorScheme),
                     ),
                   ),
-                ),
-              ),
-
-              // Labels
-              Builder(
-                builder: (context) {
-                  final cs = Theme.of(context).colorScheme;
-                  return Stack(
-                    children: [
-                      Positioned(
-                        top: 10,
-                        left: 10,
-                        child: IgnorePointer(
-                          child: _buildLabelBadge("RAW", cs.primary, opacity: (1.0 - _scanRatio).clamp(0.4, 1.0)),
-                        ),
+                  Positioned(
+                    top: 10,
+                    left: 10,
+                    child: IgnorePointer(
+                      child: _RoleBadge(
+                        label: l10n.labelRaw,
+                        isAfter: false,
+                        opacity: (1.0 - _scanRatio).clamp(0.4, 1.0),
                       ),
-                      Positioned(
-                        top: 10,
-                        right: 10,
-                        child: IgnorePointer(
-                          child: _buildLabelBadge("AFTER", cs.tertiary, opacity: _scanRatio.clamp(0.4, 1.0)),
-                        ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 10,
+                    right: 10,
+                    child: IgnorePointer(
+                      child: _RoleBadge(
+                        label: l10n.labelAfter,
+                        isAfter: true,
+                        opacity: _scanRatio.clamp(0.4, 1.0),
                       ),
-                    ],
-                  );
-                },
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
-        );
-      }
+            );
+          },
+        ),
+      ),
     );
   }
 
-  Widget _buildDropHintCard(String label, Color bg, Color fg, IconData icon) {
+  Widget _buildLayer(String? path, AppLocalizations l10n) {
+    if (path == null) {
+      return Center(
+        child: Text(
+          l10n.noImagesSelected,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.outline,
+              ),
+        ),
+      );
+    }
+    return InteractiveViewer(
+      transformationController: _rawController,
+      minScale: 0.1,
+      maxScale: 10.0,
+      child: Center(child: Image.file(File(path), fit: BoxFit.contain)),
+    );
+  }
+
+  /// Which two files are being compared, and how the canvas is currently
+  /// navigated — the same strip the crop editor carries, so both tools state
+  /// their result in the same place.
+  Widget _buildFooter(WorkbenchUIState uiState, AppLocalizations l10n, ColorScheme colorScheme) {
     return Container(
-      width: 120,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      height: 40,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       decoration: BoxDecoration(
-        color: bg.withAlpha(180),
-        borderRadius: BorderRadius.circular(12),
+        color: colorScheme.surface,
+        border: Border(top: BorderSide(color: colorScheme.outlineVariant.withAlpha(80))),
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+      child: Row(
         children: [
-          Icon(icon, size: 24, color: fg),
-          const SizedBox(height: 6),
-          Text(label, style: Theme.of(context).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold, color: fg)),
+          Expanded(
+            child: Row(
+              children: [
+                Flexible(
+                  child: _FooterEntry(
+                    label: l10n.labelRaw,
+                    path: uiState.comparatorRawPath,
+                    isAfter: false,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Icon(Icons.arrow_right_alt, size: 16, color: colorScheme.onSurfaceVariant),
+                ),
+                Flexible(
+                  child: _FooterEntry(
+                    label: l10n.labelAfter,
+                    path: uiState.comparatorAfterPath,
+                    isAfter: true,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Rebuilt from the controller alone: a zoom readout that re-ran the
+          // whole view on every pan would re-decode both images for a number.
+          AnimatedBuilder(
+            animation: _rawController,
+            builder: (context, _) {
+              final percent = (_rawController.value.getMaxScaleOnAxis() * 100).round();
+              final synced = uiState.comparatorLayout == ComparatorLayout.slider ||
+                  uiState.comparatorSyncTransform;
+              return _StatusPill(
+                label: synced
+                    ? l10n.comparatorZoomSynced(percent)
+                    : l10n.comparatorZoomIndependent(percent),
+              );
+            },
+          ),
         ],
       ),
     );
   }
+}
 
-  Widget _buildFooterLabel(String label, Color color) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
-      decoration: BoxDecoration(
-        color: color.withAlpha(40),
-        borderRadius: BorderRadius.circular(3),
-      ),
-      child: Text(label, style: Theme.of(context).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.bold, color: color)),
-    );
-  }
+/// "RAW" / "AFTER" over the top-left of a pane.
+///
+/// The before badge stays neutral ink and the after badge takes the accent:
+/// the accent means *this is the result* here, which is the one distinction
+/// the whole screen exists to draw.
+class _RoleBadge extends StatelessWidget {
+  final String label;
+  final bool isAfter;
+  final double opacity;
 
-  Widget _buildLabelBadge(String label, Color color, {double opacity = 1.0}) {
+  const _RoleBadge({required this.label, required this.isAfter, this.opacity = 1.0});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    // Ink, not surface: these sit on a photograph, where a theme-tinted plate
+    // would tint whatever it covers.
+    final background = isAfter
+        ? colorScheme.primary.withValues(alpha: 0.85 * opacity)
+        : Colors.black.withValues(alpha: 0.72 * opacity);
+
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
       decoration: BoxDecoration(
-        color: color.withAlpha((255 * opacity).round()),
-        borderRadius: BorderRadius.circular(4),
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadius.xs),
       ),
       child: Text(
         label,
-        style: Theme.of(context).textTheme.labelSmall?.copyWith(color: Colors.white, fontWeight: FontWeight.bold),
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: isAfter ? colorScheme.onPrimary : Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
       ),
     );
   }
+}
 
-  Widget _buildViewer(String? path, String label, TransformationController controller, {bool showLabel = true, Color? borderColor}) {
-    if (path == null) {
-      return Center(
-          child: Text('No image',
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white54)));
-    }
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        InteractiveViewer(
-          transformationController: controller,
-          panEnabled: true,
-          minScale: 0.1,
-          maxScale: 10.0,
-          child: Center(child: Image.file(File(path), fit: BoxFit.contain)),
+/// The filename along the foot of a pane, on a gradient that fades into the
+/// picture rather than a bar that cuts across it.
+class _FileNameOverlay extends StatelessWidget {
+  final String path;
+
+  const _FileNameOverlay({required this.path});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Colors.transparent, Colors.black.withValues(alpha: 0.55)],
         ),
-        if (showLabel)
-          Positioned(
-            top: 8,
-            left: 8,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: borderColor ?? Colors.black54, 
-                borderRadius: BorderRadius.circular(4)
-              ),
-              child: Text(label, style: Theme.of(context).textTheme.labelSmall?.copyWith(color: Colors.white, fontWeight: FontWeight.bold)),
+      ),
+      child: Text(
+        path.split(Platform.pathSeparator).last,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Colors.white,
+              fontFamily: 'monospace',
+            ),
+      ),
+    );
+  }
+}
+
+/// One "role chip + filename" pair in the footer strip.
+class _FooterEntry extends StatelessWidget {
+  final String label;
+  final String? path;
+  final bool isAfter;
+
+  const _FooterEntry({required this.label, required this.path, required this.isAfter});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+          decoration: BoxDecoration(
+            color: isAfter ? colorScheme.accentTint : colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(AppRadius.xs),
+          ),
+          child: Text(
+            label,
+            style: textTheme.labelSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: isAfter ? colorScheme.onAccentTint : colorScheme.onSurfaceVariant,
             ),
           ),
+        ),
+        const SizedBox(width: 6),
+        Flexible(
+          child: Text(
+            path?.split(Platform.pathSeparator).last ?? '—',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: textTheme.bodySmall?.copyWith(
+              fontFamily: 'monospace',
+              color: isAfter ? colorScheme.onAccentTint : colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
       ],
     );
   }
+}
+
+/// The capsule at the right of the footer strip, matching the crop editor's.
+class _StatusPill extends StatelessWidget {
+  final String label;
+
+  const _StatusPill({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: colorScheme.accentTint,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(color: colorScheme.onAccentTint),
+      ),
+    );
+  }
+}
+
+/// The curtain's grab line: a hairline with a round grip at its middle, so it
+/// reads as draggable on touch as well as under a mouse.
+class _CurtainHandle extends StatelessWidget {
+  final ColorScheme colorScheme;
+
+  const _CurtainHandle({required this.colorScheme});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 40,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Container(
+            width: 2,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.4), blurRadius: 4)],
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(5),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+              boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.25), blurRadius: 6)],
+            ),
+            child: const RotatedBox(
+              quarterTurns: 1,
+              child: Icon(Icons.unfold_more, size: 16, color: Colors.black87),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Nothing loaded yet: what the comparator is for, and the two ways to fill it.
+class _EmptyState extends StatelessWidget {
+  final AppLocalizations l10n;
+  final ColorScheme colorScheme;
+
+  const _EmptyState({required this.l10n, required this.colorScheme});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      color: colorScheme.surfaceContainerHigh,
+      child: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 64,
+                height: 64,
+                decoration: BoxDecoration(
+                  color: colorScheme.surface,
+                  borderRadius: BorderRadius.circular(AppRadius.dialog),
+                  border: Border.all(color: colorScheme.outlineVariant),
+                ),
+                child: Icon(Icons.compare, size: 28, color: colorScheme.onSurfaceVariant),
+              ),
+              const SizedBox(height: 22),
+              Text(l10n.sendToComparator, style: textTheme.titleMedium),
+              const SizedBox(height: 6),
+              Text(
+                l10n.comparatorEmptyHint,
+                textAlign: TextAlign.center,
+                style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+              ),
+              const SizedBox(height: 22),
+              // Wrap, not Row: on a phone the two cards stack instead of
+              // being squeezed to half a label each.
+              Wrap(
+                spacing: 14,
+                runSpacing: 14,
+                alignment: WrapAlignment.center,
+                children: [
+                  _PickCard(
+                    icon: Icons.photo_outlined,
+                    title: l10n.comparatorPickRaw,
+                    subtitle: l10n.selectFromLibrary,
+                  ),
+                  _PickCard(
+                    icon: Icons.auto_fix_high,
+                    title: l10n.comparatorPickAfter,
+                    subtitle: l10n.selectFromLibrary,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A "choose an image" target. Dashed rather than outlined: the edge says the
+/// box is waiting to be filled, which a solid border reads as already being.
+///
+/// Tapping goes to the gallery — the comparator is filled from an image's
+/// context menu there, so this hands the user to the place that can do it
+/// rather than opening a second, parallel picker.
+class _PickCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  const _PickCard({required this.icon, required this.title, required this.subtitle});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return InkWell(
+      onTap: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
+      borderRadius: BorderRadius.circular(AppRadius.lg),
+      child: CustomPaint(
+        painter: _DashedBorderPainter(
+          color: colorScheme.outlineVariant,
+          radius: AppRadius.lg,
+        ),
+        child: Container(
+          width: 200,
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: colorScheme.accentTint,
+                  borderRadius: BorderRadius.circular(AppRadius.md),
+                ),
+                child: Icon(icon, size: 17, color: colorScheme.onAccentTint),
+              ),
+              const SizedBox(height: 10),
+              Text(title, style: textTheme.titleSmall),
+              const SizedBox(height: 4),
+              Text(
+                subtitle,
+                style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Draws a rounded rectangle in dashes. Flutter's [Border] can't dash, and the
+/// two drop targets are the only place in the app that needs it.
+class _DashedBorderPainter extends CustomPainter {
+  static const double _dash = 5;
+  static const double _gap = 4;
+
+  final Color color;
+  final double radius;
+
+  const _DashedBorderPainter({required this.color, required this.radius});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5;
+
+    final path = Path()
+      ..addRRect(RRect.fromRectAndRadius(Offset.zero & size, Radius.circular(radius)));
+
+    for (final metric in path.computeMetrics()) {
+      var distance = 0.0;
+      while (distance < metric.length) {
+        canvas.drawPath(
+          metric.extractPath(distance, (distance + _dash).clamp(0.0, metric.length)),
+          paint,
+        );
+        distance += _dash + _gap;
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashedBorderPainter oldDelegate) =>
+      oldDelegate.color != color || oldDelegate.radius != radius;
 }
 
 class _CurtainClipper extends CustomClipper<Rect> {
@@ -330,9 +657,7 @@ class _CurtainClipper extends CustomClipper<Rect> {
   _CurtainClipper(this.ratio);
 
   @override
-  Rect getClip(Size size) {
-    return Rect.fromLTRB(0, 0, size.width * ratio, size.height);
-  }
+  Rect getClip(Size size) => Rect.fromLTRB(0, 0, size.width * ratio, size.height);
 
   @override
   bool shouldReclip(_CurtainClipper oldClipper) => oldClipper.ratio != ratio;

--- a/lib/screens/workbench/widgets/mask_editor_toolbar.dart
+++ b/lib/screens/workbench/widgets/mask_editor_toolbar.dart
@@ -1,11 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import '../../../core/design_tokens.dart';
 import '../../../core/responsive.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../services/image_metadata_service.dart';
+import '../../../state/app_state.dart';
+import '../../../state/workbench_ui_state.dart';
 import '../../../widgets/app_button.dart';
 import '../../../widgets/app_dialog.dart';
+import '../../../widgets/app_icon_button.dart';
 
-class MaskEditorToolbar extends StatelessWidget {
+/// The mask editor's header: leave, see what is being masked, pick a colour
+/// and a brush, undo, and save.
+///
+/// Drawn to the design spec's tool-toolbar shape — back button, file caption,
+/// hairline dividers between groups, the two save actions at the right — which
+/// is the row the crop editor and the comparator also draw.
+class MaskEditorToolbar extends StatefulWidget {
   final VoidCallback onUndo;
   final VoidCallback onClear;
   final VoidCallback onSave;
@@ -38,185 +50,407 @@ class MaskEditorToolbar extends StatelessWidget {
   });
 
   @override
+  State<MaskEditorToolbar> createState() => _MaskEditorToolbarState();
+}
+
+class _MaskEditorToolbarState extends State<MaskEditorToolbar> {
+  /// Source dimensions for the caption. The view loads this too;
+  /// [ImageMetadataService] caches by path, so the second reader costs a map
+  /// lookup rather than a second decode.
+  ImageMetadata? _meta;
+  String? _metaPath;
+
+  void _loadMeta(String path) {
+    if (_metaPath == path) return;
+    _metaPath = path;
+    ImageMetadataService().getMetadata(path).then((meta) {
+      if (mounted && _metaPath == path) setState(() => _meta = meta);
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
     final isNarrow = Responsive.isNarrow(context);
+    final source = Provider.of<WorkbenchUIState>(context).maskEditorSourceImage;
+
+    if (source != null) _loadMeta(source.path);
 
     return Container(
-      height: 52,
-      padding: const EdgeInsets.symmetric(horizontal: 8),
+      height: 58,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
       decoration: BoxDecoration(
         color: colorScheme.surface,
         border: Border(bottom: BorderSide(color: colorScheme.outlineVariant.withAlpha(80))),
       ),
       child: Row(
         children: [
-          // Primary High-Frequency Actions
-          
-          _buildColorCircle(context, Colors.white, l10n.white),
-          _buildColorCircle(context, Colors.black, l10n.black),
-          if (!isBinaryMode) ...[
-            _buildColorCircle(context, Colors.red, l10n.red),
-            _buildColorCircle(context, Colors.green, l10n.green),
+          AppIconButton(
+            icon: Icons.arrow_back,
+            tooltip: l10n.back,
+            onPressed: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
+          ),
+          if (!isNarrow && source != null) ...[
+            const SizedBox(width: 10),
+            _buildFileInfo(source.name, l10n, colorScheme),
           ],
-          
-          const SizedBox(width: 8),
+          _divider(colorScheme),
+
+          // Every editing control shares one scroller: a window too narrow for
+          // them scrolls rather than clipping, the same as the crop toolbar.
           Expanded(
-            child: Row(
-              children: [
-                if (!isNarrow) ...[
-                  Icon(Icons.line_weight, size: 16, color: colorScheme.onSurfaceVariant),
-                  Expanded(
-                    flex: 2,
-                    child: Slider(
-                      value: brushSize,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  _buildColorGroup(l10n, colorScheme, isNarrow),
+                  // A phone scrolls nothing but the swatches — a homogeneous
+                  // row where a half-cut circle at the edge says plainly that
+                  // there is more. Everything else moves to a fixed position
+                  // or into the overflow menu, rather than off the end of a
+                  // scroller with nothing to say it scrolls, which is where
+                  // clear and binary mode were disappearing to.
+                  if (!isNarrow) ...[
+                    _divider(colorScheme),
+                    _buildSlider(
+                      label: l10n.brushSize,
+                      icon: Icons.brush_outlined,
+                      value: widget.brushSize,
                       min: 1,
                       max: 100,
-                      onChanged: onBrushSizeChanged,
-                      label: l10n.brushSize,
+                      width: 110,
+                      readout: widget.brushSize.round().toString(),
+                      onChanged: widget.onBrushSizeChanged,
+                      colorScheme: colorScheme,
                     ),
-                  ),
-                  const SizedBox(width: 16),
-                  Icon(Icons.opacity, size: 16, color: colorScheme.onSurfaceVariant),
-                  Expanded(
-                    flex: 1,
-                    child: Slider(
-                      value: opacity,
+                    const SizedBox(width: 16),
+                    _buildSlider(
+                      label: l10n.maskOpacity,
+                      icon: Icons.opacity,
+                      value: widget.opacity,
                       min: 0.1,
                       max: 1.0,
-                      onChanged: onOpacityChanged,
-                      label: l10n.maskOpacity,
+                      width: 84,
+                      readout: '${(widget.opacity * 100).round()}%',
+                      onChanged: widget.onOpacityChanged,
+                      colorScheme: colorScheme,
                     ),
-                  ),
-                ] else ...[
-                  const Spacer(),
-                  IconButton(
-                    icon: const Icon(Icons.line_weight),
-                    onPressed: () => _showSliderDialog(
-                      context, 
-                      l10n.brushSize, 
-                      brushSize, 1, 100, 
-                      onBrushSizeChanged,
-                      (val) => "${val.toInt()}px"
-                    ),
-                    tooltip: l10n.brushSize,
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.opacity),
-                    onPressed: () => _showSliderDialog(
-                      context, 
-                      l10n.maskOpacity, 
-                      opacity, 0.1, 1.0, 
-                      onOpacityChanged,
-                      (val) => "${(val * 100).toInt()}%"
-                    ),
-                    tooltip: l10n.maskOpacity,
-                  ),
+                    _divider(colorScheme),
+                    _buildActionIcons(l10n, colorScheme),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
-          
-          IconButton(
-            icon: const Icon(Icons.undo),
-            onPressed: hasPaths ? onUndo : null,
-            tooltip: l10n.undo,
-            visualDensity: VisualDensity.compact,
-          ),
 
-          if (!isNarrow) ...[
-            IconButton(
-              icon: Icon(isBinaryMode ? Icons.contrast : Icons.image, size: 20),
-              onPressed: onToggleBinary,
-              tooltip: l10n.binaryMode,
-            ),
-            IconButton(
-              icon: const Icon(Icons.delete_outline),
-              onPressed: hasPaths ? onClear : null,
-              tooltip: l10n.clear,
-            ),
-          ],
+          const SizedBox(width: 12),
+          _buildSaveActions(l10n, colorScheme, isNarrow),
+        ],
+      ),
+    );
+  }
 
-          // Overflow Menu for Mobile
-          if (isNarrow) 
-            PopupMenuButton<String>(
-              icon: const Icon(Icons.more_horiz),
-              onSelected: (value) {
-                if (value == 'binary') onToggleBinary();
-                if (value == 'clear') onClear();
-                if (value == 'save_temp') onSave();
-                if (value == 'save_mask') onSaveMask();
-              },
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: 'binary',
-                  child: ListTile(
-                    leading: Icon(isBinaryMode ? Icons.contrast : Icons.image),
-                    title: Text(l10n.binaryMode),
-                    dense: true,
-                  ),
-                ),
-                const PopupMenuDivider(),
-                PopupMenuItem(
-                  value: 'save_temp',
-                  child: ListTile(
-                    leading: const Icon(Icons.save_outlined),
-                    title: Text(l10n.saveToTemp),
-                    dense: true,
-                  ),
-                ),
-                PopupMenuItem(
-                  value: 'save_mask',
-                  child: ListTile(
-                    leading: const Icon(Icons.layers_outlined),
-                    title: Text(l10n.saveMaskToTemp),
-                    dense: true,
-                  ),
-                ),
-                const PopupMenuDivider(),
-                PopupMenuItem(
-                  value: 'clear',
-                  child: ListTile(
-                    leading: Icon(Icons.delete_outline, color: colorScheme.error),
-                    title: Text(l10n.clear, style: TextStyle(color: colorScheme.error)),
-                    dense: true,
-                  ),
-                ),
-              ],
-            ),
+  Widget _divider(ColorScheme colorScheme) => Container(
+        width: 1,
+        height: 26,
+        margin: const EdgeInsets.symmetric(horizontal: 12),
+        // An explicit box rather than VerticalDivider, which collapses to
+        // nothing under a Row's loose height constraint.
+        color: colorScheme.outlineVariant.withValues(alpha: 0.7),
+      );
 
-          const VerticalDivider(width: 16, indent: 12, endIndent: 12),
-          
-          if (!isNarrow) ...[
-            AppButton(
-              label: l10n.saveToTemp,
-              variant: AppButtonVariant.secondary,
-              onPressed: onSave,
-            ),
-            const SizedBox(width: 8),
-            AppButton(
-              label: l10n.saveMaskToTemp,
-              onPressed: onSaveMask,
-            ),
-          ] else
-            AppButton(
-              label: l10n.saveMaskToTemp,
-              onPressed: onSaveMask,
+  /// Filename over what the export will be — the canvas only ever shows a
+  /// fitted preview, so without this the mask's real resolution is invisible.
+  Widget _buildFileInfo(String name, AppLocalizations l10n, ColorScheme colorScheme) {
+    final textTheme = Theme.of(context).textTheme;
+    final meta = _meta;
+
+    return SizedBox(
+      width: 180,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(name, style: textTheme.titleSmall, maxLines: 1, overflow: TextOverflow.ellipsis),
+          if (meta != null && meta.width > 0)
+            Text(
+              l10n.maskSourceCaption(meta.width, meta.height),
+              style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
         ],
       ),
     );
   }
 
+  /// The brush colours. Binary mode drops red and green: they would be
+  /// flattened to one of the two extremes on export, so offering them there
+  /// would be offering a choice the file cannot keep.
+  Widget _buildColorGroup(AppLocalizations l10n, ColorScheme colorScheme, bool isNarrow) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (!isNarrow) ...[
+          Text(
+            l10n.maskColor,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+          ),
+          const SizedBox(width: 8),
+        ],
+        _buildColorCircle(Colors.white, l10n.white),
+        _buildColorCircle(Colors.black, l10n.black),
+        if (!widget.isBinaryMode) ...[
+          _buildColorCircle(Colors.red, l10n.red),
+          _buildColorCircle(Colors.green, l10n.green),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildColorCircle(Color color, String tooltip) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isSelected = widget.selectedColor == color;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      child: Tooltip(
+        message: tooltip,
+        child: GestureDetector(
+          onTap: () => widget.onColorChanged(color),
+          child: Container(
+            width: 26,
+            height: 26,
+            padding: const EdgeInsets.all(3),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              // The selection ring stands off the swatch rather than thickening
+              // its edge — a heavier border on a white swatch reads as a
+              // different colour, not as a selection.
+              border: Border.all(
+                color: isSelected ? colorScheme.primary : Colors.transparent,
+                width: 1.5,
+              ),
+            ),
+            child: Container(
+              decoration: BoxDecoration(
+                color: color,
+                shape: BoxShape.circle,
+                border: Border.all(color: colorScheme.outlineVariant),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Label, track and the value it is currently at. The number is the point:
+  /// a brush slider with no readout can only be set by drawing and undoing.
+  Widget _buildSlider({
+    required String label,
+    required IconData icon,
+    required double value,
+    required double min,
+    required double max,
+    required double width,
+    required String readout,
+    required ValueChanged<double> onChanged,
+    required ColorScheme colorScheme,
+  }) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Glyph and readout, no spelled-out label: the words are what pushed
+        // the clear button off the end of the row, and between the icon, the
+        // tooltip and the live number the control is not ambiguous.
+        Tooltip(
+          message: label,
+          child: Icon(icon, size: AppSize.iconSm, color: colorScheme.onSurfaceVariant),
+        ),
+        const SizedBox(width: 6),
+        SizedBox(
+          width: width,
+          child: SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 4,
+              overlayColor: colorScheme.primary.withValues(alpha: 0.08),
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6.5),
+              overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+            ),
+            child: Slider(value: value, min: min, max: max, onChanged: onChanged, label: label),
+          ),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          readout,
+          style: textTheme.labelMedium?.copyWith(fontFamily: 'monospace', fontWeight: FontWeight.w600),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActionIcons(AppLocalizations l10n, ColorScheme colorScheme) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppIconButton(
+          icon: Icons.undo,
+          tooltip: l10n.undo,
+          onPressed: widget.hasPaths ? widget.onUndo : null,
+        ),
+        const SizedBox(width: 6),
+        AppIconButton(
+          icon: widget.isBinaryMode ? Icons.contrast : Icons.image_outlined,
+          tooltip: l10n.binaryMode,
+          selected: widget.isBinaryMode,
+          onPressed: widget.onToggleBinary,
+        ),
+        const SizedBox(width: 6),
+        AppIconButton(
+          icon: Icons.delete_outline,
+          tooltip: l10n.clear,
+          color: widget.hasPaths ? colorScheme.error : null,
+          onPressed: widget.hasPaths ? widget.onClear : null,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSaveActions(AppLocalizations l10n, ColorScheme colorScheme, bool isNarrow) {
+    if (isNarrow) {
+      // Everything the narrow row dropped, spelled out. The mask save stays a
+      // button of its own: it is what the screen is for, and a phone has room
+      // for exactly one such button.
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Undo keeps a fixed place of its own: it is the one control a hand
+          // reaches for mid-stroke, and a menu is two taps too many for it.
+          AppIconButton(
+            icon: Icons.undo,
+            tooltip: l10n.undo,
+            onPressed: widget.hasPaths ? widget.onUndo : null,
+          ),
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_horiz),
+            onSelected: (value) {
+              switch (value) {
+                case 'brush':
+                  _showSliderDialog(
+                    l10n.brushSize,
+                    widget.brushSize,
+                    1,
+                    100,
+                    widget.onBrushSizeChanged,
+                    (val) => '${val.toInt()}px',
+                  );
+                case 'opacity':
+                  _showSliderDialog(
+                    l10n.maskOpacity,
+                    widget.opacity,
+                    0.1,
+                    1.0,
+                    widget.onOpacityChanged,
+                    (val) => '${(val * 100).toInt()}%',
+                  );
+                case 'binary':
+                  widget.onToggleBinary();
+                case 'composite':
+                  widget.onSave();
+                case 'clear':
+                  widget.onClear();
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'brush',
+                child: ListTile(
+                  leading: const Icon(Icons.brush_outlined),
+                  title: Text(l10n.brushSize),
+                  trailing: Text(widget.brushSize.round().toString()),
+                  dense: true,
+                ),
+              ),
+              PopupMenuItem(
+                value: 'opacity',
+                child: ListTile(
+                  leading: const Icon(Icons.opacity),
+                  title: Text(l10n.maskOpacity),
+                  trailing: Text('${(widget.opacity * 100).round()}%'),
+                  dense: true,
+                ),
+              ),
+              PopupMenuItem(
+                value: 'binary',
+                child: ListTile(
+                  leading: Icon(
+                    widget.isBinaryMode ? Icons.contrast : Icons.image_outlined,
+                    color: widget.isBinaryMode ? colorScheme.primary : null,
+                  ),
+                  title: Text(l10n.binaryMode),
+                  dense: true,
+                ),
+              ),
+              const PopupMenuDivider(),
+              PopupMenuItem(
+                value: 'composite',
+                child: ListTile(
+                  leading: const Icon(Icons.layers_outlined),
+                  title: Text(l10n.maskSaveComposite),
+                  dense: true,
+                ),
+              ),
+              PopupMenuItem(
+                value: 'clear',
+                enabled: widget.hasPaths,
+                child: ListTile(
+                  leading: Icon(Icons.delete_outline, color: colorScheme.error),
+                  title: Text(l10n.clear, style: TextStyle(color: colorScheme.error)),
+                  dense: true,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 4),
+          // No icon on a phone: the glyph is the first thing worth spending
+          // for the swatches beside it, and the verb is not.
+          AppButton(label: l10n.maskSaveMask, onPressed: widget.onSaveMask),
+        ],
+      );
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppButton(
+          label: l10n.maskSaveComposite,
+          icon: Icons.save_outlined,
+          variant: AppButtonVariant.secondary,
+          onPressed: widget.onSave,
+        ),
+        const SizedBox(width: 8),
+        AppButton(
+          label: l10n.maskSaveMask,
+          secondaryLabel: l10n.cropResizeSaveDestinationHint,
+          icon: Icons.save_outlined,
+          onPressed: widget.onSaveMask,
+        ),
+      ],
+    );
+  }
+
   void _showSliderDialog(
-    BuildContext context, 
-    String title, 
-    double currentValue, 
-    double min, 
-    double max, 
+    String title,
+    double currentValue,
+    double min,
+    double max,
     Function(double) onChanged,
-    String Function(double) displayConverter
+    String Function(double) displayConverter,
   ) {
     // Outside the builder, so it survives the rebuilds the drag causes.
     var val = currentValue;
@@ -251,28 +485,6 @@ class MaskEditorToolbar extends StatelessWidget {
           onPressed: () => Navigator.pop(context),
         ),
       ],
-    );
-  }
-
-  Widget _buildColorCircle(BuildContext context, Color color, String tooltip) {
-    bool isSelected = selectedColor == color;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 4),
-      child: GestureDetector(
-        onTap: () => onColorChanged(color),
-        child: Container(
-          width: 20,
-          height: 20,
-          decoration: BoxDecoration(
-            color: color,
-            shape: BoxShape.circle,
-            border: Border.all(
-              color: isSelected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.outline,
-              width: isSelected ? 2 : 1,
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/screens/workbench/widgets/mask_editor_view.dart
+++ b/lib/screens/workbench/widgets/mask_editor_view.dart
@@ -4,11 +4,17 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../../core/app_theme.dart';
+import '../../../core/design_tokens.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../state/app_state.dart';
 import '../../../state/workbench_ui_state.dart';
+import '../../../widgets/app_button.dart';
 import '../../../widgets/drawing_canvas.dart';
+
+/// Radius of the image plate on the canvas — the same smallest step the
+/// comparator's panes take, so a picture sitting on a workbench canvas has one
+/// shape across the tools.
+const double _kCanvasImageRadius = AppRadius.xs;
 
 class MaskEditorView extends StatefulWidget {
   final List<DrawingPath> paths;
@@ -39,6 +45,8 @@ class MaskEditorView extends StatefulWidget {
 }
 
 class _MaskEditorViewState extends State<MaskEditorView> {
+  final TransformationController _controller = TransformationController();
+
   ui.Image? _imageInfo;
   bool _isLoading = true;
   String? _lastPath;
@@ -47,6 +55,12 @@ class _MaskEditorViewState extends State<MaskEditorView> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _checkImageChange();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 
   Future<void> _checkImageChange() async {
@@ -81,6 +95,23 @@ class _MaskEditorViewState extends State<MaskEditorView> {
     }
   }
 
+  /// Zooms about the middle of the viewport rather than the scene's origin —
+  /// scaling the raw matrix walks the picture off the top-left corner, which
+  /// is what a `+` button that "loses" the image is doing.
+  void _setScale(double target, Size viewport) {
+    final matrix = _controller.value.clone();
+    final current = matrix.getMaxScaleOnAxis();
+    final factor = target.clamp(0.1, 10.0) / current;
+    if ((factor - 1).abs() < 0.001) return;
+
+    final scenePoint = _controller.toScene(Offset(viewport.width / 2, viewport.height / 2));
+    matrix
+      ..translateByDouble(scenePoint.dx, scenePoint.dy, 0, 1)
+      ..scaleByDouble(factor, factor, 1, 1)
+      ..translateByDouble(-scenePoint.dx, -scenePoint.dy, 0, 1);
+    _controller.value = matrix;
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -88,101 +119,401 @@ class _MaskEditorViewState extends State<MaskEditorView> {
     final workbenchUIState = Provider.of<WorkbenchUIState>(context);
     final sourceImage = workbenchUIState.maskEditorSourceImage;
 
-    if (sourceImage == null) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.brush_outlined, size: 64, color: colorScheme.outlineVariant),
-            const SizedBox(height: 16),
-            Text(l10n.noImagesSelected, style: TextStyle(color: colorScheme.onSurfaceVariant)),
-            const SizedBox(height: 16),
-            FilledButton.tonalIcon(
-              onPressed: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
-              icon: const Icon(Icons.photo_library_outlined),
-              label: Text(l10n.goToGallery),
-              style: tonalButtonStyle(colorScheme),
-            ),
-          ],
-        ),
-      );
-    }
-
-    if (_isLoading) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
-    if (_imageInfo == null) {
-      return const Center(child: Text("Failed to load image"));
-    }
-
+    // The output strip stays whatever the canvas is showing: it is the
+    // screen's chrome, not a result panel, and a bar that appears only once an
+    // image arrives makes the whole layout jump under the user.
     return Column(
       children: [
-        if (widget.isBinaryMode)
-          Container(
-            width: double.infinity,
-            color: colorScheme.tertiaryContainer,
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-            child: Row(
-              children: [
-                Icon(Icons.contrast, size: 16, color: colorScheme.onTertiaryContainer),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    l10n.binaryModeActive,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onTertiaryContainer),
-                  ),
-                ),
-              ],
-            ),
-          ),
         Expanded(
           child: Container(
-            color: Colors.black,
-            child: InteractiveViewer(
-              maxScale: 10.0,
-              minScale: 0.1,
-              child: Center(
-                child: AspectRatio(
-                  aspectRatio: _imageInfo!.width / _imageInfo!.height,
-                  child: RepaintBoundary(
-                    key: widget.repaintKey,
-                    child: Stack(
-                      fit: StackFit.expand,
-                      children: [
-                        if (widget.isBinaryMode)
-                          Container(color: Colors.black)
-                        else
-                          Image.file(File(sourceImage.path), fit: BoxFit.fill),
+            color: colorScheme.surfaceContainerHigh,
+            child: sourceImage == null
+                ? _buildEmptyState(l10n, colorScheme)
+                : _isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : _imageInfo == null
+                        ? Center(
+                            child: Text(
+                              l10n.imageLoadFailed,
+                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                            ),
+                          )
+                        : _buildCanvas(sourceImage.path, l10n, colorScheme),
+          ),
+        ),
+        _MaskOutputBar(
+          image: _imageInfo,
+          isBinaryMode: widget.isBinaryMode,
+          l10n: l10n,
+          colorScheme: colorScheme,
+        ),
+      ],
+    );
+  }
 
-                        MouseRegion(
-                          cursor: SystemMouseCursors.none,
-                          onHover: (event) => widget.onHover(event.localPosition),
-                          onExit: (event) => widget.onHover(null),
-                          child: GestureDetector(
-                            onPanStart: (details) => widget.onPanStart(details.localPosition),
-                            onPanUpdate: (details) => widget.onPanUpdate(details.localPosition),
-                            child: CustomPaint(
-                              painter: MaskPainter(paths: widget.paths),
-                              foregroundPainter: widget.mousePosition != null
-                                  ? BrushPreviewPainter(
-                                      position: widget.mousePosition!,
-                                      size: widget.brushSize,
-                                      color: widget.selectedColor,
-                                    )
-                                  : null,
+  Widget _buildEmptyState(AppLocalizations l10n, ColorScheme colorScheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              color: colorScheme.surface,
+              borderRadius: BorderRadius.circular(AppRadius.dialog),
+              border: Border.all(color: colorScheme.outlineVariant),
+            ),
+            child: Icon(Icons.brush_outlined, size: 28, color: colorScheme.onSurfaceVariant),
+          ),
+          const SizedBox(height: 22),
+          Text(l10n.noImagesSelected, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 16),
+          AppButton(
+            label: l10n.goToGallery,
+            icon: Icons.photo_library_outlined,
+            variant: AppButtonVariant.secondary,
+            onPressed: () => Provider.of<AppState>(context, listen: false).setWorkbenchTab(0),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCanvas(String path, AppLocalizations l10n, ColorScheme colorScheme) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final viewport = Size(constraints.maxWidth, constraints.maxHeight);
+
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: InteractiveViewer(
+                transformationController: _controller,
+                maxScale: 10.0,
+                minScale: 0.1,
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: AspectRatio(
+                      aspectRatio: _imageInfo!.width / _imageInfo!.height,
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(_kCanvasImageRadius),
+                          boxShadow: [
+                            BoxShadow(
+                              color: colorScheme.shadow.withValues(alpha: 0.18),
+                              blurRadius: 24,
+                              offset: const Offset(0, 8),
+                            ),
+                          ],
+                        ),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(_kCanvasImageRadius),
+                          // The boundary is inside the clip and outside the
+                          // shadow: the export is the picture and the strokes,
+                          // never the canvas dressing around them.
+                          child: RepaintBoundary(
+                            key: widget.repaintKey,
+                            child: Stack(
+                              fit: StackFit.expand,
+                              children: [
+                                if (widget.isBinaryMode)
+                                  const ColoredBox(color: Colors.black)
+                                else
+                                  Image.file(File(path), fit: BoxFit.fill),
+                                MouseRegion(
+                                  cursor: SystemMouseCursors.none,
+                                  onHover: (event) => widget.onHover(event.localPosition),
+                                  onExit: (event) => widget.onHover(null),
+                                  child: GestureDetector(
+                                    onPanStart: (details) => widget.onPanStart(details.localPosition),
+                                    onPanUpdate: (details) => widget.onPanUpdate(details.localPosition),
+                                    child: CustomPaint(
+                                      painter: MaskPainter(paths: widget.paths),
+                                      foregroundPainter: widget.mousePosition != null
+                                          ? BrushPreviewPainter(
+                                              position: widget.mousePosition!,
+                                              size: widget.brushSize,
+                                              color: widget.selectedColor,
+                                            )
+                                          : null,
+                                    ),
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
                         ),
-                      ],
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
+
+            // What the brush will lay down, over the canvas' top-left — the
+            // same place the crop editor names its source.
+            Positioned(
+              left: 16,
+              top: 14,
+              child: IgnorePointer(child: _BrushBadge(
+                color: widget.selectedColor,
+                size: widget.brushSize,
+                isBinaryMode: widget.isBinaryMode,
+                l10n: l10n,
+              )),
+            ),
+
+            Positioned(
+              right: 16,
+              bottom: 14,
+              child: AnimatedBuilder(
+                animation: _controller,
+                builder: (context, _) => _ZoomPill(
+                  percent: _controller.value.getMaxScaleOnAxis() * 100,
+                  onZoomIn: () => _setScale(_controller.value.getMaxScaleOnAxis() * 1.25, viewport),
+                  onZoomOut: () => _setScale(_controller.value.getMaxScaleOnAxis() / 1.25, viewport),
+                  onFit: () => _controller.value = Matrix4.identity(),
+                  l10n: l10n,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// "White brush · 48 px", or the binary-mode notice that replaces it.
+///
+/// Replaces the full-width banner binary mode used to push the canvas down
+/// with: the state belongs where the strokes land, and the toolbar's own
+/// button already carries the accent that says the mode is on.
+class _BrushBadge extends StatelessWidget {
+  final Color color;
+  final double size;
+  final bool isBinaryMode;
+  final AppLocalizations l10n;
+
+  const _BrushBadge({
+    required this.color,
+    required this.size,
+    required this.isBinaryMode,
+    required this.l10n,
+  });
+
+  /// The name of the swatch this colour came from. The view is handed the
+  /// brush with its opacity already applied, so the alpha is dropped before
+  /// matching — otherwise every colour is an unnamed one.
+  String? _colorName() {
+    switch (color.toARGB32() & 0x00FFFFFF) {
+      case 0xFFFFFF:
+        return l10n.white;
+      case 0x000000:
+        return l10n.black;
+      default:
+        if (color.toARGB32() & 0x00FFFFFF == Colors.red.toARGB32() & 0x00FFFFFF) return l10n.red;
+        if (color.toARGB32() & 0x00FFFFFF == Colors.green.toARGB32() & 0x00FFFFFF) return l10n.green;
+        return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final name = _colorName();
+    final label = isBinaryMode
+        ? l10n.binaryModeActive
+        : name == null
+            ? '${size.round()} px'
+            : l10n.maskBrushBadge(name, size.round());
+
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 360),
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 4),
+      decoration: BoxDecoration(
+        // Ink rather than a theme surface: this sits over a photograph.
+        color: Colors.black.withValues(alpha: 0.72),
+        borderRadius: BorderRadius.circular(AppRadius.xs),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isBinaryMode) ...[
+            const Icon(Icons.contrast, size: 12, color: Colors.white),
+            const SizedBox(width: 6),
+          ],
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(color: Colors.white),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Bottom-right floating zoom readout and fit action — the crop editor's pill,
+/// so the two canvases are navigated the same way.
+class _ZoomPill extends StatelessWidget {
+  final double percent;
+  final VoidCallback onZoomIn;
+  final VoidCallback onZoomOut;
+  final VoidCallback onFit;
+  final AppLocalizations l10n;
+
+  const _ZoomPill({
+    required this.percent,
+    required this.onZoomIn,
+    required this.onZoomOut,
+    required this.onFit,
+    required this.l10n,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        border: Border.all(color: colorScheme.outlineVariant),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.shadow.withValues(alpha: 0.12),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _pillIcon(context, Icons.remove, onZoomOut),
+          SizedBox(
+            width: 44,
+            child: Text(
+              '${percent.round()}%',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(fontFamily: 'monospace'),
+            ),
+          ),
+          _pillIcon(context, Icons.add, onZoomIn),
+          Container(
+            width: 1,
+            height: 16,
+            color: colorScheme.outlineVariant,
+            margin: const EdgeInsets.symmetric(horizontal: 4),
+          ),
+          InkWell(
+            onTap: onFit,
+            borderRadius: BorderRadius.circular(AppRadius.xs),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+              child: Text(
+                l10n.fitToWindow,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _pillIcon(BuildContext context, IconData icon, VoidCallback onTap) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(AppRadius.xs),
+      child: Padding(
+        padding: const EdgeInsets.all(5),
+        child: Icon(icon, size: 14, color: Theme.of(context).colorScheme.onSurfaceVariant),
+      ),
+    );
+  }
+}
+
+/// Summary strip below the canvas: what a save writes, at what size, and
+/// where it lands — the same numbers the save is about to use, stated before
+/// the user commits. Mirrors the crop editor's output preview.
+class _MaskOutputBar extends StatelessWidget {
+  final ui.Image? image;
+  final bool isBinaryMode;
+  final AppLocalizations l10n;
+  final ColorScheme colorScheme;
+
+  const _MaskOutputBar({
+    required this.image,
+    required this.isBinaryMode,
+    required this.l10n,
+    required this.colorScheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final labelStyle = textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant);
+
+    final summary = image == null
+        ? '—'
+        : isBinaryMode
+            ? l10n.maskOutputSummary(image!.width, image!.height)
+            : l10n.maskCompositeOutputSummary(image!.width, image!.height);
+
+    return Container(
+      height: 40,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        border: Border(top: BorderSide(color: colorScheme.outlineVariant.withAlpha(80))),
+      ),
+      child: Row(
+        children: [
+          Text(l10n.maskOutputLabel, style: labelStyle),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              summary,
+              style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: colorScheme.accentTint,
+              borderRadius: BorderRadius.circular(AppRadius.pill),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.subdirectory_arrow_right, size: 12, color: colorScheme.onAccentTint),
+                const SizedBox(width: 6),
+                Text(
+                  // The workspace, not a filename: the name a save picks
+                  // carries a timestamp minted at save time, and printing a
+                  // guess at it is how the crop bar's destination line was
+                  // wrong three ways at once.
+                  l10n.maskWillSaveTo(l10n.cropResizeTempWorkspaceLabel),
+                  style: textTheme.labelSmall?.copyWith(color: colorScheme.onAccentTint),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/workbench/widgets/metadata_inspector.dart
+++ b/lib/screens/workbench/widgets/metadata_inspector.dart
@@ -1,10 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../core/design_tokens.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../services/image_metadata_service.dart';
 import '../../../state/workbench_ui_state.dart';
 
+/// The comparator's right-hand panel: the same four facts about each of the
+/// two images, and what the pair adds up to.
+///
+/// Laid out to the design spec as label-left / value-right rows under a dotted
+/// section heading, rather than the stacked label-over-value blocks it used to
+/// draw — the two images are only comparable if their numbers line up in the
+/// same column.
 class MetadataInspector extends StatefulWidget {
   final ScrollController? scrollController;
   const MetadataInspector({super.key, this.scrollController});
@@ -14,8 +22,8 @@ class MetadataInspector extends StatefulWidget {
 }
 
 class _MetadataInspectorState extends State<MetadataInspector> {
-  Map<String, String>? _rawMetadata;
-  Map<String, String>? _afterMetadata;
+  ImageMetadata? _rawMeta;
+  ImageMetadata? _afterMeta;
   bool _isLoading = false;
   WorkbenchUIState? _workbenchUIState;
 
@@ -45,33 +53,31 @@ class _MetadataInspectorState extends State<MetadataInspector> {
   }
 
   Future<void> _loadMetadata() async {
-    // Access state via stored reference if available, or provider (safely)
     final state = _workbenchUIState ?? Provider.of<WorkbenchUIState>(context, listen: false);
-    
+
     if (state.comparatorRawPath == null && state.comparatorAfterPath == null) {
-      if (mounted) setState(() { _rawMetadata = null; _afterMetadata = null; });
+      if (mounted) {
+        setState(() {
+          _rawMeta = null;
+          _afterMeta = null;
+        });
+      }
       return;
     }
 
     if (mounted) setState(() => _isLoading = true);
 
-    Map<String, String>? rawMeta;
-    Map<String, String>? afterMeta;
-
-    if (state.comparatorRawPath != null) {
-      final meta = await ImageMetadataService().getMetadata(state.comparatorRawPath!);
-      rawMeta = meta?.params;
-    }
-
-    if (state.comparatorAfterPath != null) {
-      final meta = await ImageMetadataService().getMetadata(state.comparatorAfterPath!);
-      afterMeta = meta?.params;
-    }
+    final rawMeta = state.comparatorRawPath == null
+        ? null
+        : await ImageMetadataService().getMetadata(state.comparatorRawPath!);
+    final afterMeta = state.comparatorAfterPath == null
+        ? null
+        : await ImageMetadataService().getMetadata(state.comparatorAfterPath!);
 
     if (mounted) {
       setState(() {
-        _rawMetadata = rawMeta;
-        _afterMetadata = afterMeta;
+        _rawMeta = rawMeta;
+        _afterMeta = afterMeta;
         _isLoading = false;
       });
     }
@@ -81,76 +87,194 @@ class _MetadataInspectorState extends State<MetadataInspector> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
-    
+
     if (_isLoading) {
       return const Center(child: CircularProgressIndicator());
     }
 
-    if (_rawMetadata == null && _afterMetadata == null) {
+    if (_rawMeta == null && _afterMeta == null) {
       return Center(
-        child: Text(
-          l10n.metadataSelectedNone,
-          style: TextStyle(color: colorScheme.outline),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.info_outline, size: 22, color: colorScheme.outlineVariant),
+            const SizedBox(height: 10),
+            Text(
+              l10n.metadataSelectedNone,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.outline),
+            ),
+          ],
         ),
       );
     }
 
-    final content = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (_rawMetadata != null) ...[
-          _buildSectionHeader(l10n.labelRaw, colorScheme),
-          _buildMetadataListItems(_rawMetadata!, l10n),
-          const SizedBox(height: 24),
-        ],
-        if (_afterMetadata != null) ...[
-          _buildSectionHeader(l10n.labelAfter, colorScheme),
-          _buildMetadataListItems(_afterMetadata!, l10n),
-        ],
-      ],
-    );
-
     return SingleChildScrollView(
       controller: widget.scrollController,
-      padding: const EdgeInsets.all(16),
-      child: content,
-    );
-  }
-
-  Widget _buildSectionHeader(String title, ColorScheme colorScheme) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Text(
-        title,
-        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-          fontWeight: FontWeight.bold,
-          letterSpacing: 1.2,
-          color: colorScheme.primary,
-        ),
+      padding: const EdgeInsets.fromLTRB(18, 16, 18, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_rawMeta != null) ...[
+            _SectionHeader(label: l10n.labelRaw, isAfter: false),
+            ..._buildRows(_rawMeta!, l10n),
+          ],
+          if (_afterMeta != null) ...[
+            if (_rawMeta != null) const SizedBox(height: 14),
+            _SectionHeader(label: l10n.labelAfter, isAfter: true),
+            ..._buildRows(_afterMeta!, l10n),
+          ],
+          if (_rawMeta != null && _afterMeta != null) ...[
+            const SizedBox(height: 18),
+            _SizeDeltaBox(raw: _rawMeta!, after: _afterMeta!, l10n: l10n),
+          ],
+        ],
       ),
     );
   }
 
-  Widget _buildMetadataListItems(Map<String, String> metadata, AppLocalizations l10n) {
-    return Column(
-      children: metadata.entries.map((entry) {
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(entry.key, style: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold)),
-              const SizedBox(height: 4),
-              SelectableText(
-                entry.value,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontFamily: 'monospace'),
-              ),
-              const Divider(height: 16),
-            ],
+  List<Widget> _buildRows(ImageMetadata meta, AppLocalizations l10n) {
+    final rows = <(String, String)>[
+      if (meta.width > 0) (l10n.width, '${meta.width} px'),
+      if (meta.height > 0) (l10n.height, '${meta.height} px'),
+      if (meta.aspectRatio.isNotEmpty) (l10n.aspectRatio, meta.aspectRatio),
+      (l10n.fileSize, meta.sizeString),
+    ];
+
+    return [
+      for (var i = 0; i < rows.length; i++)
+        _MetaRow(label: rows[i].$1, value: rows[i].$2, divided: i < rows.length - 1),
+    ];
+  }
+}
+
+/// A dotted heading naming which of the two images the rows below describe.
+class _SectionHeader extends StatelessWidget {
+  final String label;
+  final bool isAfter;
+
+  const _SectionHeader({required this.label, required this.isAfter});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    // The result section takes the accent, the source stays neutral — the same
+    // pairing the canvas badges and the footer chips use.
+    final color = isAfter ? colorScheme.onAccentTint : colorScheme.onSurfaceVariant;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 2),
+      child: Row(
+        children: [
+          Container(
+            width: 6,
+            height: 6,
+            decoration: BoxDecoration(
+              color: isAfter ? colorScheme.primary : colorScheme.outline,
+              borderRadius: BorderRadius.circular(2),
+            ),
           ),
-        );
-      }).toList(),
+          const SizedBox(width: 7),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.6,
+                  color: color,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One "label … value" line. The value is monospaced so digits in the two
+/// sections sit under each other.
+class _MetaRow extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool divided;
+
+  const _MetaRow({required this.label, required this.value, required this.divided});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: divided
+          ? BoxDecoration(
+              border: Border(bottom: BorderSide(color: colorScheme.outlineVariant.withAlpha(80))),
+            )
+          : null,
+      child: Row(
+        children: [
+          Text(label, style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant)),
+          const Spacer(),
+          SelectableText(
+            value,
+            style: textTheme.bodySmall?.copyWith(
+              fontFamily: 'monospace',
+              fontWeight: FontWeight.w600,
+              color: colorScheme.onSurface,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// What the pair adds up to: how much lighter (or heavier) the result is.
+///
+/// The one fact on this panel that neither image carries on its own, and the
+/// reason two of them are being read side by side.
+class _SizeDeltaBox extends StatelessWidget {
+  final ImageMetadata raw;
+  final ImageMetadata after;
+  final AppLocalizations l10n;
+
+  const _SizeDeltaBox({required this.raw, required this.after, required this.l10n});
+
+  @override
+  Widget build(BuildContext context) {
+    if (raw.fileSize <= 0) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final delta = (after.fileSize - raw.fileSize) / raw.fileSize * 100;
+    final shrank = delta <= 0;
+    final percent = '${delta.abs().toStringAsFixed(1)}%';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        border: Border.all(color: colorScheme.outlineVariant.withAlpha(80)),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            shrank ? Icons.arrow_downward : Icons.arrow_upward,
+            size: 14,
+            color: colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              shrank ? l10n.comparatorSizeReduction(percent) : l10n.comparatorSizeIncrease(percent),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/workbench/workbench_screen.dart
+++ b/lib/screens/workbench/workbench_screen.dart
@@ -663,7 +663,9 @@ class _WorkbenchScreenState extends State<WorkbenchScreen> with SingleTickerProv
             Expanded(child: ComparatorView()),
           ],
         );
-        showRightPanel = !isNarrow; // Show metadata on right
+        // The toolbar's metadata button switches this on desktop; on narrow
+        // the panel is a drawer the same button opens instead.
+        showRightPanel = !isNarrow && context.watch<WorkbenchUIState>().comparatorShowMetadata;
         showLeftPanel = false; // Auto-hide sidebar
         break;
       case 2: // Mask Editor

--- a/lib/state/workbench_ui_state.dart
+++ b/lib/state/workbench_ui_state.dart
@@ -6,6 +6,24 @@ import '../models/app_image.dart';
 import '../services/prompt_optimizer_agent.dart';
 import '../services/repositories/assistant_session_repository.dart';
 
+/// How the comparator arranges the two images.
+///
+/// Was a single `isComparatorSyncMode` boolean, which could only say
+/// "side-by-side" or "curtain" — the design spec's third arrangement (one
+/// above the other, for landscape pairs a horizontal split squeezes) had
+/// nowhere to live.
+enum ComparatorLayout {
+  /// Two panes across, before on the left.
+  sideBySide,
+
+  /// Two panes down, before on top. For wide images, where a vertical split
+  /// leaves each half too narrow to judge.
+  stacked,
+
+  /// One image over the other, revealed by a draggable curtain.
+  slider,
+}
+
 class WorkbenchUIState extends ChangeNotifier {
   WorkbenchUIState() {
     PromptOptimizerAgent.sessions[optimizerSession.id] = optimizerSession;
@@ -19,7 +37,19 @@ class WorkbenchUIState extends ChangeNotifier {
   bool isComparatorOpen = false; 
   String? comparatorRawPath;
   String? comparatorAfterPath;
-  bool isComparatorSyncMode = true; // true: Sync side-by-side, false: Hover swap
+  ComparatorLayout comparatorLayout = ComparatorLayout.sideBySide;
+
+  /// Whether the two panes share one zoom/pan transform. Off, each pane is
+  /// navigated on its own — which is what you want when the pair is framed
+  /// differently and matching the crops by hand is the point.
+  ///
+  /// Meaningless in [ComparatorLayout.slider], where both layers are the same
+  /// transform by construction.
+  bool comparatorSyncTransform = true;
+
+  /// Whether the metadata panel is showing. Desktop only: on narrow widths the
+  /// panel is a drawer, which has its own open/closed state.
+  bool comparatorShowMetadata = true;
 
   // Mask Editor State
   AppImage? maskEditorSourceImage;
@@ -252,8 +282,19 @@ class WorkbenchUIState extends ChangeNotifier {
     notifyListeners();
   }
 
-  void toggleComparatorMode() {
-    isComparatorSyncMode = !isComparatorSyncMode;
+  void setComparatorLayout(ComparatorLayout layout) {
+    if (comparatorLayout == layout) return;
+    comparatorLayout = layout;
+    notifyListeners();
+  }
+
+  void toggleComparatorSyncTransform() {
+    comparatorSyncTransform = !comparatorSyncTransform;
+    notifyListeners();
+  }
+
+  void toggleComparatorMetadata() {
+    comparatorShowMetadata = !comparatorShowMetadata;
     notifyListeners();
   }
 

--- a/lib/widgets/app_segmented_control.dart
+++ b/lib/widgets/app_segmented_control.dart
@@ -53,6 +53,14 @@ class AppSegmentedControl<T> extends StatelessWidget {
   /// Tighter type and padding, for controls tucked into a toolbar.
   final bool compact;
 
+  /// Draw each option as its [AppSegment.icon] alone, with the label as its
+  /// tooltip. For a toolbar on a phone, where the labelled track would take
+  /// the whole row — the option is never left unexplained, only unlabelled.
+  ///
+  /// Segments without an icon keep their label, so a mixed track degrades
+  /// rather than losing options.
+  final bool iconOnly;
+
   /// How the chosen option is marked.
   final AppSegmentStyle style;
 
@@ -63,6 +71,7 @@ class AppSegmentedControl<T> extends StatelessWidget {
     required this.onChanged,
     this.expand = false,
     this.compact = false,
+    this.iconOnly = false,
     this.style = AppSegmentStyle.tinted,
   });
 
@@ -113,7 +122,9 @@ class AppSegmentedControl<T> extends StatelessWidget {
       color = raised ? colorScheme.onSurface : colorScheme.onAccentTint;
     }
 
-    return InkWell(
+    final bareIcon = iconOnly && segment.icon != null;
+
+    final Widget chip = InkWell(
       onTap: selected || !segment.enabled ? null : () => onChanged(segment.value),
       borderRadius: BorderRadius.circular(AppRadius.control),
       child: AnimatedContainer(
@@ -151,25 +162,28 @@ class AppSegmentedControl<T> extends StatelessWidget {
           children: [
             if (segment.icon != null) ...[
               Icon(segment.icon, size: compact ? 14 : 17, color: color),
-              const SizedBox(width: 7),
+              if (!bareIcon) const SizedBox(width: 7),
             ],
-            Flexible(
-              child: Text(
-                segment.label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: (compact
-                        ? Theme.of(context).textTheme.labelMedium
-                        : Theme.of(context).textTheme.bodySmall)
-                    ?.copyWith(
-                  fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-                  color: color,
+            if (!bareIcon)
+              Flexible(
+                child: Text(
+                  segment.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: (compact
+                          ? Theme.of(context).textTheme.labelMedium
+                          : Theme.of(context).textTheme.bodySmall)
+                      ?.copyWith(
+                    fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                    color: color,
+                  ),
                 ),
               ),
-            ),
           ],
         ),
       ),
     );
+
+    return bareIcon ? Tooltip(message: segment.label, child: chip) : chip;
   }
 }

--- a/test/screenshots/app_screens_test.dart
+++ b/test/screenshots/app_screens_test.dart
@@ -10,6 +10,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/state/app_state.dart';
+import 'package:joycai_image_ai_toolkits/state/workbench_ui_state.dart';
 import 'package:joycai_image_ai_toolkits/widgets/app_segmented_control.dart';
 
 import 'harness/fixture_env.dart';
@@ -181,6 +182,22 @@ final List<_WorkbenchTab> _workbenchTabs = <_WorkbenchTab>[
   // strip is empty otherwise, and the strip is where the selection order the
   // model receives is shown and edited.
   _WorkbenchTab('selection', 0, (AppState s) => seedImageSelection(s), seedOnSettled: true),
+  // One entry per arrangement: the three are separate rendering paths, not
+  // three settings of one, and only the default would ever be photographed
+  // otherwise.
+  _WorkbenchTab('comparator', 1, seedComparatorPair),
+  _WorkbenchTab('comparator_stacked', 1, (AppState s) {
+    seedComparatorPair(s);
+    s.workbenchUIState.setComparatorLayout(ComparatorLayout.stacked);
+  }),
+  _WorkbenchTab('comparator_slider', 1, (AppState s) {
+    seedComparatorPair(s);
+    s.workbenchUIState.setComparatorLayout(ComparatorLayout.slider);
+  }),
+  // Unseeded on purpose: the empty state is the first thing anyone opening
+  // the comparator sees, and it is a screen of its own, not a placeholder.
+  _WorkbenchTab('comparator_empty', 1, (AppState s) {}),
+  _WorkbenchTab('mask', 2, seedMaskSource),
   _WorkbenchTab('crop', 3, seedCropSource),
   _WorkbenchTab('assistant', 4, seedOptimizerSession),
 ];

--- a/test/screenshots/harness/fixture_seed.dart
+++ b/test/screenshots/harness/fixture_seed.dart
@@ -457,6 +457,24 @@ void seedCropSource(AppState appState) {
   appState.workbenchUIState.setCropResizeSourceImage(image);
 }
 
+/// Puts a picture in the mask editor.
+void seedMaskSource(AppState appState) {
+  final AppImage? image = _firstGalleryImage(appState);
+  if (image == null) return;
+  appState.workbenchUIState.setMaskEditorSourceImage(image);
+}
+
+/// Loads two different pictures into the comparator.
+///
+/// Two, not one: the whole screen is a pair, and a fixture holding one image
+/// photographs a half-empty canvas that says nothing about how the pair reads.
+void seedComparatorPair(AppState appState) {
+  final List<AppImage> images = _galleryImages(appState).take(2).toList();
+  if (images.isEmpty) return;
+  appState.workbenchUIState.sendToComparator(images.first.path);
+  appState.workbenchUIState.sendToComparator(images.last.path, isAfter: true);
+}
+
 /// Selects the first few gallery images, so the config panel's reference strip
 /// has something to number.
 void seedImageSelection(AppState appState, {int count = 2}) {


### PR DESCRIPTION
The last two workbench tools that had not been through the design spec.
Same shape as the crop editor before them: a proper toolbar, a result
strip that states what you will get, and an empty state treated as a
screen rather than a placeholder.

> **Note on authorship:** the code here was already in the working tree —
> I organised it into commits, resolved the rebase onto `main`, and wrote
> the messages from the rationale the code itself carries. The design
> decisions are not mine to claim.

## Comparator

**Three arrangements, not a boolean.** `isComparatorSyncMode` conflated
the layout with the sync behaviour and could only name two states, so the
spec's third — one image above the other, for landscape pairs a vertical
split squeezes too narrow to judge — was unrepresentable. It splits into
`ComparatorLayout` (side-by-side / stacked / slider) and a separate
`comparatorSyncTransform` flag: two independent questions that had been
wearing one bool.

**Sync now works both ways.** Each pane has its own controller, so both
are interactive; mirroring only the left one meant panning the right pane
silently broke the very alignment the mode exists to hold. Sync is not
offered under the slider, where both layers ride one transform by
construction and the toggle would be a no-op.

**An empty comparator is a screen.** It gets the hint and two pickers,
because opening the tool with nothing loaded is the first thing anyone
does.

**A result strip** — which two files, current zoom and whether it is
shared, and how much the result grew or shrank. The same strip the crop
editor carries, so both tools state their result in the same place.

The metadata panel is rebuilt alongside as this tab's right column, and
its visibility becomes state the toolbar's own button drives: a panel on
desktop, the drawer the same button opens on narrow.

## Mask editor

Onto the same toolbar shape the crop editor and comparator draw — back
button, file caption, hairline dividers, save actions at the right.

- **Filename and source resolution are shown.** The canvas only ever
  displays a fitted preview, so without them the mask's real export size
  is invisible — the one number that matters when the mask has to line up
  with the original.
- **Binary mode drops red and green.** Both would be flattened to one of
  the two extremes on export, so offering them was offering a choice the
  file cannot keep.
- **The two exports are named separately** — the mask alone (black and
  white) and the composite — each with its own summary and destination,
  instead of one ambiguous Save.

## Supporting changes

- `AppSegmentedControl.iconOnly`: a labelled track owns its row, and on a
  phone the three layout options plus labels leave nothing beside them.
  Icons with the label moved to the tooltip — unlabelled, never
  unexplained. Segments without an icon keep their label, so a mixed
  track degrades rather than losing options.
- Screenshot fixtures: the harness only rendered whatever state a screen
  booted in, which for both tools is a blank canvas. The comparator
  fixture loads *two* pictures (one photographs a half-empty canvas that
  says nothing about how a pair reads), and each arrangement gets its own
  entry rather than a parameter, because they are three separate
  rendering paths. The empty state gets one too.

## Commit structure

Five commits, ordered so **each one builds on its own** — verified by
checking out all five and running `flutter analyze` at each, not by
eyeballing the order:

| | |
|---|---|
| `f93da6b` | `AppSegmentedControl.iconOnly` |
| `0cc8919` | 56 strings × 4 languages, purely additive |
| `92a4f40` | comparator + metadata panel + state |
| `21bad34` | mask editor |
| `ee4fd8d` | screenshot fixtures |

That check earned its keep: the first attempt put the removal of the two
superseded keys (`compareModeSync`, `compareModeSwap`) in the strings
commit, which broke the build at that revision because their last caller
was still two commits away. The removals now travel with the caller.

## Verification

`flutter analyze` clean at every commit · **528 tests pass** · rebased
onto `main` past #81 and #82.

The rebase conflicted once, on the screenshot test's import block, where
both sides had added a different import — resolved by taking both. The
generated l10n files auto-merged; I regenerated afterwards and confirmed
zero drift, since an auto-merge of machine-generated files is not
guaranteed to equal what the generator would produce.

## Reviewer note

Nothing here has been seen on a real run by me — the screenshot harness
renders these to PNGs under `build/ui-screenshots/`, which is the fastest
way to check the three comparator arrangements and the mask editor at all
three widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
