### PR TITLE
chore(llm): drop dead extraParams, stop losing tool calls on the stream

### DIFF
--- a/lib/services/llm/llm_service.dart
+++ b/lib/services/llm/llm_service.dart
@@ -26,7 +26,10 @@ class LLMService {
     List<LLMTool>? tools,
     bool useStream = true,
   }) async {
-    // Tool calling is only wired through the standard (non-streaming) path.
+    // Tool calling is only wired through the standard (non-streaming) path —
+    // see [ChatProtocol.generateStream]. Silently downgrading beats honouring
+    // useStream: a caller that passed tools needs them, and a stream that
+    // never declares them just answers as if there were none.
     if (tools != null && tools.isNotEmpty) {
       useStream = false;
     }
@@ -50,6 +53,7 @@ class LLMService {
           onLogAdded?.call('Connecting to ${config.channelType} (streaming)... ${attempt > 0 ? "(Retry $attempt/$maxRetries)" : ""}', level: 'DEBUG', contextId: contextId);
           String accumulatedText = "";
           List<Uint8List> accumulatedImages = [];
+          List<LLMToolCall> accumulatedToolCalls = [];
           Map<String, dynamic>? finalMetadata;
 
           final stream = _dispatcher.generateStream(
@@ -72,13 +76,22 @@ class LLMService {
             if (chunk.imagePart != null) {
               accumulatedImages.add(chunk.imagePart!);
             }
+            // Collected rather than ignored: a dropped tool call reads to the
+            // caller as "the model chose to answer directly", which is the one
+            // failure mode an agent loop cannot detect. Not reachable while
+            // the guard above forces tools onto the standard path, but the
+            // guard is the reason, not an excuse for losing them here.
+            if (chunk.toolCallPart != null) {
+              accumulatedToolCalls.add(chunk.toolCallPart!);
+            }
             if (chunk.metadata != null) finalMetadata = chunk.metadata;
           }
-          
+
           final response = LLMResponse(
             text: accumulatedText,
             generatedImages: accumulatedImages,
             metadata: finalMetadata ?? {},
+            toolCalls: accumulatedToolCalls,
           );
 
           // Record usage

--- a/lib/services/llm/llm_types.dart
+++ b/lib/services/llm/llm_types.dart
@@ -193,7 +193,6 @@ class LLMModelConfig {
   final double outputFee;
   final String billingMode; // 'token' or 'request'
   final double requestFee;
-  final Map<String, dynamic> extraParams;
 
   // Proxy settings
   final bool proxyEnabled;
@@ -212,7 +211,6 @@ class LLMModelConfig {
     this.outputFee = 0.0,
     this.billingMode = 'token',
     this.requestFee = 0.0,
-    this.extraParams = const {},
     this.proxyEnabled = false,
     this.proxyUrl,
     this.proxyUsername,
@@ -289,7 +287,16 @@ class LLMResponseChunk {
 
   final Uint8List? imagePart;
   final Map<String, dynamic>? metadata;
+
+  /// One whole tool call. Emitted by the Google chunk parser, which is shared
+  /// between that family's streaming and synchronous paths — the synchronous
+  /// one reassembles [LLMResponse.toolCalls] from these.
+  ///
+  /// Always a complete call, never a fragment: no protocol declares tools on
+  /// the streaming surface (see [ChatProtocol.generateStream]), so nothing
+  /// here has to survive being split across chunks.
   final LLMToolCall? toolCallPart;
+
   final bool isDone;
 
   LLMResponseChunk({this.textPart, this.reasoningPart, this.imagePart, this.metadata, this.toolCallPart, this.isDone = false});

--- a/lib/services/llm/protocols/protocol.dart
+++ b/lib/services/llm/protocols/protocol.dart
@@ -50,6 +50,19 @@ abstract class ChatProtocol {
     LLMLogger? logger,
   });
 
+  /// Deliberately takes no `tools`: the streaming surface does not declare
+  /// them, so no implementation has to assemble a tool call out of deltas.
+  /// [LLMService.request] downgrades a tool-bearing request to [generate]
+  /// instead.
+  ///
+  /// Adding tools here is a bigger change than the signature suggests. On the
+  /// ① family `function.arguments` arrives fragmented across chunks and
+  /// `delta.tool_calls[].index` — not `id`, which is fragmented too — is the
+  /// only reliable grouping key (docs/api/tools.md §4); the accumulator has to
+  /// live in the protocol and emit whole calls at stream end. And the one
+  /// consumer that would use it, the assistant's agent loop, cannot act on a
+  /// partial batch anyway: it needs every call in the message before it can
+  /// pair a single result. Hence the downgrade rather than the machinery.
   Stream<LLMResponseChunk> generateStream(
     LLMTarget target,
     List<LLMMessage> history, {


### PR DESCRIPTION
承接 #89 的 tool call 审查，收掉剩下的两个尾巴。

## 先更正一处结论

审查时我说 `LLMResponseChunk.toolCallPart` 是死字段——**那是错的**，当时只看了 OpenAI 一侧。`parseGoogleChunks` 被 Gemini 的**流式和同步两条路径共用**，同步路径正是靠它重建 `LLMResponse.toolCalls`（`gemini_chat_protocol.dart:80`）。所以"删掉字段"这个选项不成立。

## 1. `LLMModelConfig.extraParams` — 删除

既没人写也没人读：唯一从数据库读配置的构造点（`llm_config_resolver.dart:69`）不传它，所有 config 都揣着默认的 `const {}`，也没有任何 protocol 去看它；没有 DB 列，也没有 UI 入口。一个假装是"每模型逃生舱"、实际是空壳的字段，比干脆没有更坏。

## 2. 流式路径会吞掉 tool call — 补上

真正的问题不是那个字段，而是 `LLMService.request` 的**流式分支构造 `LLMResponse` 时没带 `toolCalls`**，流上来的 tool call 凭空消失。

这个失败模式值得单独说：丢掉的 tool call 在调用方看来就是"模型选择直接回答"——**这是 agent 循环唯一无法察觉的失败**。今天它不可达，因为 tools 非空时会被强制走非流式；但那个 guard 是原因，不是在这里丢掉它们的理由。

## 3. 把"流式不带 tools"从疏漏变成明确契约

`ChatProtocol.generateStream` 的 dartdoc 现在写清了为什么不接 `tools`，以及真要实现需要付出什么：

- ① 族 `function.arguments` 是跨 chunk 分片的，`delta.tool_calls[].index` 是唯一可靠的分组键（`id` 本身也会分片，`docs/api/tools.md` §4），累加器必须住在 protocol 里、流末尾才吐出完整调用；
- 而唯一的消费方——助手的 agent 循环——**本来就用不上流式**：它必须拿到该消息里的全部调用才能开始配对结果，拿到一半没有任何意义。

所以这是"有意降级到非流式"，不是"没来得及做"。`LLMService.request` 里那行 `useStream = false` 和 `LLMResponseChunk.toolCallPart`（永远是完整调用、不是分片）也都补了说明。

想让助手边生成边显示是另一回事：要把 `tools` 打通 `generateStream` → dispatcher → `requestStream` 四层，再加 protocol 内的分片累加器。那属于功能，不在本 PR。

## 验证

- `flutter analyze` → No issues found!
- `flutter test` → 582 passed（9 skipped）

纯内部清理，无行为变化、无 UI 变化，故未 bump 版本（仍为 3.15.1）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)