### PR TITLE
fix: make relay-served image generation work on both dialects

### DIFF
--- a/docs/api/landscape.md
+++ b/docs/api/landscape.md
@@ -357,7 +357,30 @@ vLLM / llama.cpp。Google 与 Anthropic 也各自提供了一层 OpenAI 兼容�
 **由此得出一条可移植的规则：面向兼容层时，在"官方两种都收"的地方要选中继
 文档写的那一种。** 官方的宽容不是中继的宽容。
 
-### 兼容层文档的通用规律（五个样本的共同点）
+### 第六个样本：同一个生图模型的两条路（截至 2026-08）
+
+New API 的 Gemini 生图模型可以走 ① 形状（`/v1/chat/completions`）也可以走
+③ 形状（`:generateContent`）。**两条路对"谁负责哪个字段"的划分正好互补**，
+而且两边的错法都不报错。以下三条读自中继源码，不是文档——文档这两页的字段
+说明是空的。
+
+- **① 形状：出图参数只认 `extra_body.google.image_config`。** 顶层
+  `image_config` 不读，键名只收 snake_case（`aspect_ratio` / `image_size`），
+  camelCase 会被显式拒绝，其余键一律丢弃。发在顶层的后果是宽高比和分辨率
+  **静默无效**——请求成功、图也出来了，只是尺寸不是你要的那个。
+- **① 形状：`modalities` 和 `safety_settings` 都不读。** 前者由中继按模型名
+  自行推导 `responseModalities`，后者取自中继的服务端配置。
+- **③ 形状：`responseModalities` 没人替你补。** 中继只在**翻译** ① 形状请求
+  时注入它，原生形状是透传。于是同一个模型走 ① 反而更稳——需要显式声明模态
+  的老模型（如 `gemini-2.0-flash-preview-image-generation`）走 ③ 时只回文本。
+
+图片回传形态同样有两种，都得接住：中继自己的适配器把 `inlineData` 写成
+**`content` 里的 markdown** `![image](data:<mime>;base64,…)`（同步和流式都是
+这个形状）；另一些中继改用结构化的
+`message.images[].image_url.url`，其中的 URL 可能是 data URI，**也可能是图床
+的 http 链接**——只认 data URI 的解析器在后一种上得到零张图。
+
+### 兼容层文档的通用规律（六个样本的共同点）
 
 1. **结构照抄，扩展在响应侧。**
 2. **枚举是子集**（reasoning_effort 只写三档、content block 只写 text）。

--- a/lib/services/llm/llm_service.dart
+++ b/lib/services/llm/llm_service.dart
@@ -258,9 +258,17 @@ class LLMService {
   Future<void> _recordUsage(String modelId, LLMModelConfig config, Map<String, dynamic> metadata, {int? modelDbId}) async {
     final db = DatabaseService();
 
-    // Standardize metadata keys (OpenAI vs Google)
-    final promptTokens = _asTokenCount(metadata['promptTokenCount'] ?? metadata['prompt_tokens']);
-    final outputTokens = _asTokenCount(metadata['candidatesTokenCount'] ?? metadata['completion_tokens']);
+    // Standardize metadata keys. Three spellings are in play: Google
+    // (`promptTokenCount`), OpenAI chat (`prompt_tokens`) and the OpenAI
+    // *Images* API (`input_tokens`) — gpt-image-1 reports only the third, so
+    // reading the first two alone recorded every image generation as zero
+    // tokens and only request-billed channels came out right.
+    final promptTokens = _asTokenCount(metadata['promptTokenCount'] ??
+        metadata['prompt_tokens'] ??
+        metadata['input_tokens']);
+    final outputTokens = _asTokenCount(metadata['candidatesTokenCount'] ??
+        metadata['completion_tokens'] ??
+        metadata['output_tokens']);
     final cacheTokens = _extractCacheTokens(metadata, promptTokens);
 
     await db.recordTokenUsage({
@@ -309,7 +317,9 @@ class LLMService {
   /// conclude the context is empty on exactly the small local models that
   /// overflow first, so this returns null and lets them fall back.
   static int? promptTokensOf(Map<String, dynamic> metadata) {
-    final raw = metadata['promptTokenCount'] ?? metadata['prompt_tokens'];
+    final raw = metadata['promptTokenCount'] ??
+        metadata['prompt_tokens'] ??
+        metadata['input_tokens'];
     if (raw == null) return null;
     final count = raw is num ? raw.toInt() : int.tryParse(raw.toString());
     return (count == null || count <= 0) ? null : count;

--- a/lib/services/llm/protocols/gemini_chat_protocol.dart
+++ b/lib/services/llm/protocols/gemini_chat_protocol.dart
@@ -29,7 +29,8 @@ class GeminiChatProtocol implements ChatProtocol {
         Uri.parse('${config.endpoint}/models/${config.modelId}:generateContent'));
     logger?.call('Preparing Google GenAI request to: ${url.host}', level: 'DEBUG');
     final headers = target.headers();
-    final payload = prepareGooglePayload(history, options, config.endpoint, tools: tools);
+    final payload = prepareGooglePayload(history, options, config.endpoint,
+        tools: tools, emitsImages: target.model.capabilities.isImageGenerator);
     logger?.call('Safety settings: ${SafetySettings.describe(options?[SafetySettings.paramKey])}', level: 'DEBUG');
 
     logger?.call('Sending POST request...', level: 'DEBUG');
@@ -69,6 +70,18 @@ class GeminiChatProtocol implements ChatProtocol {
 
       logger?.call('Response received, parsing data...', level: 'DEBUG');
 
+      // A body with no candidates and no promptFeedback reached the caller as
+      // an empty success — the same silent no-op the OpenAI surface used to
+      // have. Only the synchronous path can judge this: in a stream a chunk
+      // carrying nothing but usageMetadata is perfectly normal, so
+      // parseGoogleChunks must stay tolerant of it.
+      final candidates = data is Map ? data['candidates'] : null;
+      if (candidates is! List || candidates.isEmpty) {
+        final body = response.body;
+        throw Exception('Google GenAI returned no candidates: '
+            '${body.length > 500 ? '${body.substring(0, 500)}…' : body}');
+      }
+
       String text = "";
       List<Uint8List> images = [];
       List<LLMToolCall> toolCalls = [];
@@ -106,7 +119,8 @@ class GeminiChatProtocol implements ChatProtocol {
         '${config.endpoint}/models/${config.modelId}:streamGenerateContent?alt=sse'));
     logger?.call('Starting Google GenAI stream: ${url.host}', level: 'DEBUG');
     final headers = target.headers();
-    final payload = prepareGooglePayload(history, options, config.endpoint);
+    final payload = prepareGooglePayload(history, options, config.endpoint,
+        emitsImages: target.model.capabilities.isImageGenerator);
     logger?.call('Safety settings: ${SafetySettings.describe(options?[SafetySettings.paramKey])}', level: 'DEBUG');
 
     final request = http.Request('POST', url);

--- a/lib/services/llm/protocols/gemini_payload.dart
+++ b/lib/services/llm/protocols/gemini_payload.dart
@@ -130,6 +130,23 @@ Map<String, dynamic> prepareVeoPayload(List<LLMMessage> history, Map<String, dyn
   };
 }
 
+/// Finish reasons that mean the model was stopped by a policy rather than by
+/// running out of things to say.
+///
+/// `IMAGE_SAFETY` and `PROHIBITED_CONTENT` are the two the image models
+/// actually return; both used to fall through the `SAFETY`/`RECITATION`
+/// comparison and be logged at INFO, which is the level a successful request
+/// uses. `MAX_TOKENS` is deliberately absent — a truncated answer is still an
+/// answer.
+const Set<String> blockingFinishReasons = {
+  'SAFETY',
+  'IMAGE_SAFETY',
+  'RECITATION',
+  'BLOCKLIST',
+  'PROHIBITED_CONTENT',
+  'SPII',
+};
+
 /// Parses one `generateContent`/stream chunk into [LLMResponseChunk]s, handling
 /// prompt blocking, finish reasons and safety ratings via [logger].
 Iterable<LLMResponseChunk> parseGoogleChunks(Map<String, dynamic> chunkData, {Function(String, {String level})? logger}) sync* {
@@ -161,17 +178,18 @@ Iterable<LLMResponseChunk> parseGoogleChunks(Map<String, dynamic> chunkData, {Fu
 
   for (var candidate in candidates) {
     final finishReason = candidate['finishReason'] as String?;
+    final parts = candidate['content']?['parts'] as List?;
 
     // Handle Safety and other non-STOP reasons (Section 3.3)
     if (finishReason != null && finishReason != 'STOP') {
+      final blocked = blockingFinishReasons.contains(finishReason);
       String level = 'INFO';
-      if (finishReason == 'SAFETY') level = 'WARN';
-      if (finishReason == 'RECITATION') level = 'WARN';
+      if (blocked) level = 'WARN';
       if (finishReason == 'OTHER') level = 'ERROR';
 
       logger?.call('Generation finished with reason: $finishReason', level: level);
 
-      if (finishReason == 'SAFETY') {
+      if (blocked) {
         logger?.call('Content was flagged by safety filters.', level: 'WARN');
         if (candidate['safetyRatings'] != null) {
           final ratings = candidate['safetyRatings'] as List;
@@ -182,9 +200,18 @@ Iterable<LLMResponseChunk> parseGoogleChunks(Map<String, dynamic> chunkData, {Fu
           }
         }
       }
+
+      // A block that left nothing behind is a failure, not a quiet success.
+      // Image generation is where this bites: the candidate carries no parts
+      // at all, so the caller collected zero images and the task reported
+      // "done" with no output and only a log line to explain it. When the
+      // candidate *does* carry content (a truncated MAX_TOKENS answer, or a
+      // block that arrived after text streamed), the content is kept.
+      if (blocked && (parts == null || parts.isEmpty)) {
+        throw Exception('Google GenAI blocked the generation: $finishReason');
+      }
     }
 
-    final parts = candidate['content']?['parts'] as List?;
     if (parts != null) {
       int callIndex = 0;
       for (var part in parts) {
@@ -223,7 +250,20 @@ Iterable<LLMResponseChunk> parseGoogleChunks(Map<String, dynamic> chunkData, {Fu
 /// Standard `:generateContent` request body: system instruction, multimodal
 /// contents, image-generation config and per-request safety settings (from
 /// `options['safetySettings']`, defaulting to BLOCK_NONE for all categories).
-Map<String, dynamic> prepareGooglePayload(List<LLMMessage> history, Map<String, dynamic>? options, String? endpoint, {List<LLMTool>? tools}) {
+///
+/// [emitsImages] declares `responseModalities: ["TEXT","IMAGE"]`. It comes
+/// from the model descriptor's capabilities, never from the model id — this
+/// layer must not sniff. Nothing else supplies it: a relay only injects the
+/// modalities when it is *translating* an OpenAI-shaped request, so on the
+/// native surface the field is ours to send or the model answers in text
+/// only — silently, for the models that need it declared.
+Map<String, dynamic> prepareGooglePayload(
+  List<LLMMessage> history,
+  Map<String, dynamic>? options,
+  String? endpoint, {
+  List<LLMTool>? tools,
+  bool emitsImages = false,
+}) {
   final systemMessages = history.where((m) => m.role == LLMRole.system).toList();
   final conversationMessages = history.where((m) => m.role != LLMRole.system).toList();
 
@@ -295,6 +335,9 @@ Map<String, dynamic> prepareGooglePayload(List<LLMMessage> history, Map<String, 
   }).toList();
 
   final generationConfig = <String, dynamic>{};
+  if (emitsImages) {
+    generationConfig['responseModalities'] = ['TEXT', 'IMAGE'];
+  }
   if (options != null) {
     final imageConfig = <String, dynamic>{};
     // personGeneration is Only for Imagen model

--- a/lib/services/llm/protocols/openai_chat_protocol.dart
+++ b/lib/services/llm/protocols/openai_chat_protocol.dart
@@ -246,27 +246,89 @@ class InlineThinkStreamFilter {
   }
 }
 
-/// Throws when a 200 response body is actually an error envelope.
+/// Images carried by a structured (non-text) response field.
 ///
-/// Compat layers deliver failures inside a successful HTTP response in at
-/// least two spellings (streaming.md §3.1/§3.2): an `error` field (relays,
-/// audits, quota), or MiniMax's `base_resp.status_code != 0` (auth 1004,
-/// balance 1008, rate 1002, token limit 1039). A client that only checks the
-/// HTTP status reads an expired key as a normal empty reply.
-void throwIfEnvelopeError(Map<String, dynamic> data) {
-  final err = data['error'];
-  if (err != null) {
-    final msg = err is Map ? (err['message'] ?? err.toString()) : err.toString();
-    throw Exception('API error in response body: $msg');
-  }
-  final baseResp = data['base_resp'];
-  if (baseResp is Map) {
-    final code = baseResp['status_code'];
-    if (code is num && code != 0) {
-      throw Exception(
-          'API error (base_resp $code): ${baseResp['status_msg'] ?? 'unknown'}');
+/// Relays disagree on how a generated image comes back. New API's own Gemini
+/// adapter writes markdown `![image](data:…)` into `content`, which the text
+/// scan handles; others use `images: [{image_url: {url}}]` or a bare
+/// `image_data` base64 string. [urls] holds `http(s)` entries the caller must
+/// still fetch — a relay backed by object storage returns a link rather than
+/// the bytes, and dropping those was indistinguishable from generating nothing.
+class StructuredImages {
+  final List<Uint8List> bytes;
+  final List<String> urls;
+  const StructuredImages(this.bytes, this.urls);
+
+  bool get isEmpty => bytes.isEmpty && urls.isEmpty;
+}
+
+/// Reads the structured image fields of a `message` (sync) or `delta`
+/// (streaming) object. Unknown shapes contribute nothing.
+StructuredImages extractStructuredImages(Map<String, dynamic> source) {
+  final bytes = <Uint8List>[];
+  final urls = <String>[];
+
+  void addUrl(String url) {
+    if (url.startsWith('data:image/')) {
+      final comma = url.indexOf(',');
+      if (comma == -1) return;
+      try {
+        bytes.add(base64Decode(url.substring(comma + 1)));
+      } catch (_) {/* not decodable — nothing to add */}
+    } else if (url.startsWith('http://') || url.startsWith('https://')) {
+      urls.add(url);
     }
   }
+
+  final imageData = source['image_data'];
+  if (imageData is String && imageData.isNotEmpty) {
+    try {
+      bytes.add(base64Decode(imageData));
+    } catch (_) {/* ignore */}
+  }
+
+  // `images: [{ image_url: { url: "data:…"|"http…" } }]`
+  final imageList = source['images'];
+  if (imageList is List) {
+    for (final entry in imageList) {
+      if (entry is! Map) continue;
+      final urlField = entry['image_url'] is Map
+          ? entry['image_url']['url']
+          : (entry['image_url'] ?? entry['url']);
+      if (urlField is String && urlField.isNotEmpty) addUrl(urlField);
+      final b64 = entry['b64_json'];
+      if (b64 is String && b64.isNotEmpty) {
+        try {
+          bytes.add(base64Decode(b64));
+        } catch (_) {/* ignore */}
+      }
+    }
+  }
+
+  return StructuredImages(bytes, urls);
+}
+
+/// Image URLs a reply's *text* points at, in declaration order, deduplicated.
+///
+/// Two forms count as "this is the image you asked for":
+///  * a markdown image link — `![image](https://…)`. New API's Gemini adapter
+///    writes exactly this shape with a `data:` URI, and relays backed by
+///    object storage write it with an `http(s)` link instead; the second kind
+///    used to be dropped, so those relays produced a caption and no picture.
+///  * a bare `storage.googleapis.com` link, the historical Gemini case.
+///
+/// A bare link to any other host is deliberately *not* fetched: a chat reply
+/// that merely cites a URL must not cause the app to go download it.
+List<String> imageUrlsInText(String text) {
+  final urls = <String>{};
+  for (final m in RegExp(r'!\[[^\]]*\]\((https?://[^\s)]+)\)').allMatches(text)) {
+    urls.add(m.group(1)!);
+  }
+  for (final m
+      in RegExp(r'https?://storage\.googleapis\.com/[^\s"\]\)]+').allMatches(text)) {
+    urls.add(m.group(0)!);
+  }
+  return urls.toList();
 }
 
 /// OpenAI `POST /chat/completions` — JSON request, JSON or SSE response.
@@ -336,7 +398,9 @@ class OpenAIChatProtocol implements ChatProtocol {
       String? reasoningFieldName;
 
       final choice = data is Map<String, dynamic> ? firstChoice(data) : null;
-      final message = choice?['message'];
+      final rawMessage = choice?['message'];
+      final message =
+          rawMessage is Map ? rawMessage.cast<String, dynamic>() : null;
       if (message == null) {
         // Previously this fell through to an empty LLMResponse, which callers
         // (the assistant loop above all) read as "the model chose to say
@@ -409,7 +473,9 @@ class OpenAIChatProtocol implements ChatProtocol {
         }
 
         // Some OpenAI-compat relays expose images via a structured field.
-        _extractStructuredImages(message, images);
+        final structured = extractStructuredImages(message);
+        images.addAll(structured.bytes);
+        images.addAll(await _fetchImageUrls(structured.urls, config, logger));
 
         if (text.isNotEmpty) {
           logger?.call('Extracting images from text response...', level: 'DEBUG');
@@ -535,14 +601,29 @@ class OpenAIChatProtocol implements ChatProtocol {
         final rawFinish = choice['finish_reason'];
         if (rawFinish is String && rawFinish.isNotEmpty) finishReason = rawFinish;
 
+        // Structured image fields, read outside the tolerant try for the same
+        // reason as usage: on a relay that answers with `delta.images[]`
+        // instead of a markdown data URI in the text, these *are* the reply.
+        // Only `image_data` used to be read here, so those relays streamed
+        // zero images and the task reported success with nothing in it.
+        final rawDelta = choice['delta'];
+        final delta = rawDelta is Map ? rawDelta.cast<String, dynamic>() : null;
+        if (delta != null) {
+          final structured = extractStructuredImages(delta);
+          for (final img in structured.bytes) {
+            yield LLMResponseChunk(imagePart: img);
+          }
+          for (final img in await _fetchImageUrls(structured.urls, config, logger)) {
+            yield LLMResponseChunk(imagePart: img);
+          }
+        }
+
         try {
-          final delta = choice['delta'];
           // Same shape tolerance as the sync path — a delta carrying a content
           // array would otherwise throw into the catch below and be dropped as
           // "parse noise", losing the reply one chunk at a time.
           final text = contentToText(delta?['content']);
           final reasoning = delta?['reasoning_content'] ?? delta?['reasoning'];
-          final imageData = delta?['image_data'];
 
           if (reasoning is String && reasoning.isNotEmpty) {
             // Dedicated channel: consumers that accumulate textPart into a
@@ -571,12 +652,6 @@ class OpenAIChatProtocol implements ChatProtocol {
             }
           }
 
-          if (imageData != null) {
-            yield LLMResponseChunk(
-              imagePart: base64Decode(imageData),
-              metadata: chunkData['usage'],
-            );
-          }
         } catch (e) {
           // Ignore parse errors
         }
@@ -622,31 +697,34 @@ class OpenAIChatProtocol implements ChatProtocol {
     yield LLMResponseChunk(isDone: true);
   }
 
-  /// Pull images out of structured (non-text) response fields used by some
-  /// OpenAI-compatible relays.
-  void _extractStructuredImages(Map<String, dynamic> message, List<Uint8List> images) {
-    final imageData = message['image_data'];
-    if (imageData is String && imageData.isNotEmpty) {
-      try {
-        images.add(base64Decode(imageData));
-      } catch (_) {/* ignore */}
-    }
-
-    // `images: [{ image_url: { url: "data:..."|"http..." } }]`
-    final imageList = message['images'];
-    if (imageList is List) {
-      for (final entry in imageList) {
-        final urlField = entry is Map ? (entry['image_url']?['url'] ?? entry['url']) : null;
-        if (urlField is String && urlField.startsWith('data:image/')) {
-          final comma = urlField.indexOf(',');
-          if (comma != -1) {
-            try {
-              images.add(base64Decode(urlField.substring(comma + 1)));
-            } catch (_) {/* ignore */}
+  /// Downloads images a relay returned by reference rather than by value.
+  /// A failed fetch is logged and skipped — one dead link must not lose the
+  /// images that did arrive.
+  Future<List<Uint8List>> _fetchImageUrls(
+    List<String> urls,
+    LLMModelConfig config,
+    LLMLogger? logger,
+  ) async {
+    if (urls.isEmpty) return const [];
+    final images = <Uint8List>[];
+    final client = config.createClient();
+    try {
+      for (final url in urls) {
+        try {
+          final resp = await client.get(Uri.parse(url));
+          if (resp.statusCode == 200) {
+            images.add(resp.bodyBytes);
+          } else {
+            logger?.call('Image URL returned ${resp.statusCode}: $url', level: 'WARN');
           }
+        } catch (e) {
+          logger?.call('Failed to fetch image URL $url: $e', level: 'WARN');
         }
       }
+    } finally {
+      client.close();
     }
+    return images;
   }
 
   bool _isBase64Heuristic(String text) {
@@ -673,12 +751,9 @@ class OpenAIChatProtocol implements ChatProtocol {
         } catch (e) { /* ignore */ }
       }
 
-      // 2. Extract Cloud URLs
-      final urlRegex = RegExp(r'(https?://storage\.googleapis\.com/[^\s"\]\)]+)');
-      final urlMatches = urlRegex.allMatches(text);
-      for (var match in urlMatches) {
+      // 2. Fetch images the text points at rather than embeds.
+      for (final url in imageUrlsInText(text)) {
         try {
-          final url = match.group(1)!;
           final response = await client.get(Uri.parse(url));
           if (response.statusCode == 200) {
             images.add(response.bodyBytes);
@@ -806,26 +881,54 @@ class OpenAIChatProtocol implements ChatProtocol {
       _prepareChatPayload(target, history, options, isStreaming: isStreaming, tools: tools);
 
   /// Gemini-via-OpenAI compatibility extensions used by relay services.
+  ///
+  /// The aspect ratio and 1K/2K/4K size go out **twice**, because the two
+  /// hosts that serve Gemini through an OpenAI-shaped surface read them from
+  /// different places and neither complains about the other's spelling:
+  ///
+  ///  * New API only reads `extra_body.google.image_config`, and only its
+  ///    `aspect_ratio` / `image_size` keys — it rejects the camelCase
+  ///    spellings outright and ignores everything else, so the top-level
+  ///    `image_config` this used to send alone was silently dropped and the
+  ///    workbench's ratio and resolution controls did nothing.
+  ///  * The top-level form is what other relays (and our own history) use, so
+  ///    it stays.
+  ///
+  /// `modalities` and `safety_settings` are likewise ignored by New API — it
+  /// derives `responseModalities` from the model name and takes safety
+  /// thresholds from its own server-side config — but they are what other
+  /// OpenAI-shaped Gemini hosts read, and an unknown field costs nothing.
   void _applyGeminiCompatExtensions(Map<String, dynamic> payload, Map<String, dynamic>? options) {
     payload["modalities"] = ["image", "text"];
 
     payload["safety_settings"] =
         SafetySettings.toApiList(options?[SafetySettings.paramKey]);
 
-    if (options != null) {
-      final imageConfig = <String, dynamic>{};
-      imageConfig['person_generation'] = 'allow_all';
-      if (options.containsKey('aspectRatio') && options['aspectRatio'] != 'not_set') {
-        imageConfig['aspect_ratio'] = options['aspectRatio'];
-      }
-      if (options.containsKey('imageSize')) {
-        imageConfig['image_size'] = options['imageSize'];
-      }
-      if (imageConfig.isNotEmpty) {
-        imageConfig['number_of_images'] = 1;
-        payload["image_config"] = imageConfig;
-      }
+    if (options == null) return;
+
+    // Only these two keys are portable; `person_generation` /
+    // `number_of_images` belong to the top-level dialect alone.
+    final portable = <String, dynamic>{};
+    if (options.containsKey('aspectRatio') && options['aspectRatio'] != 'not_set') {
+      portable['aspect_ratio'] = options['aspectRatio'];
     }
+    if (options.containsKey('imageSize')) {
+      portable['image_size'] = options['imageSize'];
+    }
+    if (portable.isEmpty) return;
+
+    payload["image_config"] = {
+      'person_generation': 'allow_all',
+      ...portable,
+      'number_of_images': 1,
+    };
+
+    final extraBody = (payload['extra_body'] as Map<String, dynamic>?) ?? {};
+    final google = (extraBody['google'] as Map<String, dynamic>?) ?? {};
+    payload['extra_body'] = {
+      ...extraBody,
+      'google': {...google, 'image_config': portable},
+    };
   }
 }
 

--- a/lib/services/llm/protocols/openai_images_protocol.dart
+++ b/lib/services/llm/protocols/openai_images_protocol.dart
@@ -58,7 +58,14 @@ class OpenAIImagesProtocol implements ImageGenProtocol {
 
       if (isEdit) {
         final request = http.MultipartRequest('POST', url);
-        request.headers['Authorization'] = 'Bearer ${config.apiKey}';
+        // Auth comes from the vendor profile (layer 2) like every other
+        // surface — a hardcoded bearer header worked only because today's
+        // OpenAI-family vendors all happen to use one, and would have failed
+        // on the next one while plain generation kept working. Content-Type
+        // is dropped: the multipart body sets its own with a boundary.
+        request.headers.addAll(
+          Map.of(target.headers())..removeWhere((k, _) => k.toLowerCase() == 'content-type'),
+        );
         request.fields['model'] = config.modelId;
         request.fields['prompt'] = prompt;
         if (size != null) request.fields['size'] = size;
@@ -118,22 +125,46 @@ class OpenAIImagesProtocol implements ImageGenProtocol {
       }
 
       final data = jsonDecode(response.body);
-      final List<dynamic> items = data['data'] ?? [];
+      if (data is Map<String, dynamic>) {
+        // 200 does not mean success on a relay — an `{"error": …}` body used
+        // to parse as zero images and report the task as finished with
+        // nothing in it. Same check the chat surface makes.
+        throwIfEnvelopeError(data);
+      }
+      final rawItems = data is Map ? data['data'] : null;
+      final List<dynamic> items = rawItems is List ? rawItems : const [];
       final List<Uint8List> images = [];
 
       for (final item in items) {
-        final b64 = item['b64_json'] as String?;
-        if (b64 != null) {
+        if (item is! Map) continue;
+        final b64 = item['b64_json'];
+        if (b64 is String && b64.isNotEmpty) {
           images.add(base64Decode(b64));
           continue;
         }
-        final imgUrl = item['url'] as String?;
-        if (imgUrl != null) {
+        final imgUrl = item['url'];
+        if (imgUrl is String && imgUrl.isNotEmpty) {
           try {
             final imgResp = await client.get(Uri.parse(imgUrl));
-            if (imgResp.statusCode == 200) images.add(imgResp.bodyBytes);
-          } catch (_) {/* ignore */}
+            if (imgResp.statusCode == 200) {
+              images.add(imgResp.bodyBytes);
+            } else {
+              logger?.call('Image URL returned ${imgResp.statusCode}: $imgUrl', level: 'WARN');
+            }
+          } catch (e) {
+            logger?.call('Failed to fetch image URL: $e', level: 'WARN');
+          }
         }
+      }
+
+      if (images.isEmpty) {
+        // The Images API has exactly one deliverable. Returning an empty
+        // response here reads to the task executor as a successful generation
+        // that produced nothing, which is indistinguishable from a model
+        // refusing — so say what actually came back instead.
+        final body = response.body;
+        throw Exception('OpenAI Images API returned no image: '
+            '${body.length > 500 ? '${body.substring(0, 500)}…' : body}');
       }
 
       logger?.call('Images parse complete. Images: ${images.length}', level: 'DEBUG');
@@ -141,7 +172,11 @@ class OpenAIImagesProtocol implements ImageGenProtocol {
       return LLMResponse(
         text: '',
         generatedImages: images,
-        metadata: data['usage'] ?? {},
+        // gpt-image-1 reports `input_tokens`/`output_tokens` here, not the
+        // chat spelling — see LLMService._recordUsage, which reads both.
+        metadata: (data is Map ? data['usage'] : null) is Map
+            ? (data['usage'] as Map).cast<String, dynamic>()
+            : const {},
       );
     } finally {
       client.close();

--- a/lib/services/llm/protocols/protocol.dart
+++ b/lib/services/llm/protocols/protocol.dart
@@ -124,6 +124,32 @@ abstract class DiscoveryProtocol {
 // Shared wire-level helpers
 // ---------------------------------------------------------------------------
 
+/// Throws when a 200 response body is actually an error envelope.
+///
+/// Compat layers deliver failures inside a successful HTTP response in at
+/// least two spellings (streaming.md §3.1/§3.2): an `error` field (relays,
+/// audits, quota), or MiniMax's `base_resp.status_code != 0` (auth 1004,
+/// balance 1008, rate 1002, token limit 1039). A client that only checks the
+/// HTTP status reads an expired key as a normal empty reply.
+///
+/// Lives here rather than in one protocol because every JSON surface a relay
+/// fronts can return it — the images endpoints as much as chat.
+void throwIfEnvelopeError(Map<String, dynamic> data) {
+  final err = data['error'];
+  if (err != null) {
+    final msg = err is Map ? (err['message'] ?? err.toString()) : err.toString();
+    throw Exception('API error in response body: $msg');
+  }
+  final baseResp = data['base_resp'];
+  if (baseResp is Map) {
+    final code = baseResp['status_code'];
+    if (code is num && code != 0) {
+      throw Exception(
+          'API error (base_resp $code): ${baseResp['status_msg'] ?? 'unknown'}');
+    }
+  }
+}
+
 /// [endpoint] without any trailing slashes.
 ///
 /// Redundant for a [LLMModelConfig.endpoint], which is normalized on

--- a/test/image_relay_compat_test.dart
+++ b/test/image_relay_compat_test.dart
@@ -1,0 +1,236 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/model_descriptor.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/protocols/gemini_payload.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/protocols/openai_chat_protocol.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/protocols/protocol.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/vendors/vendors.dart';
+
+/// Pins the two ways a relay serves a Gemini image model — the OpenAI chat
+/// shape and the Gemini-native shape — since the two disagree about which
+/// side is responsible for which field.
+void main() {
+  final pixel = base64Encode([1, 2, 3]);
+
+  LLMTarget target(String modelId) {
+    final config = LLMModelConfig(
+      modelId: modelId,
+      channelType: Vendors.newApiOpenAI,
+      endpoint: 'https://relay.example.com/v1',
+      apiKey: 'k',
+    );
+    return LLMTarget(
+      config: config,
+      vendor: Vendors.byId(config.channelType),
+      model: ModelDescriptor.of(config.modelId),
+    );
+  }
+
+  group('extractStructuredImages', () {
+    test('data URIs decode in place; http links are deferred to the caller', () {
+      // The http form is what a relay backed by object storage returns. It
+      // used to be dropped on the floor, which looked exactly like the model
+      // generating nothing.
+      final r = extractStructuredImages({
+        'images': [
+          {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,$pixel'}},
+          {'type': 'image_url', 'image_url': {'url': 'https://cdn.example.com/a.png'}},
+        ]
+      });
+      expect(r.bytes, hasLength(1));
+      expect(r.bytes.first, [1, 2, 3]);
+      expect(r.urls, ['https://cdn.example.com/a.png']);
+    });
+
+    test('the flat image_url spelling and b64_json are both accepted', () {
+      final flat = extractStructuredImages({
+        'images': [
+          {'image_url': 'https://cdn.example.com/b.png'},
+          {'url': 'data:image/png;base64,$pixel'},
+          {'b64_json': pixel},
+        ]
+      });
+      expect(flat.urls, ['https://cdn.example.com/b.png']);
+      expect(flat.bytes, hasLength(2));
+    });
+
+    test('the bare image_data field still works', () {
+      final r = extractStructuredImages({'image_data': pixel});
+      expect(r.bytes, hasLength(1));
+      expect(r.urls, isEmpty);
+    });
+
+    test('absent or malformed fields yield nothing, never a throw', () {
+      expect(extractStructuredImages({}).isEmpty, isTrue);
+      expect(extractStructuredImages({'images': 'nope'}).isEmpty, isTrue);
+      expect(extractStructuredImages({'images': ['nope']}).isEmpty, isTrue);
+      expect(extractStructuredImages({'image_data': '!!not base64!!'}).isEmpty, isTrue);
+      expect(extractStructuredImages({
+        'images': [{'image_url': {'url': 'ftp://example.com/x.png'}}]
+      }).isEmpty, isTrue);
+    });
+  });
+
+  group('imageUrlsInText', () {
+    test('a markdown image link is fetched whatever the host', () {
+      // New API's own adapter writes `![image](data:…)`; relays that store
+      // the file write the same shape with a link.
+      expect(
+        imageUrlsInText('here you go\n\n![image](https://cdn.example.com/a.png)'),
+        ['https://cdn.example.com/a.png'],
+      );
+    });
+
+    test('a bare link that is merely cited is left alone', () {
+      // Downloading every URL a chat reply mentions is not acceptable; only
+      // the historical Gemini bucket keeps its bare-link exemption.
+      expect(imageUrlsInText('see https://cdn.example.com/a.png for details'), isEmpty);
+      expect(
+        imageUrlsInText('https://storage.googleapis.com/bucket/a.png'),
+        ['https://storage.googleapis.com/bucket/a.png'],
+      );
+    });
+
+    test('data URIs are not URLs to fetch — the base64 scan already has them', () {
+      expect(imageUrlsInText('![image](data:image/png;base64,$pixel)'), isEmpty);
+    });
+
+    test('the same link twice is fetched once', () {
+      expect(
+        imageUrlsInText('![a](https://x.example/1.png) ![b](https://x.example/1.png)'),
+        hasLength(1),
+      );
+    });
+  });
+
+  group('Gemini-via-OpenAI image config', () {
+    final protocol = OpenAIChatProtocol();
+
+    Map<String, dynamic> payloadWith(Map<String, dynamic>? options) =>
+        protocol.buildChatPayloadForTest(
+          target('gemini-2.5-flash-image'),
+          [LLMMessage(role: LLMRole.user, content: 'a cat')],
+          options: options,
+          isStreaming: false,
+        );
+
+    test('the ratio and size also go out under extra_body.google.image_config', () {
+      // New API reads *only* this path, and only these two snake_case keys —
+      // the top-level copy alone was silently ignored, so the workbench's
+      // aspect-ratio and 1K/2K/4K controls did nothing.
+      final payload = payloadWith({'aspectRatio': '16:9', 'imageSize': '4K'});
+
+      final google = (payload['extra_body'] as Map)['google'] as Map;
+      expect(google['image_config'], {'aspect_ratio': '16:9', 'image_size': '4K'});
+      // Keys New API rejects or ignores must not ride along in extra_body.
+      expect((google['image_config'] as Map).containsKey('person_generation'), isFalse);
+      expect((google['image_config'] as Map).containsKey('number_of_images'), isFalse);
+      expect((google['image_config'] as Map).containsKey('aspectRatio'), isFalse);
+    });
+
+    test('the top-level dialect is kept for the hosts that read it', () {
+      final payload = payloadWith({'aspectRatio': '16:9', 'imageSize': '4K'});
+      expect(payload['image_config'], {
+        'person_generation': 'allow_all',
+        'aspect_ratio': '16:9',
+        'image_size': '4K',
+        'number_of_images': 1,
+      });
+    });
+
+    test('nothing to configure means neither field is sent', () {
+      final payload = payloadWith({'aspectRatio': 'not_set'});
+      expect(payload.containsKey('image_config'), isFalse);
+      expect(payload.containsKey('extra_body'), isFalse);
+    });
+
+    test('a non-Gemini model gets none of the extensions', () {
+      final payload = protocol.buildChatPayloadForTest(
+        target('gpt-5-chat'),
+        [LLMMessage(role: LLMRole.user, content: 'hi')],
+        options: {'aspectRatio': '16:9'},
+        isStreaming: false,
+      );
+      expect(payload.containsKey('extra_body'), isFalse);
+      expect(payload.containsKey('image_config'), isFalse);
+      expect(payload.containsKey('modalities'), isFalse);
+    });
+  });
+
+  group('Gemini native image request', () {
+    final history = [LLMMessage(role: LLMRole.user, content: 'a cat')];
+
+    test('an image model declares responseModalities — nobody else will', () {
+      // A relay injects the modalities only when translating an OpenAI-shaped
+      // request; on the native surface the field is ours to send.
+      final payload = prepareGooglePayload(history, null, null, emitsImages: true);
+      expect(payload['generationConfig']['responseModalities'], ['TEXT', 'IMAGE']);
+    });
+
+    test('a text model does not', () {
+      final payload = prepareGooglePayload(history, null, null);
+      expect(
+        (payload['generationConfig'] as Map).containsKey('responseModalities'),
+        isFalse,
+      );
+    });
+
+    test('imageConfig keeps the native camelCase spelling', () {
+      final payload = prepareGooglePayload(
+        history,
+        {'aspectRatio': '16:9', 'imageSize': '2K'},
+        null,
+        emitsImages: true,
+      );
+      expect(payload['generationConfig']['imageConfig'],
+          {'aspectRatio': '16:9', 'imageSize': '2K'});
+    });
+  });
+
+  group('Gemini blocking finish reasons', () {
+    Map<String, dynamic> candidate(String finishReason, {List<dynamic>? parts}) => {
+          'candidates': [
+            {
+              'finishReason': finishReason,
+              if (parts != null) 'content': {'parts': parts},
+            }
+          ]
+        };
+
+    test('a block that produced nothing is a failure, not an empty success', () {
+      // IMAGE_SAFETY and PROHIBITED_CONTENT are what the image models return;
+      // both used to be logged at INFO and reported as a completed task with
+      // no picture in it.
+      for (final reason in ['IMAGE_SAFETY', 'PROHIBITED_CONTENT', 'SAFETY']) {
+        expect(
+          () => parseGoogleChunks(candidate(reason)).toList(),
+          throwsA(predicate((e) => e.toString().contains(reason))),
+          reason: reason,
+        );
+      }
+    });
+
+    test('a truncated answer is still an answer', () {
+      final chunks = parseGoogleChunks(
+        candidate('MAX_TOKENS', parts: [{'text': 'as far as I got'}]),
+      ).toList();
+      expect(chunks.single.textPart, 'as far as I got');
+    });
+
+    test('content that arrived before the block is kept', () {
+      final chunks = parseGoogleChunks(
+        candidate('SAFETY', parts: [{'text': 'partial'}]),
+      ).toList();
+      expect(chunks.single.textPart, 'partial');
+    });
+
+    test('a usage-only chunk stays legal — streams end with one', () {
+      final chunks = parseGoogleChunks({
+        'usageMetadata': {'promptTokenCount': 7}
+      }).toList();
+      expect(chunks.single.metadata, {'promptTokenCount': 7});
+    });
+  });
+}


### PR DESCRIPTION
中转站的 Gemini 生图模型有两条路：[① OpenAI chat 形状](https://www.newapi.ai/zh/docs/api/ai-model/images/gemini/geminirelayv1beta-389846313) 和 [③ Gemini 原生形状](https://www.newapi.ai/zh/docs/api/ai-model/images/gemini/geminirelayv1beta-383837589)。审查下来，**两边对「谁负责哪个字段」的划分正好互补**，而且错法全是静默的。

这两页文档的字段说明是空的，所以下面的结论读自中继源码（`QuantumNous/new-api`），不是文档。

## 请求侧

**① 出图参数发错了位置（严重）**

```go
// relaykit/relayconvert/internal/oai_chat/to_gemini_chat_req.go:120-146
if imageConfig, ok := googleBody["image_config"].(map[string]interface{}); ok {
    geminiImageConfig["aspectRatio"] = imageConfig["aspect_ratio"]
    geminiImageConfig["imageSize"]   = imageConfig["image_size"]
}
```

只读 `extra_body.google.image_config`，只收这两个 snake_case 键（camelCase 会被显式拒绝）。我们发的是顶层 `image_config` → **工作台的宽高比和 1K/2K/4K 开关完全不生效**。请求成功、图也出来了，只是尺寸不是用户选的那个。

现在**两处都发**：顶层保留原样（`person_generation`/`number_of_images` 是那个方言的一部分），extra_body 只放中继接收的两个键。不做替换——Google 官方 OpenAI 兼容层读哪种我没验证，多余字段两边都会忽略。

顺带记录：`modalities` 和 `safety_settings` 中继也不读（前者按模型名自行推导，后者取服务端配置）。保留发送，因为别的 OpenAI 形状 Gemini 主机读它们。

**② 原生路径从不发 `responseModalities`（严重）**

`SupportsImagineModel` 只在 `oai_chat` / `oai_responses` 两个转换器里被调用——**中继只在翻译 ① 形状请求时注入模态，原生形状是透传**。于是原生路径全靠模型默认值，需要显式声明的模型（如 `gemini-2.0-flash-preview-image-generation`，我们的 family 判定 `id.contains('gemini') && id.contains('image')` 匹配得到）只回文本。

讽刺的是同一个模型走 ① 反而更稳。现在由 `ModelDescriptor` 的 `capabilities.isImageGenerator` 驱动发送——不是嗅探 model id，守住分层规则。

## 响应侧

**③ 图片回传只覆盖了两种半**

中继自己的适配器把 `inlineData` 写成 `content` 里的 markdown `![image](data:…)`（同步和流式都是），这条我们一直能接住。但：

- 流式只读 `delta.image_data`，用 `delta.images[]` 的中继**流式下零张图**
- `image_url.url` 是 http 图床链接而非 data URI 时，两条路径都直接丢弃——和「什么都没生成」无法区分

抽出共享的 `extractStructuredImages()`，返回「已解码字节」+「待抓取 http 链接」，同步流式共用，顺带认了扁平 `image_url` 字符串和 `b64_json`。

文本链接从「只抓 `storage.googleapis.com`」放宽到 **markdown 图片语法一律抓**。裸链接仍然不抓——聊天回复里顺口提到的 URL 不该让 app 去下载它；googleapis 保留历史豁免。

**④ Images API 缺 200-带错检查**

`throwIfEnvelopeError` 移到 `protocol.dart` 的共享 wire helper 区（本来就不属于某一个协议），images 路径接上。零张图时抛出带响应体的异常，而不是返回空结果——和 chat 路径的「no choices」一致。

**⑤ 阻断型 finishReason 只写日志**

新增 `blockingFinishReasons`，补上漏掉的 `IMAGE_SAFETY`、`PROHIBITED_CONTENT`、`BLOCKLIST`、`SPII`（前两个正是生图模型实际返回的，原来连 WARN 都没有，按 INFO 记）。**被拦且没有产出任何 parts 时抛异常**；有产出时保留内容只记警告。`MAX_TOKENS` 刻意不在集合里——截断的答案仍是答案。

**⑥ 空 candidates 静默返回**

判断放在 `GeminiChatProtocol.generate()` 而**不是** `parseGoogleChunks` 里：流式收尾 chunk 只带 `usageMetadata` 不带 candidates 是完全正常的，在解析器里抛会打断正常的流。只有同步路径看得到完整响应，有资格下这个判断。

## 另外两项

**⑦ 用量字段名** —— OpenAI Images API 用的是 `input_tokens`/`output_tokens`，不是 chat 的 `prompt_tokens`/`completion_tokens`。`_recordUsage` 和 `promptTokensOf` 都加了兜底，否则每次 gpt-image-1 生成都记 0 token，只有按次计费的渠道能算对钱。

**⑧ `/images/edits` 硬编码 Bearer** —— 改用 `target.headers()` 并剥掉 `Content-Type`（multipart 自带 boundary）。原来只是因为当前 OpenAI 族 vendor 恰好都用 bearer 才没炸，下一个非 bearer 供应商接进来会出现「生图正常、改图 401」。

## 测试

`flutter analyze` 干净，610 passed / 9 skipped（新增 19 个）。

新增 `test/image_relay_compat_test.dart`：`extractStructuredImages` 4 · `imageUrlsInText` 4 · ① 形状 image_config 双发 4 · ③ 形状 responseModalities/imageConfig 3 · 阻断型 finishReason 4。其中两条是**策略锁定**，不只是行为验证：裸链接不抓、usage-only 的 Gemini chunk 仍然合法。

`docs/api/landscape.md` 加了第六个兼容层样本，记录这个字段责任划分互补的现象，并标注结论来自源码而非文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)