### PR TITLE
fix: repair three OpenAI-compat wire defects on the streaming path

### DIFF
--- a/docs/api/streaming.md
+++ b/docs/api/streaming.md
@@ -25,10 +25,19 @@ Gemini 的每个 chunk 是一个**完整的 `GenerateContentResponse`**，不是
 按"拼接 delta"的思路处理会重复累加。它的 `parts` 是这一片的全部内容，直接追加
 即可。
 
-### ① 的三个实现细节
+### ① 的五个实现细节
 
 - **SSE 行会被网络切开。** 一个 `data:` 行可能跨两次 read 到达，解析半行会
   静默丢掉 token 或 usage。必须把最后一个不完整行留到下次。
+- **`data:` 后的空格是可选的。** SSE 规范里 `data:{"id":…}` 与
+  `data: {"id":…}` 等价，两种拼法都在流通。只匹配带空格的那种，遇到另一种
+  不会报错——整个回复原样到达、逐行解析为空、当噪声跳过。
+- **usage 尾 chunk 的 `choices` 是空数组，不是缺失字段。** 开了
+  `include_usage` 之后最后一个 chunk 形如
+  `{"choices": [], "usage": {…}}`；`chunk["choices"]?[0]` 这类空值守卫挡的是
+  null 不是空数组，会抛越界异常。而这个异常通常落在"容忍畸形 chunk"的 catch
+  里，于是 usage 静默归零——与下面那条"兼容层没实现 `stream_options`"表现
+  完全一样，排查时容易归错因。
 - **`tool_calls` 的分组键是 `index`，不是 `id`** —— `id` 本身也可能分片到达。
 - **`stream_options.include_usage` 是很多兼容层没实现的第一个东西。** 不实现
   的表现不是报错，是 usage 全为 0。

--- a/lib/services/llm/llm_types.dart
+++ b/lib/services/llm/llm_types.dart
@@ -182,7 +182,19 @@ class LLMModelConfig {
   /// The channel's stored vendor id (`llm_channels.type`) — resolved to a
   /// [VendorProfile] by the dispatcher. See `vendors/vendors.dart`.
   final String channelType;
+
+  /// Channel base URL, always without surrounding whitespace or a trailing
+  /// slash — normalized here rather than at each call site.
+  ///
+  /// Protocols append their path to this (`$endpoint/chat/completions`), so a
+  /// channel saved as `https://relay.example.com/v1/` used to produce
+  /// `/v1//chat/completions`, which fails on gateways that do not collapse
+  /// empty path segments. Only the surfaces that happened to call
+  /// [trimBaseUrl] were safe — `/models` was, `/chat/completions` was not, so
+  /// model discovery succeeded and every request failed. Normalizing on the
+  /// way in covers channels already stored with a slash too; no migration.
   final String endpoint;
+
   final String apiKey;
   final double inputFee;
 
@@ -204,7 +216,7 @@ class LLMModelConfig {
     this.id,
     required this.modelId,
     required this.channelType,
-    required this.endpoint,
+    required String endpoint,
     required this.apiKey,
     this.inputFee = 0.0,
     this.cacheInputFee,
@@ -215,7 +227,17 @@ class LLMModelConfig {
     this.proxyUrl,
     this.proxyUsername,
     this.proxyPassword,
-  });
+  }) : endpoint = normalizeEndpoint(endpoint);
+
+  /// Strips surrounding whitespace and trailing slashes from a base URL.
+  /// See [endpoint].
+  static String normalizeEndpoint(String raw) {
+    var base = raw.trim();
+    while (base.endsWith('/')) {
+      base = base.substring(0, base.length - 1);
+    }
+    return base;
+  }
 
   /// Rate actually charged per cached input token.
   double get effectiveCacheInputFee => cacheInputFee ?? inputFee;

--- a/lib/services/llm/protocols/openai_chat_protocol.dart
+++ b/lib/services/llm/protocols/openai_chat_protocol.dart
@@ -105,6 +105,46 @@ String resolveToolCallId(Object? rawId, int index) {
   return (id == null || id.isEmpty) ? 'call_$index' : id;
 }
 
+/// The payload of one SSE line, or null when the line carries none.
+///
+/// The single space after `data:` is *optional* in the SSE grammar — a relay
+/// emitting `data:{"id":…}` is as conformant as one emitting `data: {"id":…}` —
+/// but only the spaced spelling was recognized, and an unrecognized line fell
+/// through to a JSON decode of the whole `data:{…}` string, which fails and is
+/// skipped as noise. The reply arrived in full and parsed as nothing, with no
+/// error anywhere.
+///
+/// Comments (`:` keep-alives), blank lines and the `[DONE]` terminator carry no
+/// payload. A line with no `data:` prefix at all is returned unchanged, keeping
+/// the tolerance for relays that stream bare JSON lines without SSE framing.
+String? sseDataPayload(String line) {
+  var s = line.trimRight();
+  if (s.isEmpty) return null;
+  if (s.startsWith('data:')) {
+    s = s.substring(5);
+    if (s.startsWith(' ')) s = s.substring(1);
+  } else if (s.startsWith(':')) {
+    return null;
+  }
+  if (s.isEmpty || s == '[DONE]') return null;
+  return s;
+}
+
+/// The first `choices` entry of a response or stream chunk, or null when there
+/// is none.
+///
+/// The usage-only chunk that `stream_options.include_usage` produces at stream
+/// end carries `"choices": []`, and a null-aware `chunk['choices']?[0]` does
+/// not guard an *empty* list — it throws a `RangeError` that the stream loop's
+/// shape-tolerant catch swallowed as a malformed chunk. Every OpenAI-family
+/// streaming request lost its token usage that way, silently.
+Map<String, dynamic>? firstChoice(Map<String, dynamic> chunk) {
+  final choices = chunk['choices'];
+  if (choices is! List || choices.isEmpty) return null;
+  final first = choices.first;
+  return first is Map ? first.cast<String, dynamic>() : null;
+}
+
 /// Result of separating inline `<think>…</think>` chain-of-thought from
 /// model text.
 class InlineThinkResult {
@@ -246,7 +286,10 @@ class OpenAIChatProtocol implements ChatProtocol {
     LLMLogger? logger,
   }) async {
     final config = target.config;
-    final url = Uri.parse('${config.endpoint}/chat/completions');
+    // Trimmed like every sibling protocol's base URL. [LLMModelConfig.endpoint]
+    // already guarantees no trailing slash; this keeps the call sites uniform
+    // so the next one copied from here cannot reintroduce `//chat/completions`.
+    final url = Uri.parse('${trimBaseUrl(config.endpoint)}/chat/completions');
     logger?.call('Preparing OpenAI request to: ${url.host}', level: 'DEBUG');
     final headers = target.headers();
     final payload = _prepareChatPayload(target, history, options, isStreaming: false, tools: tools);
@@ -292,8 +335,7 @@ class OpenAIChatProtocol implements ChatProtocol {
       String? reasoningContent;
       String? reasoningFieldName;
 
-      final choices = data['choices'];
-      final choice = (choices is List && choices.isNotEmpty) ? choices[0] : null;
+      final choice = data is Map<String, dynamic> ? firstChoice(data) : null;
       final message = choice?['message'];
       if (message == null) {
         // Previously this fell through to an empty LLMResponse, which callers
@@ -406,7 +448,7 @@ class OpenAIChatProtocol implements ChatProtocol {
     LLMLogger? logger,
   }) async* {
     final config = target.config;
-    final url = Uri.parse('${config.endpoint}/chat/completions');
+    final url = Uri.parse('${trimBaseUrl(config.endpoint)}/chat/completions');
     logger?.call('Starting OpenAI stream: ${url.host}', level: 'DEBUG');
     final headers = target.headers();
     final payload = _prepareChatPayload(target, history, options, isStreaming: true);
@@ -453,25 +495,28 @@ class OpenAIChatProtocol implements ChatProtocol {
     // <think> tags arrive split across chunks; the filter reassembles them
     // and keeps the thinking out of the text channel.
     final thinkFilter = InlineThinkStreamFilter();
+    // Usage and finish_reason arrive on different chunks (and, on some relays,
+    // alongside content rather than on a choices-less tail chunk), so they are
+    // collected here and emitted once at stream end — the consumer keeps the
+    // last metadata it sees, so a single final chunk cannot be overwritten by
+    // a later one carrying only half the picture.
+    Map<String, dynamic>? usageMetadata;
+    String? finishReason;
 
     try {
       await for (final line in response.stream.transform(utf8.decoder).transform(const LineSplitter())) {
         if (debugFile != null && line.isNotEmpty) {
           await LLMDebugLogger.appendLine(debugFile, line);
         }
-        if (line.isEmpty || line == 'data: [DONE]') continue;
-
-        String dataLine = line;
-        if (line.startsWith('data: ')) {
-          dataLine = line.substring(6);
-        }
+        final dataLine = sseDataPayload(line);
+        if (dataLine == null) continue;
 
         Map<String, dynamic>? chunkData;
         try {
           final decoded = jsonDecode(dataLine);
           if (decoded is Map<String, dynamic>) chunkData = decoded;
         } catch (_) {
-          continue; // Non-JSON SSE noise (comments, keep-alives).
+          continue; // Non-JSON SSE noise.
         }
         if (chunkData == null) continue;
 
@@ -480,15 +525,17 @@ class OpenAIChatProtocol implements ChatProtocol {
         // a malformed chunk (streaming.md §3.1/§3.2).
         throwIfEnvelopeError(chunkData);
 
-        try {
-          final choice = chunkData['choices']?[0];
-          if (choice == null) {
-            if (chunkData['usage'] != null) {
-              yield LLMResponseChunk(metadata: chunkData['usage']);
-            }
-            continue;
-          }
+        // Same: usage is the whole point of the choices-less tail chunk, so it
+        // is read before any parsing that is allowed to fail.
+        final usage = chunkData['usage'];
+        if (usage is Map) usageMetadata = usage.cast<String, dynamic>();
 
+        final choice = firstChoice(chunkData);
+        if (choice == null) continue;
+        final rawFinish = choice['finish_reason'];
+        if (rawFinish is String && rawFinish.isNotEmpty) finishReason = rawFinish;
+
+        try {
           final delta = choice['delta'];
           // Same shape tolerance as the sync path — a delta carrying a content
           // array would otherwise throw into the catch below and be dropped as
@@ -560,6 +607,16 @@ class OpenAIChatProtocol implements ChatProtocol {
       }
     } finally {
       client.close();
+    }
+
+    // Last, so it wins over any metadata attached to an earlier chunk. Without
+    // it a streamed request recorded no token usage at all — the sync path's
+    // `usage` + `finish_reason` are reported here in the same shape.
+    if (usageMetadata != null) {
+      yield LLMResponseChunk(metadata: {
+        ...usageMetadata,
+        'finish_reason': ?finishReason,
+      });
     }
 
     yield LLMResponseChunk(isDone: true);

--- a/lib/services/llm/protocols/protocol.dart
+++ b/lib/services/llm/protocols/protocol.dart
@@ -125,6 +125,10 @@ abstract class DiscoveryProtocol {
 // ---------------------------------------------------------------------------
 
 /// [endpoint] without any trailing slashes.
+///
+/// Redundant for a [LLMModelConfig.endpoint], which is normalized on
+/// construction — kept so every protocol builds its URL the same way and a
+/// raw string from elsewhere is safe too.
 String trimBaseUrl(String endpoint) {
   var base = endpoint.trim();
   while (base.endsWith('/')) {

--- a/test/llm_model_config_test.dart
+++ b/test/llm_model_config_test.dart
@@ -30,6 +30,27 @@ void main() {
       expect(config.proxyUrl, 'http://localhost:8080');
     });
 
+    test('endpoint is normalized — a pasted trailing slash cannot reach a URL builder', () {
+      // Protocols append their path directly, so `…/v1/` used to yield
+      // `/v1//chat/completions` and every request 404'd while discovery,
+      // which trimmed, kept working.
+      LLMModelConfig at(String endpoint) => LLMModelConfig(
+            modelId: 'm',
+            channelType: 'openai',
+            endpoint: endpoint,
+            apiKey: 'k',
+          );
+
+      expect(at('https://relay.example.com/v1/').endpoint,
+          'https://relay.example.com/v1');
+      expect(at('https://relay.example.com/v1///').endpoint,
+          'https://relay.example.com/v1');
+      expect(at('  https://relay.example.com/v1  ').endpoint,
+          'https://relay.example.com/v1');
+      expect(at('https://relay.example.com/v1').endpoint,
+          'https://relay.example.com/v1');
+    });
+
     test('LLMMessage should be initialized correctly', () {
       final message = LLMMessage(
         role: LLMRole.user,

--- a/test/openai_chat_payload_test.dart
+++ b/test/openai_chat_payload_test.dart
@@ -130,6 +130,70 @@ void main() {
     });
   });
 
+  group('sseDataPayload', () {
+    test('the spec-optional space after data: is accepted either way', () {
+      // `data:{…}` is as conformant as `data: {…}`; only the spaced form was
+      // recognized, so a relay using the bare one delivered a reply that
+      // parsed as nothing, with no error raised anywhere.
+      expect(sseDataPayload('data: {"a":1}'), '{"a":1}');
+      expect(sseDataPayload('data:{"a":1}'), '{"a":1}');
+    });
+
+    test('only one space is consumed — leading whitespace inside is preserved', () {
+      expect(sseDataPayload('data:  {"a":1}'), ' {"a":1}');
+    });
+
+    test('terminators, comments and blanks carry no payload', () {
+      expect(sseDataPayload('data: [DONE]'), isNull);
+      expect(sseDataPayload('data:[DONE]'), isNull);
+      expect(sseDataPayload(''), isNull);
+      expect(sseDataPayload('   '), isNull);
+      expect(sseDataPayload('data:'), isNull);
+      expect(sseDataPayload(': keep-alive'), isNull);
+    });
+
+    test('a stray CR from \\r\\n framing is stripped', () {
+      expect(sseDataPayload('data: {"a":1}\r'), '{"a":1}');
+      expect(sseDataPayload('data: [DONE]\r'), isNull);
+    });
+
+    test('an unframed JSON line still passes through', () {
+      // Some relays stream bare JSON lines with no SSE field name; that
+      // tolerance predates this helper and is kept.
+      expect(sseDataPayload('{"a":1}'), '{"a":1}');
+    });
+  });
+
+  group('firstChoice', () {
+    test('an empty choices list reads as absent, not as a RangeError', () {
+      // The `stream_options.include_usage` tail chunk is exactly this shape.
+      // `chunk['choices']?[0]` threw into the stream loop's tolerant catch,
+      // so every streamed request silently recorded zero token usage.
+      final tail = {
+        'id': 'x',
+        'choices': [],
+        'usage': {'prompt_tokens': 10, 'completion_tokens': 2},
+      };
+      expect(firstChoice(tail), isNull);
+      expect(tail['usage'], isNotNull);
+    });
+
+    test('a missing or malformed choices field reads as absent', () {
+      expect(firstChoice({'usage': {}}), isNull);
+      expect(firstChoice({'choices': 'nope'}), isNull);
+      expect(firstChoice({'choices': ['nope']}), isNull);
+    });
+
+    test('a real choice is returned as a typed map', () {
+      final choice = firstChoice({
+        'choices': [
+          {'index': 0, 'delta': {'content': 'hi'}, 'finish_reason': null}
+        ]
+      });
+      expect(choice?['delta']['content'], 'hi');
+    });
+  });
+
   group('throwIfEnvelopeError', () {
     test('error field throws with the upstream message', () {
       expect(


### PR DESCRIPTION
对照 [New API 的 `/v1/chat/completions` 规格](https://www.newapi.ai/zh/docs/api/ai-model/chat/openai/createchatcompletion) 审查了我们的中转接口兼容性。**请求侧和同步响应路径完全合规**；流式路径有三个真实缺口。

## ① 流式用量全丢（严重）

开了 `stream_options.include_usage` 之后，最后一个 chunk 形如 `{"choices": [], "usage": {…}}`。原来的 `chunkData['choices']?[0]` 挡的是 null，**不挡空数组** —— 抛出的 RangeError 落进了循环里那个「容忍畸形 chunk」的 catch，被当噪声丢掉。

后果：所有走流式的 OpenAI 系请求**从来没有记录过 token 和成本**，指标页里这些渠道一直是空的。紧邻的 `if (choice == null)` 分支说明作者本就想处理这个 chunk，只是只考虑了 `choices` 字段缺失，而空数组才是实际形态。同步路径 (`:296`) 一直是对的——这大概就是它长期没被发现的原因，加上 Prompt 助手带 tools 强制降级到同步，最常用的路径正好绕开了它。

修法：新增 `firstChoice()`，同步路径也换用它，两条路径共用一套取值规则。同时把 usage 的收集改成**不依赖它出现在哪个 chunk**（任意 chunk 的 `usage` 是 Map 就记下，所以内容 chunk 里的 `"usage": null` 不会覆盖已记录的值），流结束时统一发一个 metadata chunk——消费端保留最后一个 metadata，放最后发才保证不被覆盖。`finish_reason` 一并带上，流式 metadata 现在和同步路径同形。

## ② 端点尾斜杠

`/chat/completions` 是**唯一**直接拼裸 `config.endpoint` 的接口；同文件的 `/models` 和其余 8 个 protocol 都走 `trimBaseUrl()`。渠道存成 `.../v1/` 就得到 `/v1//chat/completions`，典型表现是**「模型列表拉得到、一对话就失败」**。手动编辑渠道时会踩到（新建向导有归一，编辑对话框没有）。

修法：不逐个 protocol 打补丁，而是把它变成 `LLMModelConfig` 的构造不变量。一次覆盖全部 11 个拼 URL 的地方（包括 `gemini_chat_protocol.dart:29/106` 这两个同样没 trim 的），**也覆盖数据库里已经存着尾斜杠的老渠道，不需要迁移**。`openai_chat_protocol` 的两处仍调 `trimBaseUrl()`，只为跟兄弟 protocol 写法一致。

## ③ SSE `data:` 无空格不识别

`data:` 后那个空格在 SSE 规范里是**可选**的，`data:{…}` 与 `data: {…}` 等价。原来只匹配带空格的，遇到另一种拼法：整个回复原样到达 → 逐行 jsonDecode 失败 → 当噪声跳过 → **一个字都收不到，且不报错**。`sseDataPayload()` 两种都认，注释行 / 空行 / `[DONE]` / `\r\n` 残留的 CR 都正确处理，并保留了原来对「不带 SSE 帧、直接吐裸 JSON 行」的容忍。

## 测试

`flutter analyze` 干净，591 passed / 9 skipped（新增 9 个）。

- `openai_chat_payload_test.dart` — `sseDataPayload` 5 个、`firstChoice` 3 个（含真实尾 chunk 形状）
- `llm_model_config_test.dart` — 端点归一 4 个 case

`docs/api/streaming.md` §1 补了两条协议事实。特别记了一句：空数组尾 chunk 的失败表现和「兼容层没实现 `stream_options`」**一模一样**，排查时极易归错因。

## 未改动（有意）

- **流式 tool_calls** — `protocol.dart:53` 已文档化，带 tools 时强制降级到同步，规格上不违规。
- **`temperature`/`max_tokens`/`top_p`/`seed`/`response_format`/`reasoning_effort` 不发送** — 全部走上游默认值，合法，但目前无法配置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)