### PR TITLE
fix(ui): the assistant composer's send button, and its second border

### DIFF
--- a/lib/screens/workbench/widgets/prompt_optimizer_view.dart
+++ b/lib/screens/workbench/widgets/prompt_optimizer_view.dart
@@ -854,8 +854,18 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
             // fill the design spec replaced everywhere else.
             decoration: BoxDecoration(
               color: colorScheme.surface,
-              borderRadius: BorderRadius.circular(AppRadius.dialog),
+              borderRadius: BorderRadius.circular(AppRadius.lg),
               border: Border.all(color: colorScheme.outlineVariant),
+              // The spec lifts the composer off the transcript rather than
+              // leaving it flush with it — it is the one thing on this screen
+              // that is always available, whatever is scrolled above it.
+              boxShadow: [
+                BoxShadow(
+                  color: colorScheme.shadow.withValues(alpha: 0.10),
+                  blurRadius: 10,
+                  offset: const Offset(0, 2),
+                ),
+              ],
             ),
             padding: const EdgeInsets.fromLTRB(4, 4, 4, 4),
             child: Column(
@@ -879,7 +889,16 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                       hintStyle: textTheme.bodyMedium?.copyWith(
                         color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
                       ),
+                      // All three, not just `border`. The app's
+                      // InputDecorationTheme sets `enabledBorder` and
+                      // `focusedBorder`, and those outrank `border` — so
+                      // `border: InputBorder.none` alone left the field's own
+                      // outline standing, drawing a second box inside the
+                      // composer card. The spec has one edge here, not two.
                       border: InputBorder.none,
+                      enabledBorder: InputBorder.none,
+                      focusedBorder: InputBorder.none,
+                      disabledBorder: InputBorder.none,
                       contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
                     ),
                   ),
@@ -896,20 +915,32 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                     return Row(
                       children: [
                         if (attachedCount > 0) ...[
-                          Flexible(
+                          // Capped, not [Flexible]. Two flex children split the
+                          // free space evenly and the unused half of the first
+                          // is not handed back — the chip took 168px of its
+                          // 235px share and the 67px left over stayed where it
+                          // was, pushing the hint and the send button 67px
+                          // clear of the card's right edge. Capping it instead
+                          // leaves it a non-flexible child that sizes to its
+                          // text, so the [Expanded] below owns every pixel
+                          // that is actually free.
+                          ConstrainedBox(
+                            constraints: BoxConstraints(maxWidth: constraints.maxWidth * 0.45),
                             child: Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                               decoration: BoxDecoration(
-                                // A step up from the composer's own surface,
-                                // which it used to match — on the bordered
-                                // card the chip had no edge of its own left.
-                                color: colorScheme.surfaceContainerHighest,
-                                borderRadius: BorderRadius.circular(AppRadius.control),
+                                // The spec's accent capsule: this states what
+                                // leaves with the message, which is the one
+                                // thing about the composer that is not
+                                // obvious, and a badge is one of the three
+                                // places accent is allowed.
+                                color: colorScheme.accentTint,
+                                borderRadius: BorderRadius.circular(AppRadius.pill),
                               ),
                               child: Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
-                                  Icon(Icons.image_outlined, size: 14, color: colorScheme.onSurfaceVariant),
+                                  Icon(Icons.image_outlined, size: 14, color: colorScheme.onAccentTint),
                                   const SizedBox(width: 6),
                                   Flexible(
                                     child: Text(
@@ -917,14 +948,14 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                                       maxLines: 1,
                                       overflow: TextOverflow.ellipsis,
                                       style: textTheme.labelMedium
-                                          ?.copyWith(color: colorScheme.onSurfaceVariant),
+                                          ?.copyWith(color: colorScheme.onAccentTint),
                                     ),
                                   ),
                                 ],
                               ),
                             ),
                           ),
-                          const SizedBox(width: 8),
+                          const SizedBox(width: 10),
                         ],
                         Expanded(
                           child: showHint
@@ -940,7 +971,7 @@ class _PromptOptimizerChatViewState extends State<PromptOptimizerChatView> {
                                 )
                               : const SizedBox.shrink(),
                         ),
-                        const SizedBox(width: 8),
+                        const SizedBox(width: 10),
                         IconButton.filled(
                           icon: const Icon(Icons.send_rounded, size: 18),
                           tooltip: l10n.optSend,


### PR DESCRIPTION
Reported from a running window: 提示词助手 的输入框布局，尤其是发送按钮的位置
与设计图不符。Two faults, both measured with a throwaway geometry probe
rather than eyeballed.

## The send button sat 67px clear of the card edge

The footer row is `[Flexible(chip), Expanded(hint), send]`. Both flex
children are flex 1, so the 470px of free width is split evenly at 235 each —
the chip uses 168 of its share and the leftover **67px is not handed back**,
carrying the hint and the send button 67px left of where they belong.

```
before  sendIconButton: L=940.0  R=980.0     (card inner edge = 1047)
after   sendIconButton: L=1007.0 R=1047.0    flush
```

The chip becomes a capped non-flexible child (`ConstrainedBox`, 45% of the
row), so `Expanded` owns every pixel that is actually free.

This is the same flex trap as the header's mode badge truncating to
`知识库 · Ag…` in #84 — same file, same shape. Worth remembering that two
`Flexible`s in one `Row` do not behave like `margin-left: auto`.

## The field drew a box inside the card

`InputDecoration` resolves `enabledBorder`/`focusedBorder` **ahead of**
`border`, and the app's `InputDecorationTheme` sets both — so
`border: InputBorder.none` on the composer never removed anything, and the
field's own outline stood inside the composer card as a visible second box.
All four states are spelled out now; the spec draws one edge here.

## Also to `10d` while here

- The attachment chip takes the spec's accent capsule
  (`accentTint` + `AppRadius.pill`) instead of a grey
  `surfaceContainerHighest` rounded rect — it states what leaves with the
  message, and a badge is one of the three places accent is allowed.
- Card radius 14 → 12, plus the spec's shadow.

## Checks

- `flutter analyze` — No issues found!
- `flutter test test/screenshots` — 68/68, no overflows
- Re-rendered desktop light + dark, and separately under the **Orange** seed in
  dark, which is the theme the report came from

One file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
