### PR TITLE
fix: harden LLM error handling (M1 bugfix batch)

### DIFF
--- a/docs/ai-agent-playbook/01-provider-layering.md
+++ b/docs/ai-agent-playbook/01-provider-layering.md
@@ -1,0 +1,216 @@
+# 01 · 分层模型与统一抽象
+
+> 本篇解决的问题：同时对接 OpenAI Chat Completions、Google Gemini、Anthropic Messages 三个协议族，以及大量第三方"兼容"中继（New API、MiniMax、DeepSeek、OpenRouter、Ollama、LM Studio…）时，代码应当如何分层，才能做到「加一家新供应商 = 加一行数据，不是加一个文件」。
+> 不读会踩的坑：为每家供应商建一个 Provider 子类，第三方之间 99% 相同的代码被复制 N 份；`switch (standard)` 写在消息形状分支上，每个新 `_compat` 值静默掉进 OpenAI 分支；传输配置在十几个调用点手工摊平，漏一处不是编译错误而是某个界面静默行为不一致。
+
+参考实现：simple-ai-writer `src/lib/ai/`（`types.ts`、`index.ts`、`conn.ts`），设计文档 `docs/provider-layering.md`。
+
+---
+
+## 1. 四层模型：L1 / L2 / L3 + 探测维
+
+任何参数、任何差异，都应当先被归入下面四层之一，再决定放在哪：
+
+```
+L1  协议族      wire format 本身（body 长什么样）      服务商定义，一族一个 adapter
+L2  端点        baseUrl / 鉴权方式 / 族方言参数        作者配置的一行（Provider 表）
+L3  模型        能力、档位、上下文/输出上限、价格       端点下的一行（Model 表）
+────────────────────────────────────────────────
+探测维          真实行为的实测结果（带时间戳）          机器写入，不是配置
+```
+
+### 三条铁律
+
+1. **只有 L1 允许"每族一份代码"。** 运行时永远只有"每个协议族一个 adapter"；"某一家供应商"（DeepSeek、Ollama…）是一张**预设数据表**，不是子类。禁止 `DeepSeekProvider extends OpenAIProvider` 这种形态——第三方之间 99% 相同，继承会把 99% 复制 N 份，而那 1% 的差异（一个 header、一个字段）一行配置就能表达。**加一家新供应商 = 加一行数据，不是加一个文件。**
+2. **枚举值是稀缺的。** 只有"body 形状不同"才配拥有一个 `ApiStandard` 值。鉴权不同、默认值不同、私有字段不同，全用 L2 数据字段表达。
+3. **新参数归属判断法**（按顺序问）：决定 body 形状？→ L1；换 key/baseUrl 会变？→ L2；同端点换模型会变？→ L3；作者答不上来只能实测？→ 探测维。同时命中 L2/L3 的放 L3（细粒度层永远能表达粗的）。
+
+## 2. 协议族的判定标准
+
+规则是一句话：**"能不能只改 URL 与鉴权头就跑通？能，就不是新族。"**
+
+按这个标准，业内收敛成四族：
+
+1. **OpenAI Chat Completions** —— 事实标准 + 全行业兼容层；
+2. **OpenAI Responses** —— 与 ① 同厂却是独立一族（`input` vs `messages`、扁平 vs 嵌套工具定义、类型化事件 vs delta 拼接、服务端状态）；
+3. **Google GenAI generateContent**；
+4. **Anthropic Messages**。
+
+Azure OpenAI、Vertex、Bedrock 上的 Claude 只是**部署变体**（同 body，换鉴权与 URL），不是新族。Bedrock Converse 实际是第五种独立 body（camelCase、SigV4）——接它就是接一个新族，不要伪装成 compat 选项；如果不打算写第五个 adapter，就明确不接。
+
+## 3. ApiStandard = 协议族 × official/compat
+
+每个协议族拆成 official 与 compat 两个枚举值，`familyOf()` 把它们折回族：
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/types.ts
+export type ApiStandard =
+  | "openai" | "openai_compat"
+  | "gemini" | "gemini_compat"
+  | "anthropic" | "anthropic_compat";
+
+export type ProtocolFamily = "openai" | "gemini" | "anthropic";
+
+export function familyOf(standard: ApiStandard): ProtocolFamily {
+  return PROTOCOL_FAMILY[standard] ?? "openai";  // DB 旧值的防御性兜底
+}
+```
+
+`_compat` 不是装饰，两种契约实质不同：
+
+| | official 契约 | compat 契约 |
+| --- | --- | --- |
+| 地址 | 锁定（存空串，域名变更是代码改动不是数据迁移） | 自填（要归一化） |
+| 鉴权 | 锁定 | 可选（下拉，见第 2 篇鉴权矩阵） |
+| `/models` | 缺失视为错误 | 缺失降级探测（见第 6 篇） |
+| 能力默认值 | 乐观 | 保守 |
+
+**分发规则（红线）**：凡是问"消息长什么样"的地方必须 `switch (familyOf(standard))` 而不是 `switch (standard)`——否则每个新增的 `_compat` 值都会静默掉进 default（OpenAI）分支。只有 official/compat 契约差异（地址校验、鉴权选项、探测策略）才允许直接看 standard。
+
+## 4. 内部 lingua franca：OpenAI Chat Completions 形状
+
+内部消息表示应当统一选一种形状，推荐 OpenAI chat.completions：`system/user/assistant/tool` 角色、`tool_calls`、`tool_call_id`、`image_url` data-URL 多模态 part。Gemini/Anthropic 适配器各自做**单向转换**（`convertToGeminiContents` / `convertToAnthropicMessages`），转换只发生在 adapter 内部、发出前的最后一刻。
+
+跨协议无法用 OpenAI 形状表达的东西（思维链回传物、Gemini 的 thoughtSignature 等），用 **`_` 前缀私有字段**随消息携带，adapter 上线前按前缀统一剥除：
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/types.ts —— 全部消息变体
+export type StreamMessage =
+  | { role: "system" | "user" | "assistant"; content: MessageContent }
+  | {
+      role: "assistant";
+      content: null;
+      tool_calls: AssistantToolCall[];
+      _geminiModelParts?: unknown[];          // Gemini 原始 parts（含 thoughtSignature）
+      _reasoning?: NativeReasoning;           // OpenAI 系思维链（{field, text}），工具轮回传用
+      _thinkingBlocks?: ThinkingBlockCarry;   // Anthropic thinking blocks（{modelId, blocks}）
+    }
+  | { role: "tool"; tool_call_id: string; content: string };
+
+export type ContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } }; // url = data:<mime>;base64,<data>
+```
+
+**剥除按前缀，不按名单。** 参考实现（`src/lib/ai/openai.ts` 的 `toWireMessages`）：
+
+```ts
+// "Drop by prefix rather than by name: every protocol that needs carry-back adds
+// a field here, and an allow-list of names silently lets the next one through
+// to the wire."
+const wire = Object.fromEntries(Object.entries(bag).filter(([k]) => !k.startsWith("_")));
+const reasoning = bag._reasoning as NativeReasoning | undefined;
+return reasoning ? { ...wire, [reasoning.field]: reasoning.text } : wire;
+```
+
+陷阱：如果剥除逻辑是一张字段名白名单，下一个协议加的 `_` 字段会被静默放行到 wire 上——多数端点对未知顶层键直接 400。前缀约定使"新增一个载体字段"零成本地安全。
+
+## 5. 统一流事件：StreamChunk 变体联合
+
+调用方只见一种 chunk 流。判别一律用 **key 判别**（`"text" in chunk` 式），因此**新增变体对旧消费者天然是 no-op**——这是加 `reasoning`/`serverTool` 变体不破坏任何调用点的机制，也是这个联合可以持续生长的前提。
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/types.ts
+export type StreamChunk =
+  | { text: string }                       // 正文（会进稿子的唯一变体）
+  | { reasoning: string }                  // 思维链片段（绝不能混进正文，故独立变体）
+  | { serverTool: ServerToolEvent }        // 端点自己跑的工具（纯上报，无需回传）
+  | { turnResumed: { leg: number; final: boolean } }  // 一次调用变多次请求的可观测信号
+  | { done: true; inputTokens: number; outputTokens: number;
+      truncated?: boolean;                 // finish_reason=length / MAX_TOKENS / max_tokens
+      stopReason?: string;                 // 端点原话，仅诊断，永不分支
+      cachedTokens?: number }              // inputTokens 的子集（已归一化）
+  | { toolCalls: AccumulatedToolCall[];
+      _geminiModelParts?: unknown[];
+      _reasoning?: NativeReasoning;        // 整轮思维链，随 toolCalls 交付（仅工具轮需要）
+      _thinkingBlocks?: ThinkingBlockCarry };
+```
+
+设计准则：
+
+- **正文与思维链必须是不同变体。** 混流的后果是思考散文进入用户稿子（见第 3 篇）。
+- **`stopReason` 只做诊断，永不作为分支条件**——它是端点原话，各家拼写不同且随时增补；需要分支的语义（截断）单独归一化成 `truncated` 布尔。
+- `done` chunk 携带归一化后的 usage（口径见第 6 篇）。
+
+## 6. 统一入口 streamCompletion 与 StreamOptions
+
+所有调用最终收敛到一个入口函数，在这里完成横切关注点（prefix 合并、上下文预检、日志接线），然后按族分发：
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/index.ts —— 全文即此
+export async function streamCompletion(opts: StreamOptions): Promise<void> {
+  const merged = { ...opts, messages: applyPrefix(opts.messages, opts.prefix) };
+  const log = beginApiLog(merged);
+  if (merged.contextSize && merged.contextSize > 0) {
+    const estimated = estimateMessagesTokens(merged.messages) + estimateToolsTokens(merged.tools);
+    if (estimated > merged.contextSize) { /* throw ContextSizeError（发送前拦截） */ }
+  }
+  const wrapped = { ...merged,
+    _onRequestBody: (body) => log.requestBody(body),   // 日志自己的管线，调用方不接
+    onChunk: (chunk) => { log.chunk(chunk); merged.onChunk(chunk); } };
+  switch (familyOf(wrapped.standard)) {
+    case "gemini": await streamGemini(wrapped); break;
+    case "anthropic": await streamAnthropic(wrapped); break;
+    default: await streamOpenAI(wrapped);
+  }
+}
+```
+
+`StreamOptions` 的传输字段（节选）：`baseUrl / apiKey / standard / authMode / modelId / messages / onChunk / signal / tools / serverTools / toolChoice / extraBody / safetySettings / prefix / contextSize / maxOutput / reasoningEffort / thinkingDialect / _onRequestBody`。
+
+其中几个字段的语义必须写进规范，因为它们在三族上行为不同：
+
+- **`extraBody`** —— per-request escape hatch，优先级高于配置（OpenAI 路径最后 spread）；Gemini 路径也收（JSON 模式用它塞 `generationConfig`）；**Anthropic 路径故意不 spread**——它携带的是 OpenAI 形状字段（如 `response_format`），Messages API 对未知顶层字段直接 400。规则：escape hatch 的形状属于某一族时，其他族的适配器应当拒绝 spread 而不是"透传以示通用"。
+- **`maxOutput`** —— 只有 Anthropic 路径真的发出去（`max_tokens` 必填、无服务端默认）；OpenAI/Gemini 路径上只作上下文预算的规划输入。
+- **`contextSize`** —— 发送前用估算器拦截超窗请求，抛 `ContextSizeError`（携带 estimated/contextSize 两个数字供 UI 展示）。理由：ollama 这类本地栈会**静默从头部丢弃**超出部分（先丢的正是 system 指令），返回 200 装没事——事后无法发现，只能事前拦。
+- **`prefix`** —— 模型级前缀 prompt，`applyPrefix` 合并进首条 system。**必须不可变、返回新数组**——agent 循环跨轮复用同一 history 数组，原地修改会把 prefix 重复叠加。
+
+## 7. config→request 的收口：conn.ts 模式
+
+背景教训（来自参考实现）：约 9 个传输字段全部可选，曾在 16 个调用点手工摊平、8 个参数类型重复声明——漏一处**不是编译错误，是某个界面静默行为不一致**（可选字段的遗漏类型系统查不出来）。
+
+收口方案：
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/conn.ts
+export interface AiConn { provider: Provider; model: Model; apiKey: string }
+
+export interface ConnOptions {   // StreamOptions 中"来自配置"的那一半，结构子集
+  baseUrl: string; apiKey: string; standard: ApiStandard;
+  safetySettings?: GeminiSafetySettings; authMode?: AuthMode;
+  modelId: string; prefix?: string; contextSize?: number; maxOutput?: number;
+  reasoningEffort?: ReasoningEffort; thinkingDialect?: ThinkingDialect;
+  serverTools?: ServerToolId[];
+}
+export function connOptions(conn: AiConn): ConnOptions { /* 逐字段摊平 */ }
+export function pickConnOptions(o: ConnOptions): ConnOptions { /* 反向收窄 */ }
+export function resolveConn(models, providers, modelId): ConnResolution
+  // 三种失败保持可区分：未选模型 / 模型已删 / 供应商已删
+```
+
+规则：
+
+- 任何携带 provider 接线的参数类型 **`extends ConnOptions`**；调用点统一写 `{...connOptions(conn), messages, onChunk}`。
+- **新增一个 L2/L3 传输字段 = 改 `ConnOptions` + `connOptions()` + `pickConnOptions()` 三处，且在同一文件。**"加字段 = 改一处（文件）"是这个模式的全部意义。
+- 两份手写字段表（摊平与收窄）的分歧由**往返单测**盯住——类型系统查不出可选字段的遗漏。
+- `resolveConn` 的三种失败（未选模型 / 模型已删 / 供应商已删）保持可区分，UI 才能给出正确的修复指引。
+- 陷阱：`connOptions` 刻意**不给空 baseUrl 填默认值**。空串意为"用该协议自己的默认"，只有 URL 模块（`urls.ts`）知道那是哪个；在 conn 层填 `api.openai.com` 会把 Gemini 供应商指过去——参考实现历史上真发生过这个 bug。
+- 收口时机：调用点 ≥3 个时就该收口，别等到 16 个。
+
+---
+
+## 本篇检查清单
+
+- [ ] 运行时 adapter 数量 = 协议族数量，没有任何"每供应商一个类/文件"的形态。
+- [ ] 每个候选新参数都用"归属判断法"过了一遍（body 形状→L1；换端点变→L2；换模型变→L3；只能实测→探测维）。
+- [ ] `ApiStandard` 只在 body 形状不同时增加值；official/compat 成对出现。
+- [ ] 全部消息形状分支写的是 `switch (familyOf(standard))`，grep 不到直接 `switch (standard)` 的消息形状代码。
+- [ ] `familyOf` 对未知/旧枚举值有防御性兜底（不抛错，落回默认族）。
+- [ ] 内部消息统一为一种 lingua franca 形状；跨协议私有数据全部用 `_` 前缀字段承载。
+- [ ] adapter 发出 wire 消息前按 `_` **前缀**（而非名单）剥除私有字段。
+- [ ] `StreamChunk` 用 key 判别；新增变体后，跑一遍旧消费者确认是 no-op。
+- [ ] `stopReason` 没有出现在任何 `if`/`switch` 条件里（只展示/记日志）。
+- [ ] 存在唯一入口 `streamCompletion`，prefix 合并、上下文预检、日志接线都在入口做，不散落在调用方。
+- [ ] `applyPrefix` 等消息变换函数是纯函数，不修改传入数组。
+- [ ] 存在 `ConnOptions` 收口；所有携带 provider 接线的参数类型 `extends ConnOptions`；有摊平/收窄的往返单测。
+- [ ] `connOptions` 不给空 baseUrl 填任何默认值。

--- a/docs/ai-agent-playbook/02-protocol-differences.md
+++ b/docs/ai-agent-playbook/02-protocol-differences.md
@@ -1,0 +1,153 @@
+# 02 · 三家协议差异对照
+
+> 本篇解决的问题：把 OpenAI Chat Completions（①）、Google GenAI generateContent（③）、Anthropic Messages（④）三族的 wire 差异一次性列全——消息容器、角色、工具、流式机制、鉴权、URL 约定——并给出适配器里必须做的结构性修补。
+> 不读会踩的坑：Anthropic 的交替律 400、连续 tool 消息拆开发送被拒、Gemini 把 SSE chunk 当 delta 拼接导致内容重复、baseURL 归一化"修复对称"后中继路由全断、Gemini key 走查询串泄进代理日志。
+
+参考实现：simple-ai-writer `src/lib/ai/openai.ts`、`gemini.ts`、`anthropic.ts`、`urls.ts`、`http.ts`；协议事实见其 `docs/api/landscape.md`。
+
+---
+
+## 1. 总对照表
+
+| | ① OpenAI Chat Completions | ③ Google GenAI | ④ Anthropic Messages |
+| --- | --- | --- | --- |
+| 端点 | `POST {base}/chat/completions` | `POST {base}/models/{id}:streamGenerateContent?alt=sse`（模型名在 URL！） | `POST {root}/v1/messages` |
+| 鉴权 | `Authorization: Bearer`（无 key 时**整个头省略**） | `x-goog-api-key` 头 | `x-api-key` + `anthropic-version: 2023-06-01`（pinned） |
+| 历史容器 | `messages[]` | `contents[]` | `messages[]` |
+| 模型侧角色 | `assistant` | **`model`** | `assistant` |
+| system | `messages[0].role="system"` | 顶层 `systemInstruction:{parts:[{text}]}` | 顶层 `system` 字符串（消息数组内**无** system 角色） |
+| 文本载体 | `content` 字符串或 part 数组 | `parts[].text` | `content` 字符串或 block 数组 |
+| 图片 | `{type:"image_url", image_url:{url: dataURL}}` | `{inlineData:{mimeType,data}}` | `{type:"image", source:{type:"base64",media_type,data}}` |
+| 工具定义 | `tools[].function.{name,description,parameters}`（嵌套） | `tools[0].functionDeclarations[]`（同名字段） | `tools[].{name,description,input_schema}`（唯一不叫 parameters） |
+| 模型发起调用 | `assistant.tool_calls[]`（带 id；arguments 是 **JSON 字符串**） | `parts[].functionCall`（**无 id**；args 是**已解析对象**） | block `type:"tool_use"`（带 id；input 是对象） |
+| 结果回传 | `role:"tool"` + `tool_call_id` | `role:"user"` 的 `parts[].functionResponse`，**靠函数名匹配** | `role:"user"` 的 `tool_result` block + `tool_use_id` |
+| tool_choice | `"auto"/"none"/"required"/{type:"function",function:{name}}` | `toolConfig.functionCallingConfig.mode: AUTO/ANY/NONE` (+`allowedFunctionNames`) | `{type:"auto"/"any"/"tool"(+name)/"none"}` |
+| 流式机制 | SSE 匿名 chunk，客户端拼 delta，`data: [DONE]` 收尾 | SSE，**每个 chunk 是完整响应对象**（parts 直接追加，不是 delta） | SSE **类型化事件** `message_start`→`content_block_*`→`message_delta`→`message_stop` |
+| 结束原因 | `finish_reason: stop/length/tool_calls/content_filter` | `finishReason: STOP/MAX_TOKENS/SAFETY/RECITATION/...` | `stop_reason: end_turn/tool_use/max_tokens/refusal/pause_turn` |
+| 输出上限 | `max_tokens`→`max_completion_tokens`（选填） | `generationConfig.maxOutputTokens`（选填） | `max_tokens` **必填、无服务端默认** |
+| usage | `usage.prompt_tokens/completion_tokens`（**须开 `stream_options:{include_usage:true}`**，随末 chunk 到） | 每个 chunk 都带 `usageMetadata.promptTokenCount/candidatesTokenCount/thoughtsTokenCount` | 分两次：`message_start` 给 input，`message_delta` 给 output；**三桶不重叠** |
+| 缓存计数 | `prompt_tokens_details.cached_tokens`，**input 的子集** | `cachedContentTokenCount`，子集 | `cache_read/creation_input_tokens` 与 `input_tokens` **互不重叠，要相加** |
+
+## 2. 消息转换的结构性修补
+
+内部消息是 OpenAI 形状（见第 1 篇），转换到 ③④ 时不是逐字段改名，而是要做**结构性修补**——这是适配器里真正的活。
+
+### 2.1 Anthropic（最严格）
+
+参考实现：simple-ai-writer `src/lib/ai/anthropic.ts` 的 `convertToAnthropicMessages` / `extractSystem`。
+
+规则与修补，逐条：
+
+1. **交替律**：首条必须是 `user`，相邻消息必须交替角色。OpenAI 形状允许连续同角色（agent 循环会自然产生 assistant+assistant）。转换器必须做三件事：
+   - 丢弃开头的 assistant 消息；
+   - 合并同角色相邻消息；
+   - **把连续 tool 消息合并成一条 user 消息**——Anthropic 要求一轮的所有 `tool_result` 一起到达，拆开发既违反协议又破坏交替律。
+2. **system hoist**：消息数组内没有 system 角色，全部 system 消息 hoist 到顶层 `system` 字段（多条用 `\n\n` join）。陷阱：内容若是 `ContentPart[]`，必须先用 `textOf` 拍平成字符串，否则序列化成 `[object Object]`。
+3. **工具轮 assistant 消息的 content 顺序**：`[...thinkingBlocks, ...tool_use blocks]`——thinking 在前且原样（顺序即 400 红线，详见第 3 篇回传义务）。
+4. **labelAuthorText**：tool_result 和作者（用户）的话都住在 `role:"user"` 里，合并可能产生 `[tool_result, "continue"]` 这种消息——作者的话被装进了模型当作工具输出读的信封。实测事故：作者一上午敲的三次重试（continue/retry/重试）混进 `read_file` 结果，被后续 39 轮反复重发，模型把它读成"用户要我一直继续"的常设指令。修法：合并进带 tool_result 的消息的第一条文本前加 【…】 标签，标明这是作者发言，使其可归因。
+5. **tool_use 的 `name` 兜底链**：`tc.function.name || toolCallIdToName.get(tc.id) || "unknown_function"`——id→name 表预先扫全量 messages 建好。历史里的 tool_calls 可能来自持久化或另一族转换，name 缺失不能让整条请求炸掉。
+
+### 2.2 Gemini
+
+参考实现：simple-ai-writer `src/lib/ai/gemini.ts` 的 `convertToGeminiContents`。
+
+1. `assistant` → `model` 角色。
+2. tool 消息 → `role:"user"` 的 `functionResponse` parts。**Gemini 协议层没有调用 id**，靠预建的 id→name 表查函数名回填。推论：同名函数的并行调用，其结果对应关系在协议上**不可表达**——只能接受这个信息损失，不要试图发明私有配对机制。
+3. 工具轮 assistant 若带 `_geminiModelParts`，**原样整组回传**而不重建——为保住 `thoughtSignature`（第 3 篇详述）。规则：能原样回传的历史，永远不要"理解后重建"。
+
+## 3. 流式解析：共同骨架 + 三家差异
+
+### 3.1 共同骨架（三族适配器共享同一 SSE 读法）
+
+```
+res.body.getReader() + TextDecoder({stream: true})
+→ 按 "\n" split
+→ 最后一个不完整行留到下次 read（行缓冲）
+→ 流结束后再 flush 一次 buffer 尾巴
+```
+
+两条理由都来自真实事故：一个 `data:` 行可能跨两次网络 read 到达，**解析半行会静默丢 token/usage**；有的端点不发 `[DONE]`/`message_stop` 就断流，不 flush 尾巴就丢最后一段。
+
+### 3.2 各族差异
+
+**① OpenAI**：
+- tool_calls 用 `Map<index, {id,name,args}>` 累积。**分组键是 `index` 不是 `id`——id 本身也可能分片到达**（参考实现里 `entry.id += partial.id`）。用 id 分组，流式下同轮多个交错调用会拼错。
+- malformed SSE 行直接忽略，不抛错。
+
+**③ Gemini**：
+- **不是 delta！** 每个 chunk 是完整响应对象，`parts` 直接追加。按 delta 逻辑拼会重复内容。
+- `functionCall` 一次给全不分片，但**没有 id**——适配器自造 `gtc_${Date.now()}_${n}` 补上，让上层的统一 tool 循环仍能用 id 关联。
+
+**④ Anthropic**：按事件类型 switch。
+- `content_block_start` 建块：**浅拷贝后整块留存，包括不认识的类型**——paused turn 要原样回话，重建会丢 `encrypted_content`（见第 5 篇）。
+- `input_json_delta` 按**块索引**累积。
+- `thinking_delta` 流出去展示 + 累积进块；`signature_delta` 只累积不展示。
+- `message_delta` 收 stop_reason 和 output usage。
+- `event:` 行无 payload，只认 `data:` 行。
+- **空参数工具调用不会流任何 `input_json_delta`**：累积出的 `""` 必须转成 `"{}"`，否则 agent 循环拿到一个解析不了的调用。
+
+## 4. baseURL 的不对称归一化
+
+参考实现：simple-ai-writer `src/lib/ai/urls.ts`（`trimBase` / `anthropicRoot` / `migrateLegacyStandard`）。
+
+三个生态对"base URL 是什么"的约定**不同**，归一化规则因此必须不对称——这是有依据的差异，不是随意：
+
+- **OpenAI / Gemini 生态**：base **自带版本段**（`.../v1`、`.../v1beta`），照 `OPENAI_BASE_URL` 惯例，path 直接拼。**陷阱：不要"修复"这个不对称去给 OpenAI 补 `/v1`**——它的 base 本来就以 /v1 结尾，且中继合法地路由在 /v1 之下（如 `https://relay/openai`），补了就断。
+- **Anthropic 生态**：base 是**根地址**（`ANTHROPIC_BASE_URL` 惯例，官方 SDK / Claude Code / 所有第三方文档都由客户端补 `/v1/messages`）。参考实现的历史 bug：曾只拼 `/messages`，于是照第三方文档粘贴的 base 一律 404——**你的 app 的约定若是全生态里唯一不同的那个，错的是你**。修法 `anthropicRoot`：先剥尾部 `/messages` 再剥 `/v1`，接受作者会粘贴的三种形状（根 / 根+`/v1` / 完整 curl 端点 URL），统一拼 `root + "/v1" + path`。
+- **Gemini**：额外剥尾部 `/models`（把模型列表 URL 粘成 base 是易犯错误）。
+
+官方端点存**空串** base（地址是厂商常量不是设置；域名变更 = 代码编辑而非数据迁移），适配器用 `baseUrl || DEFAULT_*` 兜底。
+
+**读取时幂等迁移**：做 official/compat 拆分这类 schema 演进时，旧行的迁移放在读取时（base 非空且非官方地址 → 打 `_compat` 标），而非一次性 DB migration——因为导入旧版导出的配置也要走同一条规则；一处规则，两条路径不会漂移。
+
+## 5. 鉴权矩阵
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/types.ts
+export type AuthMode = "default" | "bearer" | "both";
+export function authModesFor(standard: ApiStandard): AuthMode[] {
+  return standard === "anthropic_compat" || standard === "gemini_compat"
+    ? ["default", "bearer", "both"] : ["default"];
+}
+```
+
+| 族 | 默认（官方唯一方式） | compat 可选 | 不做的及原因 |
+| --- | --- | --- | --- |
+| OpenAI | `Authorization: Bearer`；**无 key 时整个头省略**（Ollama/LM Studio 收到空 Bearer 会拒） | 无 | Azure `api-key` 头：URL 形状（`/openai/deployments/{d}/...?api-version=`）与模型标识都不同，一个头救不了，要做是第四族不是 compat 选项 |
+| Gemini | `x-goog-api-key` | `bearer` / `both` | `?key=` 查询串**故意不实现**：key 进代理日志/报错信息 = 泄漏 |
+| Anthropic | `x-api-key` + `anthropic-version: 2023-06-01`（**pinned 不追 latest**——wire 形状按它版本化）+ `anthropic-dangerous-direct-browser-access: true` | `bearer` / `both` | — |
+
+要点：
+
+- **Anthropic 的 bearer 必须做**：生态里 `ANTHROPIC_API_KEY→x-api-key` 与 `ANTHROPIC_AUTH_TOKEN→Bearer` 是**两套一等约定**，大量网关只认后者且文档只写自己要的那个——读错头的网关看到的是未鉴权请求，401。
+- **`both` 的存在理由**：给文档啥也不说的网关两个头都发。但**只在 compat 提供**——api.anthropic.com 对携带两种凭证的请求拒绝，在官方端点上提供这个选项 = 递给作者一个只能坏事的设置。
+- 存储上 `default` 存 NULL（没碰过设置的行读回来逐字节不变），且**读取时按 standard 校验**——供应商从 compat 改回 official 时残留的 `bearer` 会失效而不是照发。
+- 版本头 pin 死一个日期值，不追 latest：wire 形状按版本头版本化，追 latest 等于让服务端单方面改你的解析器契约。
+
+## 6. CORS / 浏览器直连
+
+桌面（Tauri/Electron 原生 HTTP）与浏览器环境的差异要显式处理：
+
+- 打包版请求走原生 HTTP 栈（参考实现：Rust reqwest 经 Tauri IPC，`src/lib/http.ts` 的 fetch 包装），**没有 CORS preflight**，`anthropic-dangerous-direct-browser-access` 在打包版是 no-op。
+- 带上它是为了 dev 模式纯浏览器环境（回落全局 fetch）也能连——不带则 Anthropic 直接拒绝浏览器 origin 的请求。
+- 本地 Ollama 的 Windows 打包版 403 问题：靠 http 层覆盖 `Origin` 头修复。注意这个修复位于比 provider 枚举更底层的位置，拿不到枚举值，只能按"URL 指向本机"判断——这也是"Ollama 不做成枚举值"的理由之一（L2 数据能表达的就不进代码）。
+
+---
+
+## 本篇检查清单
+
+- [ ] 三族各有一份对照表意识：容器名、模型侧角色、system 位置、工具字段名、流式机制、结束原因、usage 到达方式，写适配器前先对表。
+- [ ] Anthropic 转换器实现了：丢头部 assistant、同角色合并、连续 tool 消息合并成单条 user、system hoist（ContentPart 拍平）、thinking 块在 tool_use 前。
+- [ ] user 信封里混入作者文本时打了可归因标签（labelAuthorText）。
+- [ ] tool_use name 有三级兜底（自带 → id→name 表 → `"unknown_function"`）。
+- [ ] Gemini 转换：assistant→model、functionResponse 靠 id→name 表回填函数名、`_geminiModelParts` 原样整组回传。
+- [ ] SSE 解析有行缓冲（半行留存）+ 流末 flush；malformed 行忽略不抛。
+- [ ] OpenAI tool_calls 按 `index` 分组累积，id 用 `+=` 拼接。
+- [ ] Gemini chunk 按完整对象处理（append，不是 delta 拼接）；自造 functionCall id。
+- [ ] Anthropic 块整存（含不认识的块类型）；空参数工具调用 `""` → `"{}"`。
+- [ ] baseURL 归一化不对称：OpenAI/Gemini 不补 `/v1`；Anthropic 走 `anthropicRoot`（剥 `/messages`、`/v1` 再统一拼）；Gemini 剥尾部 `/models`。
+- [ ] 官方端点 base 存空串，适配器兜默认常量；旧配置走读取时幂等迁移。
+- [ ] OpenAI 无 key 时省略整个 Authorization 头。
+- [ ] Gemini 不实现 `?key=` 查询串鉴权。
+- [ ] `both` 鉴权只对 compat 开放；authMode 读取时按 standard 校验残留值。
+- [ ] anthropic-version pin 死，不追 latest。

--- a/docs/ai-agent-playbook/03-reasoning.md
+++ b/docs/ai-agent-playbook/03-reasoning.md
@@ -1,0 +1,132 @@
+# 03 · 思考/推理的统一处理
+
+> 本篇解决的问题：把各家"thinking / reasoning"支持拆解成三件可以独立设计的事——**强度**（请求怎么说"想多久"）、**思维链取回**（响应怎么给你看）、**回传义务**（下一轮要不要还回去），并给出每一件的三族实现规范。
+> 不读会踩的坑：回传义务是唯一会让请求被拒的一件，却最少被文档放在显眼处——Anthropic 不回传 thinking block 是**静默**关闭思考（无任何报错）；Gemini 丢 thoughtSignature 是 HTTP 200 + 特殊 finishReason；DeepSeek 系不回传直接 400。三种失败模式完全不同，排查方式也不同。另外：`<think>` 标签混进正文、`display` 默认 omitted 付全额思考费拿不到一个字、换模型不剥 thinking block 静默计费。
+
+参考实现：simple-ai-writer `src/lib/ai/reasoning.ts`（词汇、翻译表、切分器）、三个适配器的接线、设计文档 `docs/reasoning-plan.md` / `docs/anthropic-plan.md` / `docs/gemini-plan.md`。
+
+---
+
+## 1. 三分法：强度 / 取回 / 回传义务
+
+规范的第一条是概念拆分。三件事各自独立变化，混在一个"thinking 开关"里必然顾此失彼：
+
+| | 问题 | 谁定义 | 失败方式 |
+| --- | --- | --- | --- |
+| 强度 | 请求体里怎么表达"想多久" | 每族一套字段与枚举 | 发了对面不认的档位 → 400 |
+| 取回 | 思维链在响应流的哪里 | 每族一个读取位置 | 读不到（少看一段），或混进正文（严重） |
+| 回传义务 | 工具轮历史要不要携带思考物 | 每族一种载体 | **三族三种**：400 / 特殊 finishReason / 静默降级 |
+
+## 2. 强度：自有六档词汇 + 每族翻译表
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/reasoning.ts
+export type ReasoningEffort = "default" | "off" | "low" | "medium" | "high" | "max";
+```
+
+核心原则：**配置层存储的是本项目自己的词汇，绝不让某一家的拼写进配置层。** 各家档位名"像但语义不像"是陷阱：DeepSeek 的 medium 被折进 high；`minimal`/`none` 有的模型 400；Gemini 要 token 预算/level 不要档位名。
+
+`"default"`/缺省的语义是 **一个字段都不发**，让端点用自己的默认——"任何主动发出的字段都是某个中继可以拒绝的字段"。
+
+翻译表（`reasoningBody(standard, effort, dialect)`）：
+
+| 本项目档位 | ① OpenAI 系 `reasoning_effort` | ③ Gemini `generationConfig.thinkingConfig.thinkingLevel` | ④ Anthropic `output_config.effort` |
+| --- | --- | --- | --- |
+| off | `"none"` | `"MINIMAL"`（③ 关不掉，诚实降级为"最少"） | `"low"`（disabled 会被多款模型 400，官方也建议降 effort 而非关） |
+| low/medium/high | 同名 | `LOW/MEDIUM/HIGH`（**全大写**！小写 `thinking_level` 属于另一个 surface：Interactions API） | 同名 |
+| max | `"max"` | `"HIGH"`（枚举到头） | `"max"` |
+
+必须写进实现的细节：
+
+- ③ 发 level 时**强制搭配 `includeThoughts: true`**——思考横竖在跑、横竖计费，这个开关只决定你能不能看见；只调深度不开显示等于"付钱买看不见的思考"。
+- ③ 的旧字段 `thinkingBudget` 与新字段 `thinkingLevel` 并存于同一对象，靠"用错模型报错"区分。规则：**只发一代字段**，选目标支持范围对应的那代（参考实现支持 Gemini 3 起，只发 level）。
+- ④ 的 `output_config.effort` 管的是**整个回复**（正文 + 工具调用 + 思考），不只思考深度。UI 上仍然只放一个拨盘，变的是标签——因为没有任何端点把"回复深度"与"思考深度"作为两个独立输入暴露，两个拨盘 = 两个控件写一个值。
+- 私有方言开关（如 DeepSeek 的 `thinking:{type}`）**故意不发**——OpenAI 官方端点对未知顶层字段直接拒绝，为一家的方言破坏官方路径不值。
+
+## 3. ThinkingDialect：代次差异由作者声明，不猜
+
+④ 族（形状上也覆盖 ③ 2.5 代）的思考参数**换代改形**，且**代次无法从模型 id 恢复**——中继上模型 id 是作者输入的自由文本（如 `特价kiro | claude-opus-4-6-thinking`）。因此方言做成 **L3 模型字段由作者声明**，不做探测、不做猜测启发式：
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/reasoning.ts
+export type ThinkingDialect = "adaptive" | "extended" | "switch" | "none";
+
+export function thinkingBody(dialect, budgetTokens, effort?) {
+  switch (dialect) {
+    case "adaptive": return { thinking: { type: "adaptive", display: "summarized" } };
+    case "extended": return { thinking: { type: "enabled", budget_tokens: budgetTokens, display: "summarized" } };
+    case "switch":   return { thinking: { type: effort === "off" ? "disabled" : "adaptive" } };
+    case "none":     return undefined;
+  }
+}
+```
+
+四种方言的语义：
+
+- **`adaptive`**（Claude 4.6+）：`display:"summarized"` **必须显式发**——当前代默认 `"omitted"`，返回的 thinking block 文本为空串但**照全额计费**（omitted 省的是延迟不是钱）。
+- **`extended`**（Claude ≤4.5；Gemini 2.5 同形）：固定 token 预算。预算钳制：`Math.max(1024, Math.min(16384, maxTokens/2))`——budget 必须 < max_tokens（二者共享一个上限，预算贴顶 = 正文没地方存在）。
+- **`switch`**（为 MiniMax-M3 的 `/anthropic/v1/messages` 这类精简兼容层建）：只有 `{type:"adaptive"|"disabled"}` 开关，无 `display`、无 `output_config`。声明此方言同时意味着"该端点没有深度拨盘"——`reasoningBody` 对它返回 undefined，effort 唯一的用途是 off→disabled。该端点思考**默认关**，不发开关就永不思考。另注意：schema 没有的字段（如 display）不发——兼容层"忽略未知键"与"400 未知键"一样常见，文档没写的不发。
+- **`none`**：不发任何 thinking 字段。
+
+**缺省方言的猜测规则**：anthropic 族猜 `adaptive`，其他族 `none`。乐观猜的理由：对支持范围（4.6+）全对；错的方式是旧模型 400 且报出字段名——比默认"不思考"让作者纳闷"我的推理模型怎么从不推理"好得多。原则：**乐观猜测只在"错的方式会响"时使用**。
+
+## 4. 思维链的流式暴露：三族三种读法，统一产出 `{reasoning}` chunk
+
+| 族 | 读哪里 |
+| --- | --- |
+| ① | `delta.reasoning_content` / `delta.reasoning`（候选字段表 `REASONING_CONTENT_FIELDS`，按序试；**非字符串值忽略不强转**——有端点在旁边发结构化 `reasoning_details` 数组，`String()` 会给用户看 `[object Object]`）+ 内联 `<think>` 切分（见 §6） |
+| ③ | `part.thought === true` 的文本 part |
+| ④ | `thinking_delta.thinking` 事件（仅当请求发了 `display:"summarized"` 才会有） |
+
+扩展规则：支持一家新端点的思维链拼写 = 往 `REASONING_CONTENT_FIELDS` 加一个字符串。**刻意设计成永远不会变成 per-vendor 分支**——候选字段表是数据，分支是代码。
+
+产出侧统一为 `{reasoning: string}` chunk（与 `{text}` 是不同变体，见第 1 篇）：思维链绝不能混进正文流。
+
+## 5. 回传义务：三族三种载体、三种失败模式
+
+**心法：跨轮要回传的东西必须整块留存原物，不能归一化后重建。**"理解后重建"恰好丢掉的就是完整性校验依赖的那部分（signature、encrypted payload、字段拼写、块顺序）。
+
+| 族 | 不回传的后果 | 载体 |
+| --- | --- | --- |
+| ① DeepSeek 系 | **400**（会响，逼你修） | `_reasoning: {field, text}`——收到什么字段名就用什么名字还回去，无需知道对面是谁 |
+| ③ Gemini | 多轮工具失效；HTTP 200 + `finishReason: MISSING_THOUGHT_SIGNATURE`（第三种形态：不是 400 也不是静默） | `_geminiModelParts: unknown[]`——整组原始 parts 原样回传（含 thought parts 与 thoughtSignature） |
+| ④ Anthropic | **静默降级**：API 不报错，直接关掉这轮思考（最危险——唯一验证手段是看响应里还有没有 thinking block）；**改动/重排/部分丢弃才是 400** | `_thinkingBlocks: {modelId, blocks}`——有序块数组原样回传（`redacted_thinking` 只有不透明 data 也要回） |
+
+实现规则：
+
+1. **只在带 tool_calls 的 assistant 消息上携带**（三个载体一致）：这些端点把"调用工具前的思考"视为同一条回复的一部分（工具调用是模型暂停自己回复的构造，去等外部信息）；普通轮次端点自己会过滤，带上 = 白付 token。
+2. **`_thinkingBlocks` 带 `modelId`**：thinking block 与产出它的模型绑定。允许会话中途换模型的应用，换了就整组丢弃（`thinkingBlocksFor` 比对 modelId）——别的模型不会拒绝，会**静默忽略且照 input 计费**，最坏的组合。
+3. **三个 `_` 字段并存是刻意选择，不要泛化承载**：④ 的载体是有序数组、成员可能只有不透明 payload、顺序受完整性校验，无法复用 `{field,text}`；泛化载体会把 modelId 特例变成所有人的负担。真正泛化的是**剥除**（`_` 前缀丢弃，见第 1 篇），不是承载。
+4. **`redacted_thinking` 块必须回传**：它只有不透明 `data` 字段。按 `type === "thinking"` 过滤内容块的代码会静默丢掉它——过滤条件应当是"是思考类块"而不是精确类型匹配。
+
+## 6. `<think>` 标签兜底切分器
+
+部分 ① 族中继（MiniMax 等）不分离思维链，直接把 `<think>…</think>\n\n正文` 塞进 `delta.content`。不切分则思考散文会进用户稿子。
+
+参考实现：simple-ai-writer `src/lib/ai/reasoning.ts` 的 `createThinkTagSplitter()`。状态机三阶段（start / thinking / body），两条安全性质是规范的核心：
+
+1. **只认响应最开头的 `<think>`**（允许前导空白）。正文中途出现的 `<think>` 视为作者/模型自己的文本。理由：对内容生产类应用，静默吃掉一段正文比留一个标签在稿子里严重得多——切分器宁可漏切不可误切。
+2. **跨 chunk 标签拼接**：`<thi` + `nk>` 分两片到达是常态。用 `danglingPrefix`（缓冲区尾部"是标签真前缀的最长后缀"）扣住可能成为标签的尾巴不发；下一片到达后拼接再判。流结束时未闭合的块按 reasoning flush——被截断的思考不是作者要的散文。
+
+第三条规则：**切出来的 reasoning 只展示、不并入 `_reasoning` 回传**——它没有自己的 wire 字段名，编一个名字 = 往下一个请求塞没人认识的键。
+
+---
+
+## 本篇检查清单
+
+- [ ] 思考支持在设计文档里拆成了强度/取回/回传三节，各自有三族对照。
+- [ ] 配置层存自有六档词汇（含 `default`/`off`/`max`），任何一家的拼写都没有进入存储。
+- [ ] `default` 档一个字段都不发。
+- [ ] Gemini 翻译用全大写 `thinkingLevel` 枚举，且发 level 必带 `includeThoughts: true`；只发一代字段。
+- [ ] Anthropic `off` 翻译为降 effort 而不是 disabled。
+- [ ] `ThinkingDialect` 是作者声明的 L3 字段，没有任何"从模型 id 猜代次"的启发式。
+- [ ] `adaptive`/`extended` 恒发 `display:"summarized"`；`switch` 方言不发 display。
+- [ ] `extended` 的 budget 钳在 `[1024, min(16384, maxTokens/2)]`。
+- [ ] 缺省方言的猜测方向满足"错的方式会响"。
+- [ ] ① 族思维链读取走 `REASONING_CONTENT_FIELDS` 候选表；非字符串值忽略不强转；新拼写 = 表加一项。
+- [ ] 三个回传载体（`_reasoning` / `_geminiModelParts` / `_thinkingBlocks`）只挂在带 tool_calls 的 assistant 消息上。
+- [ ] `_thinkingBlocks` 带 modelId，换模型整组丢弃。
+- [ ] `redacted_thinking` 不会被内容过滤丢掉。
+- [ ] `<think>` 切分器只认响应开头、有 danglingPrefix 跨片处理、流末未闭合按 reasoning flush。
+- [ ] 切分出的 reasoning 不进回传载体。
+- [ ] 有一条验证手段确认 Anthropic 多轮工具会话中 thinking block 仍然出现（静默降级的唯一判据）。

--- a/docs/ai-agent-playbook/04-structured-output.md
+++ b/docs/ai-agent-playbook/04-structured-output.md
@@ -1,0 +1,97 @@
+# 04 · 结构化输出与降级链
+
+> 本篇解决的问题：让"要求模型输出一个符合 schema 的 JSON"在三个协议族、官方与兼容端点、思考型与非思考型模型上都能拿到可解析的结果——靠一条明确的降级链，而不是祈祷。
+> 不读会踩的坑：把 `response_format` 发给 Anthropic 硬 400；OpenAI `json_object` 在 prompt 不含 "JSON" 字面量时报错或输出无限空白流；用裸子串 "does not support" 判定回退，把无关的上游错误也吞进回退——翻倍花钱 + 掩盖真实错误；回退路径退成零约束纯散文，恰好落在最不容易吐干净 JSON 的思考型模型上。
+
+参考实现：simple-ai-writer `src/lib/ai/jsonMode.ts`、`src/lib/ai/json.ts`、`src/lib/agent/structured.ts`。
+
+---
+
+## 1. 四种强度与本方案的两级组合
+
+结构化输出手段按约束强度排序：
+
+```
+prompt 描述  <  JSON mode  <  json_schema 严格模式  <  强制工具调用
+```
+
+规范采用**两级组合**：**首选强制 pseudo-tool（schema 即工具 parameters），失败退回 JSON mode + 提示词**。
+
+为什么不用 `json_schema` 严格模式：
+
+- schema 要求 `additionalProperties: false` + 全字段 required，对天然有可选字段的领域模型不友好；
+- DeepSeek 等兼容层不支持；
+- 强制工具调用是四族官方都有的机制，**可移植性最好的 schema 手段**。
+
+## 2. JSON mode 的每族形状：jsonModeShaping
+
+JSON mode 的开启方式三族三样，必须收口在一个函数里，返回 `{ extraBody?, cue? }`：
+
+```ts
+// 参考实现：simple-ai-writer src/lib/ai/jsonMode.ts
+case "gemini":    // responseMimeType + cue 双保险（有模型静默无视 mimeType）
+  return { extraBody: { generationConfig: { responseMimeType: "application/json" } },
+           cue: JSON_ONLY_CUE };
+case "anthropic": // 无此参数，发 response_format 是硬 400 —— cue 是全部机制
+  return { cue: JSON_ONLY_CUE };
+default:          // OpenAI 系
+  return { extraBody: { response_format: { type: "json_object" } },
+           ...(mentionsJson(promptText) ? {} : { cue: JSON_ONLY_CUE }) };
+```
+
+三条规则：
+
+1. **Anthropic 无 JSON mode 参数，cue（提示词追加）是全部机制。** 发 `response_format` 是硬 400。为此参考实现做了双保险：Anthropic 适配器干脆不 spread `extraBody`（见第 1 篇 `extraBody` 语义）。历史教训：这个决定曾是散落两处的 `standard === "gemini"` 二元三目——于是**除 Gemini 外的一切**（包括 Anthropic）都被发了 `response_format`。收口成按族 switch 的单一函数后，这类"第三家被二元判断误伤"的 bug 结构性消失。
+2. **Gemini 双保险**：`responseMimeType` 照发，cue 也发——有模型静默无视 mimeType。
+3. **`mentionsJson` 不是风格检查，是文档明载的前置条件**：OpenAI `json_object` 在上下文找不到 "JSON" 字面量时报错（否则"模型可能生成无限空白流"），DeepSeek 同款要求。这个条件平时"恰好总成立"（prompt 通常提到 JSON），直到某次作者改写 prompt 删掉那个词——**prompt 可编辑的系统不能把它当既成事实**，必须检测、缺则追加 cue。同时 cue 在 OpenAI 路径上是**条件追加**：原生 enforcement 已在，cue 只为补前置条件；无条件加 = 每请求白花 token 复述 prompt 已说的话。
+
+## 3. 强制工具 → JSON mode 的回退链：runStructuredTask
+
+参考实现：simple-ai-writer `src/lib/agent/structured.ts`。
+
+### 路径一：强制 pseudo-tool
+
+- 声明单个 pseudo-tool，`parameters` = 输出 schema；`toolChoice: {type:"function", function:{name}}` 强制调用；读 toolCalls 的 arguments 即结果。
+- **`serverTools` 显式置 undefined**——结构化任务不上网。否则一个"唯一允许的工具调用是输出 schema"的请求里，模型可能跑去搜网页。
+- 空 arguments 抛 `EMPTY_TOOL_CALL`（进入回退判定）。
+
+### 回退判定：TOOL_CAPABILITY_ERROR 正则
+
+**只对能力类错误回退。** 正则要求能力词（function / tool call…）与"不支持"措辞**同现**。
+
+反面教训（必须写进代码注释）：早期用裸子串 `"does not support"` 判定，真实上游错误（如 "does not support streaming for this region"）也触发回退，把整个请求静默重发成另一形状——**翻倍花钱 + 掩盖真实错误**。回退是重发钱包，判定条件必须窄。
+
+### 路径二：JSON mode + 抠取
+
+- 用 `jsonModeShaping` 的 extraBody + cue + prose 指令重发。
+- **关键：回退路径必须仍带 JSON mode 原生参数。** 触发回退的恰是思考型模型（拒绝 forced tool_choice 的那种），在最不容易吐干净 JSON 的模型上退成零约束纯散文是反的。
+- 产出用 `extractJsonObject` 抠（参考实现：`src/lib/ai/json.ts`）：优先 ```json 围栏，否则取最外层 `{...}` span——思考型模型爱在 JSON 周围包散文。
+
+### 截断的鉴别
+
+JSON 输出场景对 `max_tokens` 截断尤其敏感：截断的 JSON 解析失败，看起来像"模型不听话"。**结束原因是唯一能区分二者的信息**——`length`/`max_tokens` 调上限，格式错改 prompt。解析失败时必须连同 `truncated`/`stopReason`（第 1 篇 done chunk）一起上报。
+
+## 4. 与被砍档 tool_choice 方言的联动降级
+
+有的兼容端点把 tool_choice 枚举砍到只剩 `auto|none`（实例：MiniMax `switch` 方言端点，见第 3 篇）——**强制档不存在**。
+
+规则：适配器的 `toolChoiceBody` 对已知砍档的方言把 forced **降级为 auto**，而不是发出去等 400。
+
+降级安全的论证（这类"预判降级"必须论证，否则宁可让它 400）：唯一使用强制档的调用方（runStructuredTask）本来就把"模型没调工具"当回退信号——最坏结果是回退早触发一轮；不降级则是"保证失败的请求 + 同一个回退"，多付一趟。**降级不改变任何调用方的语义，只省掉一次必败请求时，才允许静默降级。**
+
+---
+
+## 本篇检查清单
+
+- [ ] 结构化输出走"强制 pseudo-tool → JSON mode"两级链，不依赖单一机制。
+- [ ] 没有使用 `response_format: json_schema` 严格模式（或有明确的可移植性豁免记录）。
+- [ ] JSON mode 形状收口在单一 `jsonModeShaping` 按族 switch 中，grep 不到散落的 `standard === "gemini"` 式二元判断。
+- [ ] Anthropic 路径只有 cue，没有任何 `response_format`；适配器不 spread extraBody 双保险在位。
+- [ ] Gemini 路径 mimeType + cue 双发。
+- [ ] OpenAI 路径实现了 `mentionsJson` 检测，cue 条件追加。
+- [ ] 结构化请求显式关闭 serverTools。
+- [ ] 回退判定正则要求能力词与否定措辞同现；有针对"无关上游错误不触发回退"的测试用例。
+- [ ] 回退路径仍携带 JSON mode 原生参数（extraBody），不是纯散文请求。
+- [ ] `extractJsonObject` 支持围栏与最外层 span 两种抠法。
+- [ ] JSON 解析失败的错误报告携带 stop reason / truncated，能区分"截断"与"格式错"。
+- [ ] 已知砍档方言的 forced tool_choice 降级为 auto，且降级的安全性有书面论证。

--- a/docs/ai-agent-playbook/05-tools-and-server-tools.md
+++ b/docs/ai-agent-playbook/05-tools-and-server-tools.md
@@ -1,0 +1,127 @@
+# 05 · 工具协议与 server tools
+
+> 本篇解决的问题：本地工具（客户端执行）在三族上的定义转换、tool_choice 翻译、流式参数拼接，以及 server tools（端点自己执行的工具，如 web_search）带来的一整类新问题——包括「一次调用 = 多次 HTTP 请求」的续跑循环。
+> 不读会踩的坑：tool_call 与结果消息的配对是硬要求且**违约不自愈**——一次缺失永远留在会话历史里每轮重发，整段对话从此不可用；把 `server_tool_use` 当成欠结果的调用去回 tool_result 是协议错误；不设 `max_uses` 的服务端搜索是无上限花费；兼容层可能"响应侧抄全了、请求侧没抄"，协议规定的续跑方式恰好是它唯一不收的形状。
+
+参考实现：simple-ai-writer `src/lib/ai/serverTools.ts`、三个适配器的工具接线（`openai.ts` / `gemini.ts` / `anthropic.ts`，尤其 anthropic.ts 的续跑循环）；协议事实见其 `docs/api/tools.md`。
+
+---
+
+## 1. 工具定义的统一形状与三家转换
+
+内部统一用 OpenAI 嵌套形状：
+
+```ts
+ToolDefinition = { type: "function", function: { name, description, parameters } }
+// parameters 即 JSON Schema
+```
+
+转换规则：
+
+- **Gemini**：`tools: [{ functionDeclarations: tools.map(t => ({name, description, parameters})) }]`——同 schema，换容器。
+- **Anthropic**：`{ name, description, input_schema: t.function.parameters }`——**schema 字段唯一改名的一家**（`parameters` → `input_schema`）。
+
+## 2. toolChoice 翻译
+
+| 内部值 | Gemini | Anthropic |
+| --- | --- | --- |
+| `"required"` | `mode: "ANY"` | `{type: "any"}` |
+| `{type:"function", function:{name}}` | `mode: "ANY"` + `allowedFunctionNames: [name]` | `{type: "tool", name}` |
+
+限定规则：Anthropic 只在**自己声明了（本地）工具**时才发 tool_choice——请求里只有 server tools 时发 `{type:"auto"}` 等于对端点内部决策发表意见。已知砍档方言（枚举只有 `auto|none`）的 forced 降级见第 4 篇 §4。
+
+## 3. 流式参数拼接：三家三样
+
+| 族 | 拼接方式 |
+| --- | --- |
+| ① | 按 `delta.tool_calls[].index` 分片拼 `arguments` 字符串——**分组键必须是 index 不是 id，id 自身也可能分片**（`entry.id += partial.id`） |
+| ③ | 整个 `functionCall` 一次到齐（对象、无 id、适配器自造 id） |
+| ④ | 按块索引拼 `input_json_delta.partial_json`；空参数调用不会流任何 delta，`""` 必须转 `"{}"` |
+
+**参数类型分歧**：① 给 JSON 字符串（要自己 parse，可能非法——`parseJsonArgs` 全员 try/catch 兜 `{}`），③④ 给已解析对象。内部统一存字符串形态时，回传给 Anthropic 要 `parseJsonArgs(tc.function.arguments)` 转回对象。
+
+## 4. 配对是硬要求，且违约不自愈
+
+**每个 tool_call 必须有对应的结果消息，四族一致拒绝缺失。**
+
+危险之处在会话历史累加：一次缺失**永远留在历史里、每轮重发**——整段对话从此不可用，且报错发生在之后的每一轮而不是出错的那一轮。
+
+规则：任何可中途退出的实现（中止 / 异常 / 超时 / 用户取消）必须保证二选一：
+
+- 要么 tool_call 与结果**两条都不进历史**；
+- 要么调用**一定配上结果**——哪怕内容是"未执行"。
+
+这条规则属于 agent 循环层，但适配器层要为它兜底（如 Anthropic 转换器把孤儿 tool 消息合并、name 兜底链），因为持久化的历史可能已经带伤。
+
+## 5. Server tools：端点自己跑的工具
+
+参考实现：simple-ai-writer `src/lib/ai/serverTools.ts`（形状为 ④ 族的 `web_search`）。
+
+### 三原则
+
+1. **声明而非注册**：server tool 是请求体字段 + per-model 权限配置，**不进 agent 的工具注册表**。
+2. **无可执行**：runtime 的工具循环**绝不能把 `server_tool_use` 当成欠一个结果的调用**——给已完成的调用回 tool_result 是协议错误。
+3. **只读上报**：对上层只做执行日志展示（搜了什么、回了什么），没有任何回传义务。
+
+### wire 形状与 max_uses 刹车
+
+```ts
+{ type: "web_search_20250305", name: "web_search", max_uses: 10 }
+```
+
+- 与本地工具同处一个 `tools` 数组（两种条目形状并存）。
+- 类型按日期版本化。**id → wire type 的映射表集中一处**——版本升级 = 一处编辑，不是存进每行模型数据里永远冻着旧版本。
+- **`max_uses` 是唯一的刹车**：服务端工具不问就跑、按次计费（官方 $10/1000）+ 结果按 input token 计；一个研究型问题实测一轮 8 次搜索。即使中继文档没列这个字段也照发——这是对"只发中继文档写了的字段"规则的**刻意例外**，因为省略它的下行风险是无上限花费。
+
+### 响应流的防御读取
+
+- `server_tool_use` 块：query 按 `input_json_delta` 分片到达，**也有端点在 start 块整个给全——两种形状都要收**。
+- `web_search_tool_result` 块：整块到达无 delta。`content` 正常是结果数组、出错时是单个 error 对象——**读取端对容器形状全防御：认不出 = 零结果，而不是抛异常炸掉已完成的响应**。
+- 对外表达为两阶段 `ServerToolEvent`（`phase: "call" | "result"`），靠 `server_tool_use` 的 id 与结果块的 `tool_use_id` 配对。call 在 `content_block_stop` 时上报（此刻 query 才完整）——让执行日志在结果到达前就能显示"正在搜什么"。
+
+## 6. pause_turn 与「一次调用 = 多次请求」的续跑循环
+
+**「一次请求装下一个完整回答」在 server tools 下不成立**，且"装不下"有两种说法，只有一种明说：
+
+| 信号 | 谁 | 续跑方式 |
+| --- | --- | --- |
+| `stop_reason: "pause_turn"` | 官方 ④ | **verbatim**：整组 content block 原样作为 assistant 消息追加回去（`encrypted_content` 一字不改——服务端靠解密它恢复模型看到的搜索内容，重建块 = 400） |
+| 停在 `*_tool_result` 块上、报 `end_turn` | 某些兼容端点（MiniMax，实测 2026-08） | **transcript**：把搜索结果渲染成纯文本，以"assistant 开场白 + user 结果文本"两条普通消息送回（交替律所致必须两条；空 assistant 消息也是 400，故有兜底文案） |
+
+### spokeSinceSearch 判据
+
+第二种信号**没有任何字段**——只能问"**结果之后模型还说话了吗**"。`spokeSinceSearch` 刻意做成**关于文本流的事实**而非检查最后一个块：块记录依赖 `content_block_start` 到过，缺一个事件就会把"完成的 turn"误判成"没说话"而重发重计费。
+
+### 为什么兼容端点不能走 verbatim
+
+实测：MiniMax **拒收自己发出来的块**——`400 invalid params, tool result's tool id(...) not found`。其请求侧校验器把一切 `*_tool_result` 当客户端工具结果去找同 id 的 tool_use（响应侧实现了、请求侧没有，beta 兼容层的典型形态）。**协议规定的续跑方式恰好是它唯一不收的形状。** 纯文本 transcript 是不依赖对方懂不懂 server tools 的可移植兜底（代价：丢掉 citation 机制）。
+
+可移植教训：**兼容层可能"响应侧抄全了、请求侧没抄"——同一个数据结构，它发得出来、收不回去。** 任何"原样回话"的设计都要准备一条纯文本降级路径。
+
+### 续跑循环的工程约束
+
+- **`MAX_PAUSE_CONTINUATIONS = 4`**：每次续跑是一次全新计费请求、重发整个未完成 turn 含搜索结果——这个常数同时是成本上限与循环护栏。**触顶不是错误**，turn 就地结束。
+- **最后一条腿的提示词明说"这是最后机会"**——否则模型会用它宣布下一步计划而不写正文（实测 16 次搜索只换来 69 字预告）。
+- **usage 跨腿求和不覆盖**：每条腿报自己的 running total，只留最新 = 只计最后一条腿，而续跑腿才是贵的。
+- **对上层只有一条连续文本流** + 一个 done + `turnResumed` 诊断 chunk——"一个回答花了几次 HTTP 是传输层的事"。
+- **transcript 双层长度闸**：单条结果 600 字符、整份 12,000 字符，**按结果检查预算而非按 section**——防一个长 section 挤掉后续 query 的全部命中。
+- **无结果可交时不续跑**——"让模型对着同样的空气再答一次，多付一趟"。
+
+---
+
+## 本篇检查清单
+
+- [ ] 工具定义内部统一 OpenAI 嵌套形状；Gemini 换容器、Anthropic 改 `input_schema`，转换各在适配器内一处。
+- [ ] toolChoice 三族翻译齐全；Anthropic 仅在声明了本地工具时发 tool_choice。
+- [ ] ① 族参数拼接按 index 分组、id 累积拼接；④ 族空参数 `""` → `"{}"`；`parseJsonArgs` 全员 try/catch。
+- [ ] agent 循环保证 tool_call/结果配对：中止/异常/超时路径下要么双双不入历史、要么补"未执行"结果。
+- [ ] server tools 走声明而非注册，不在 agent 工具注册表里；工具循环对 `server_tool_use` 不回 tool_result。
+- [ ] server tool 的 id→wire type 映射集中一处，type 按日期版本化。
+- [ ] 每个 server tool 声明都带 `max_uses`。
+- [ ] `server_tool_use` 的 query 同时支持 delta 分片与 start 块整给两种到达形状。
+- [ ] 结果块读取全防御：认不出的容器形状 = 零结果，不抛异常。
+- [ ] 实现了 pause_turn verbatim 续跑（块原样回话，encrypted_content 不动），或至少把 `pause_turn` 当已知未完成态报警。
+- [ ] 有 transcript 纯文本降级路径，判据是"结果之后模型说话了吗"（文本流事实，非块记录）。
+- [ ] 续跑有腿数上限；触顶按正常结束处理；usage 跨腿求和；最后一腿提示词声明"最后机会"。
+- [ ] transcript 有单条 + 总量双层长度闸，按结果计预算。
+- [ ] 上层只见一条文本流；`turnResumed` 仅诊断用。

--- a/docs/ai-agent-playbook/06-errors-probing-observability.md
+++ b/docs/ai-agent-playbook/06-errors-probing-observability.md
@@ -1,0 +1,166 @@
+# 06 · 错误处理、usage、探测与可观测性
+
+> 本篇解决的问题：在兼容层世界里回答三个问题——「这次调用成功了吗」（默认答案 HTTP 200=成功在兼容层上是**错**的）、「这次花了多少钱」（两个口径陷阱会让你少报一个数量级）、「这个端点实际能接受什么」（文档/网关/作者说的都不算数）。
+> 不读会踩的坑：过期密钥被读成一次正常空回复；长 prompt + 缓存命中时 input 少报一个数量级；Gemini 思考 token 全部漏计；被限流的探测请求被记录成上下文上限的证据；API key 泄进日志与错误消息。
+
+参考实现：simple-ai-writer `src/lib/ai/usage.ts`、`modelHealth.ts`、`apiLog.ts`、`providerProbe.ts`、`endpointProbe.ts`、`probeAnalysis.ts`，以及三个适配器的错误通道处理。
+
+---
+
+## 1. usage 归一化：两个口径陷阱
+
+内部统一口径：
+
+- `inputTokens` —— 总输入；
+- `outputTokens` —— 总输出，**含思考**；
+- `cachedTokens` —— **inputTokens 的子集**，按缓存价计费的部分。
+
+计费公式：`(input − cached) × 全价 + cached × 缓存价`。
+
+两处**必须**归一化，否则数字直接错：
+
+1. **Anthropic 三桶不重叠**（参考实现：`anthropic.ts` 的 `readUsage`）：`input_tokens` 只是未命中缓存的余量，`cache_read_input_tokens`、`cache_creation_input_tokens` 单列。总输入 = 三者之和——直接读 `input_tokens` 会在长 prompt + 缓存命中时**少报一个数量级**。cache write 计价高于基础价而费率表通常没这档，归入全价桶——宁可高估（用户拿这个数决定跑不跑，高估是安全方向）。另外 `message_delta` 只报 output，不能让它缺失的 input 字段清零 `message_start` 已立的数（`input || prev.inputTokens`）。
+2. **Gemini 思考不在 `candidatesTokenCount` 里**：`outputTokens = candidatesTokenCount + thoughtsTokenCount`——只读前者会把"思考 5k、回答 500"记成 500，少算的正是最贵的部分。（①④ 的输出已含思考，details 只是明细。）
+
+### 持久化与 rollup
+
+参考实现：`src/lib/ai/usage.ts`。
+
+- `persistUsage` 每次调用一行（model_id / task / prompt / cached / completion / cost / created_at），**best-effort 永不抛**——记账不能炸调用方。
+- 读侧两个 GROUP BY rollup（byModel / byTask）；`total` **从 byModel 求和派生而非单独查**——标题数字与明细行永远不可能不一致。
+- SUM 空组的 NULL 在边界强转 0——否则一路 NaN 渲染成 "NaN tokens"。
+
+## 2. 错误处理：HTTP 200 不等于成功
+
+核心论点：失败通道的差异是**正确性**问题——它决定"这次调用成功了吗"这个判断本身，而默认答案（HTTP 200 = 成功）在兼容层上是错的。必须处理的**四种"看起来成功"的失败**：
+
+1. **SSE 体内 `data: {"error":...}`**（三族适配器都要处理）：审核拦截、上游故障、余额耗尽经常这样送达（OpenRouter routinely）。不处理 = 流在此结束、之前的部分文本被当成正常短回复。
+2. **`base_resp.status_code`**（OpenAI 系适配器单独处理）：同一件事的第二种拼法（MiniMax：1004 鉴权失败、1008 余额不足、1002 限流），0 为成功。只认 `error` 字段的客户端会**把过期密钥读成一次正常空回复**。
+3. **内容拦截在文本已开始后到达**：
+   - Gemini：请求级 `promptFeedback.blockReason` 与响应级 `finishReason ∈ {SAFETY, PROHIBITED_CONTENT, BLOCKLIST, RECITATION, SPII, IMAGE_SAFETY}`（后者可能在半截文本后到）；
+   - Anthropic：`stop_reason: "refusal"`；
+   - OpenAI：`finish_reason: "content_filter"`（Azure 及多家网关用它而非错误状态码，且几乎不带文本）。
+   三者都必须 **throw** 而不是当正常结束——已交付上层的文本需要作废。
+4. **请求缺陷伪装成正常短答**：Gemini 的 `GEMINI_REQUEST_FAULTS` 集合——`MISSING_THOUGHT_SIGNATURE`（我方丢了签名，不是用户的错，报错措辞刻意区分，否则用户会去自己的内容里找根本不存在的敏感词）、`UNEXPECTED_TOOL_CALL`、`TOO_MANY_TOOL_CALLS`、`MALFORMED_RESPONSE`。这组说明 finishReason 检查**不能只是 in blocked-set**：HTTP 200 + 不认识的 finishReason，不处理就读成正常短回复。
+
+推论规则：**健壮解析器要把"200 且没有任何内容"当可疑而非成功。**
+
+### 错误消息的两条纪律
+
+- **一律带上实际请求的 URL**：第三方端点最常见的故障是 base 解析到了意料之外的地方，裸的 "404: \<html\>" 让用户无从对照自己粘贴的地址。
+- **永不带 key**（同一原则贯穿 apiLog、`?key=` 不实现，见第 2 篇）。
+
+### safety-block 粘性标记
+
+参考实现：`src/lib/ai/modelHealth.ts` 的 `isSafetyBlockMessage`。安全拦截类错误由正则识别（匹配三族的措辞），把该模型标记为 blocked——**跨会话粘性，直到该模型完成一次成功运行才清除**。模型选择器用它提示"这个模型刚拒绝过这类内容，换一个"。
+
+## 3. 重试 / abort / 超时
+
+- **主聊天路径不重试**：一次 streamCompletion 一次机会，错误直接上抛给任务层决定。（用户在看着流，静默重试 = 内容闪回重来。）
+- **探测路径重试**：`RETRY_ATTEMPTS = 3`、线性退避 1.2s×n、**只对 `isTransient`（429/5xx）重试**。关键理由：**被限流的请求绝不能被记录成上下文上限的证据。**
+- **abort**：`AbortSignal` 一路穿透到 fetch。探测用 `requestSignal` 合并外部 signal 与每请求超时 timer，并把 controller 交出——error probe 在 `res.ok` 时**读到响应头就主动 abort**，不为一次探测付整段生成的钱。
+- **超时**：探测每请求 180s（本地后端吃大上下文会 paging 数分钟，探测不能继承聊天级耐心）；**主聊天路径不设自有超时**（长生成合法），交给 signal。
+- **ContextSizeError**：发送前估算拦截（第 1 篇 §6），错误对象携带 estimated / contextSize 两个数字供 UI 展示。
+
+## 4. API 日志：为兼容层调试而生
+
+参考实现：`src/lib/ai/apiLog.ts`。**强烈建议第一批实现**——后续所有兼容层坑都靠它定位。
+
+设计规则：
+
+- 开关在设置里；关着时返回 **noop logger**（调用点无条件调用，无 if）。
+- JSONL 按天一文件。
+- **永不写 apiKey。**
+- base64 图片替换成 `<image data url, N chars omitted>` 占位——结构化递归裁剪任何 >2048 字符的字符串，**协议无关**（适配器 body 形状变了照样工作）。
+- **写入串行化**——agent 循环并发调用不能交错行。
+- 三类条目：
+  - `request` —— 调用方意图（消息形状）；
+  - `request-body` —— **适配器实际发出的每个 HTTP body，带 leg 序号**。续跑腿的 body 除此之外无处可看；参考实现的经验是"resume 路径上每个已发现的 bug 都是靠读这些 body 找到的"；
+  - `response` / `error` —— 含 stopReason / truncated。"回答就这么停了"是这份日志要解释的头号问题：只有 stop reason 能区分 max_tokens 截断 / tool_use 该继续 / end_turn 模型自认写完。
+
+验证方法论：所有"文档说支持但未实测"的能力（thinking 各方言等），验证方式就是**打开 API 日志直接读 body**——这个日志是兼容层适配的第一调试工具。
+
+## 5. providerProbe：连接测试与模型列表（配置时点）
+
+参考实现：`src/lib/ai/providerProbe.ts`。
+
+- **先打 `/models`**：存在时一次回答两个问题（可达 + 已鉴权）且零成本。三族响应形状：OpenAI `{data:[{id}]}`、Gemini `{models:[{name:"models/x", displayName}]}`、Anthropic `{data:[{id, display_name}]}`。
+- **compat 且 `/models` 404/405/501**（`ENDPOINT_ABSENT` 集合——"服务器不 serve 这个路径"，区别于 401/429/500 "served 了但拒绝"）→ 不报失败，降级到 **completion probe**：POST 一个最小 body，模型名用**不可能存在的** `__connection_probe__`——连接测试发生在用户选模型之前，真名会计费一次真实生成。
+- completion probe **读的是被拒绝的形状，不是结果**：
+  - 401/403 → 鉴权失败；
+  - 非 2xx 但 body 是**该协议自己的 JSON error 结构** → **判连通成功**（只有真在说这套协议的服务才这样回话）；
+  - body 是 HTML/空/非 JSON → 报错——这正是要抓的"base URL 指向了不是 API 的东西"（nginx 404、登录页、CDN）；它与"没有 /models"同样是 404，唯一区别是回话的形状；
+  - 2xx → 连通（端点无视了 model 字段，少见但可达且收了 key）。
+- **没有 `/models` 的中继是正常配置不是坏的**（模型 id 可手填）。报错文案必须说清这一点而不是甩状态码——否则用户会读成"我的 key 错了"。
+
+## 6. endpointProbe：模型真实上限的实测
+
+参考实现：`src/lib/ai/endpointProbe.ts`（HTTP 管线）+ `probeAnalysis.ts`（纯判断）。回答的问题是"这个端点**实际**接受什么"，而不是文档/网关/用户猜的。四步递进、花钱递增：
+
+```
+Step 0  discover()   免费元数据：/models 扩展字段（OpenRouter context_length、
+                     LM Studio max_context_length…）；Gemini/Anthropic 的
+                     per-model 端点直接给 inputTokenLimit/outputTokenLimit、
+                     max_input_tokens/max_tokens（这两族后续步骤基本可省）；
+                     本地栈加测 ollama /api/show 与 llama.cpp /props    0 token
+Step 1  errorProbe() 两个词的 prompt + max_tokens=10,000,000（荒谬值）：
+                     执行上限的服务器会把真实上限写进 4xx body——花几个
+                     token 换一个精确数字；接受了的（stream:true）读到
+                     响应头就挂断，不付生成费                        ~0 token
+Step 2  calibrate()  两个已知字符数的 padding → 该端点真实 chars-per-token
+                     （模板开销在两点间抵消）
+        truncation() 发已知大小 prompt（快测 8k，正中 ollama 默认 num_ctx
+                     2048/4096 的雷区）对比服务器报的 prompt_tokens：
+                     short fall = 静默截断实锤；一致 ≠ 无截断——
+                     不对称性一路带到报告，UI 对两种结果措辞不同
+Step 3  deep(opt-in) 从声明值开始的二分搜索找真实接受上限（声明值直接过 =
+                     一次请求收工，永不从零盲扫；不能定论的错误直接停，
+                     不当证据）；真实生成测输出长度——任务必须是模型
+                     不可能自然写完的（"从 1 数数"），否则 stop 分不清
+                     是上限还是写完了；capped 才是上限证据 high，
+                     跑满只是下界 low
+```
+
+配套设计原则：
+
+- **判断逻辑独立可单测**：所有判断（这个错误是上限还是限流？这个差距是截断还是分词噪音？）抽在无网络依赖的 `probeAnalysis.ts`，probe 本体只是管线。
+- 每个 finding 带 source / detail / confidence：描述"实际加载运行的值"的键（`num_ctx` / `max_model_len`）置 high，理论能力键置 medium——ollama 的 `model_info` 与 `parameters` 常差 30 倍，**小的那个才算数，这个差值本身就是静默截断 bug**。
+- **探测成本先告知**：探测前 `planProbeCost` 给用户看预估花费（"看不见成本的同意不是同意"），结束给实际花费回执。
+- `max_tokens` 被拒时自动换名 `max_completion_tokens` 重试一次（记 param-switched 警告）。
+- **`probedAt` 过期语义**：测量会过期——中继明天可能把同一模型名路由到另一个上游。UI 呈现为"某日实测"而非永久事实。
+- 存储上给"作者填的值"与"实测值"**各留位置**——直接覆盖同名字段后，"这个 128k 是填的还是测的"答不上来，且用户填的值不可恢复。
+
+## 7. 探测的边界：能声明的声明、能从失败恢复的不预探、只有数值才实测
+
+**endpointProbe 探测的是上下文/输出上限，不是"这个端点说哪种方言"。** 分工规则：
+
+- **方言（协议族）**：作者选择 ApiStandard 声明；
+- **thinking 代次（dialect）**：作者声明（理由见第 3 篇：中继上模型 id 是自由文本，代次不可探测）;
+- **tools / JSON mode 能力**：不主动探测，靠**运行时降级**（structured 的错误正则回退、providerProbe 的错误形状判定）；
+- **上下文窗口 / 输出上限**：作者自己也不知道的**数值**，才花钱实测。
+
+这是刻意取舍，配合三条贯穿性原则收尾：
+
+1. **最小公倍数发送、最大宽容接收。** 官方端点可乐观假设可选部分存在，兼容端点不行；主动发出的每个字段都是某个中继可以 400 的字段（`max_uses` 是唯一有记录的刻意例外，见第 5 篇）。
+2. **凡跨轮回传的，原物整存**（thinking blocks、thoughtSignature、encrypted_content、reasoning 字段名）；"理解后重建"恰好丢掉的就是完整性校验依赖的那部分。
+3. **先问失败会不会响。** 会响的（400）靠错误驱动降级即可；不响的（静默降级/静默截断/静默忽略）必须主动验证（API 日志对照、探测、"结果之后模型说话了吗"式的间接判据），并且**只有这类才值得预先花设计预算**。
+
+---
+
+## 本篇检查清单
+
+- [ ] usage 内部口径三字段（input / output 含思考 / cached 为 input 子集）+ 计费公式有文档。
+- [ ] Anthropic input = 三桶求和；`message_delta` 不清零已立的 input。
+- [ ] Gemini output = `candidatesTokenCount + thoughtsTokenCount`。
+- [ ] `persistUsage` best-effort 永不抛；total 从明细 rollup 派生；NULL→0 在边界处理。
+- [ ] 三族适配器都处理 SSE 体内 `data:{"error":...}`；OpenAI 系另处理 `base_resp.status_code`。
+- [ ] content_filter / SAFETY / refusal 都 throw 作废已流出文本，不当正常结束。
+- [ ] Gemini 的 finishReason 检查覆盖 `GEMINI_REQUEST_FAULTS`，且我方缺陷（丢签名）与内容拦截的报错措辞区分。
+- [ ] 错误消息带实际请求 URL，永不带 key；apiLog 永不写 key。
+- [ ] safety-block 有跨会话粘性标记，成功一次即清除。
+- [ ] 主路径不重试不设超时；探测路径仅对 429/5xx 重试、每请求超时、限流结果不入证据。
+- [ ] apiLog：noop 开关、按天 JSONL、图片/长串裁剪、写入串行化、request-body 带 leg 序号、response 含 stopReason/truncated。
+- [ ] providerProbe：/models 优先；compat 对 `ENDPOINT_ABSENT` 降级 completion probe；probe 用不可能模型名；按被拒形状判定；"没有 /models"的文案不吓人。
+- [ ] endpointProbe 四步递进；判断逻辑在独立纯函数模块可单测；探测前告知成本；finding 带 confidence；probedAt 呈现为"某日实测"。
+- [ ] 作者填的值与实测值分开存储。
+- [ ] 新能力接入时先过一遍"声明 / 运行时降级 / 花钱实测"三分法，只有数值才实测。

--- a/docs/ai-agent-playbook/07-agent-runtime.md
+++ b/docs/ai-agent-playbook/07-agent-runtime.md
@@ -1,0 +1,359 @@
+# 07 · Agent Runtime：preset 驱动的 tool loop 与事件系统
+
+> 本篇解决的问题：一个应用里往往有多种 AI 任务——续写、结构化提取、对话助手、子代理调查——如果每种任务各写一个循环，工具协议不变量（tool_call 配对、abort 配平、上下文裁剪）就会被复制 N 份并各自腐坏。本篇规定一种**唯一的 tool loop 实现**（runtime），由纯数据的 **TaskPreset** 驱动其行为差异，并通过结构化 **AgentEvent** 流向 UI 汇报进展。工具注册、权限分级与写入安全见第 08 篇；工具动态路由与子代理见第 09 篇；结构化输出双路径详见第 04 篇。
+>
+> 参考实现：simple-ai-writer `src/lib/agent/runtime.ts` / `presets.ts` / `events.ts` / `logModel.ts`。
+
+---
+
+## 1. 总体架构与五条核心设计决策
+
+分层骨架（自上而下）：
+
+```
+UI 层（各任务面板 / 对话界面 / 各类 modal）
+   │ 以 TaskPreset 启动，注入回调（onEvent / onOutputText / requestApproval…）
+   ▼
+会话与审批 store        ← 审批队列（pending / pendingPlans / pendingRoundLimits）
+                          + 对话会话（wire 历史数组 + 展示层 turns）
+   ▼
+runtime.ts              ← runAgent：多轮 tool loop、trimHistory、round-limit、abort
+registry.ts             ← REGISTRY: Record<ToolId, RegisteredTool>（定义 + access + 执行器）
+presets.ts              ← TaskPreset（tools / maxRounds / finishPolicy / scratchpad / serverTools）
+plan.ts / backup.ts     ← 领域数据写入的方案门控、写前备份（见第 08 篇）
+   ▼
+流式客户端（streamCompletion 多协议 SSE；ConnOptions 作为传输配置的唯一切面）
+```
+
+迁移到任何新项目时，以下五条决策是**必须保留的骨架**，不是可选风格：
+
+1. **runtime 只做循环，不做策略。**哪些工具可用、跑几轮、怎么收尾，全部由 preset 数据决定；工具执行一律查注册表分发，runtime 内**绝不允许出现 `switch(toolName)` 硬编码**。加任务 = 加一个 preset 常量；加工具 = 在注册表登记一项。
+2. **权限不在 runtime 里执行，在工具执行器里执行。**runtime 无差别调用 `executeRegisteredTool`；L1 自动写的备份、L2 审批写的阻塞、方案门控，全部在各工具的 `execute` 内部完成。`access` 字段更多是声明/文档/UI 用途，不是 runtime 的分支依据。
+3. **审批 = Promise 挂起。**L2 工具在 execute 内 `await ctx.requestApproval(proposal)`，整个 tool loop 同步阻塞在这里，直到用户在 UI 卡片上批准/拒绝。批准后的落盘由**审批方**（store）完成，工具本身永不直接写用户核心内容。
+4. **错误全部回给模型。**执行器不 throw（注册表捕获后转成 `Error: ...` 文本结果）：坏调用变成模型下一轮可读、可纠正的信息，单次坏调用不杀死整个运行。
+5. **history 即会话。**runtime **原地 mutate** 调用者持有的 messages 数组；对话场景把同一数组跨轮复用，上一轮的 tool 调用与结果留在上下文里供下一轮指代。因此协议完整性（每个 tool_call 必须有配对回复）是**生死攸关的不变量**——历史一旦畸形，此后每一轮都会被 provider 拒绝，会话永久报废。
+
+---
+
+## 2. runtime 契约（输入 / 输出）
+
+参考实现：simple-ai-writer `src/lib/agent/runtime.ts`。
+
+```ts
+export interface AgentRuntimeOptions extends ConnOptions {
+  // 传输层字段全部来自 ConnOptions（baseUrl / apiKey / standard / modelId /
+  // contextSize / maxOutput / reasoningEffort / thinkingDialect / serverTools…），
+  // 用 connOptions(conn) 构造。新增传输字段只改 ConnOptions 一处。
+  inputCeilingTokens?: number;              // 上下文预算规划器给出的输入上限
+  extraBody?: Record<string, unknown>;      // 额外顶层请求字段（如 JSON mode 的 response_format）
+  preset: TaskPreset;
+  messages: StreamMessage[];                // 种子历史：system + 首个 user；被原地追加
+  toolContext: ToolContext;
+  signal: AbortSignal;
+  onEvent: (event: AgentEvent) => void;
+  onRoundLimit?: (roundsUsed: number) => Promise<RoundLimitDecision>;  // 轮次上限时阻塞询问
+  onOutputText: (fullText: string) => void; // 快照式全量输出：调用方赋值，而非追加
+}
+
+export interface AgentRunResult {
+  rounds: number;
+  inputTokens: number; outputTokens: number; cachedTokens: number;
+  outcome: "completed" | "paused";   // paused = 用户在轮次上限选择了「存盘暂停」
+}
+```
+
+两个关键契约，应当写进接口文档并在 code review 中守住：
+
+- **不变量：messages 原地 mutate。**调用者持有的数组就是完整成绩单。会话场景直接把它当持久历史存起来，下一轮继续传入。runtime 不复制、不返回新数组。
+- **不变量：onOutputText 是快照，不是增量。**只有 runtime 知道某一轮的文本最终「不算输出」——模型在调工具前说的「我先去找文件列表。」是自言自语，不是答案。文本照常流式显示，但一旦该轮以工具调用结束，整段回滚（`onOutputText(committedText)`，即撤回到上一次已确认的全文）。快照式接口是唯一能自然表达「撤回」的形式；增量接口做不到。被丢弃那一轮做了什么由执行日志记录，信息不丢失。
+  - 陷阱：若用增量接口，「工具轮的自言自语」会被插进用户文档（实际事故：一句「我先去找文件列表。」混进了正文）。
+
+---
+
+## 3. round 循环完整骨架
+
+以下伪代码是**可照抄的实现规范**（参考实现：simple-ai-writer `src/lib/agent/runtime.ts` 的 `runAgent`）：
+
+```
+for round in 1..maxRounds:                         // maxRounds 可被 onRoundLimit 中途扩大
+  if signal.aborted: throw AbortError
+  isLastRound = round === maxRounds
+
+  ── 轮次上限询问（仅 force-text + 有工具 + round>1 + 提供了 onRoundLimit）──
+  if isLastRound && …:
+      decision = await opts.onRoundLimit(round - 1)   // 阻塞（如同审批）
+      pause  → return { …, outcome: "paused" }        // 干净退出点：轮首，历史必然配对完整
+      extend → maxRounds += decision.rounds; isLastRound = false
+      finish → 继续走强制成文
+
+  ── 强制成文与工具撤除 ──
+  withholdTools = tools为空 || (isLastRound && finishPolicy === "force-text")
+  若强制成文：push 一条临时 user 消息（轮次上限提示），请求发出后 splice 移除
+
+  ── checkpoint 提示（scratchpad: "required" 且历史 > ceiling*0.85）──
+  push 临时 user 消息：「上下文接近上限即将裁剪，用 write_note 把关键结论写进笔记」
+  同样在 finally 中撤回；checkpointArmed 防重复，trim 发生后重新武装
+
+  ── 裁剪 ──
+  dropped = trimHistory(history, inputCeilingTokens)
+  dropped > 0 → emit {kind:"context-trimmed", count}
+
+  emit {kind:"round-start", round, maxRounds, estInputTokens}
+
+  ── 一次流式请求 ──
+  await streamCompletion({ ...pickConnOptions(opts), messages: history,
+      extraBody, tools: withholdTools ? undefined : toolDefinitions,
+      serverTools: withholdServerTools ? undefined : opts.serverTools,
+      signal, onChunk })
+  onChunk 分支：
+    reasoning   → 累积 + 反复 emit 同一条 {kind:"reasoning", round, text, done:false}
+    turnResumed → emit {kind:"turn-resumed"}（端点分腿续传可见化）
+    serverTool  → emit 日志行（端点自跑的工具，绝不进 roundToolCalls）
+    text        → roundText += chunk; onOutputText(committedText + roundText)
+    toolCalls   → 记录 roundToolCalls + thinking 回传字段
+    done        → 累计 tokens；chunk.truncated → emit {kind:"output-truncated"}
+
+  ── 收尾判定 ──
+  if roundToolCalls.length === 0:
+      committedText += roundText
+      return { rounds: round, …, outcome: "completed" }    // 出散文即结束
+
+  // 工具轮：回滚展示文本
+  if roundText: onOutputText(committedText)
+
+  // 追加 assistant tool_calls 消息（带 thinking 回传字段）
+  history.push({ role:"assistant", content:null, tool_calls:[…],
+                 _geminiModelParts, _reasoning, _thinkingBlocks })
+
+  ── 逐个执行工具调用 ──
+  for tc of roundToolCalls:
+      if abortedMidRound || signal.aborted:
+          history.push({role:"tool", tool_call_id: tc.id, content: ABORTED_TOOL_RESULT})
+          continue                                          // 仍要配平！
+      emit tool-step running
+      result = await executeRegisteredTool(tc, preset.tools, {…toolContext, signal, onNestedEvent})
+      emit tool-step done/error（resultSummary 截取头部）
+      history.push({role:"tool", tool_call_id: tc.id, content: result.content})
+      if result.imageDataUrls:                              // 图片走后续 user 消息
+          history.push({role:"user", content:[{text}, …image_url parts]})
+  if abortedMidRound: throw AbortError                      // 配平完成后才抛
+```
+
+### 3.1 唯一终止条件：「出散文即完成」
+
+**不变量：无工具调用的轮 = 答案。**这是 tool loop 唯一的正常终止条件。跑满 `maxRounds` 落出循环只是防御性返回（`force-text` 策略下最后一轮已撤除工具，理论上不会发生），且不得丢弃已累计的 token usage。不要发明第二种终止条件（如「模型说 DONE」「输出某个标记」）——它们全都依赖模型服从性，而「这一轮没调工具」是协议层面的客观事实。
+
+### 3.2 abort 配平不变量与 repairToolCallPairing
+
+**不变量：中断也必须配平。**abort 信号到达在一轮多个 tool call 中间时，剩余的调用一律以桩回复（如 `"[not run — the user stopped the task]"`）填入 history，**配平完成后才抛 AbortError**。原因：assistant 的 `tool_calls` 消息已经进了 history，而 history 就是会话历史；k < N 的 tool 回复会让后续每一轮都被 provider 拒绝，会话永久报废、唯一出路是新建对话。
+
+配套要求：
+
+- **每个 tool call 前都要重查 `signal.aborted`**，不只每轮查一次——审批队列 `rejectAll` 解决被阻塞的 Promise 的瞬间就可能伴随 abort 到来。
+- **提供并导出 `repairToolCallPairing(history)`**：在「裤带」（abort 补桩）之外再系一条「背带」。它扫描历史，为所有缺失回复的 tool_call 倒序 splice 补桩（先补后面的不影响前面索引）。会话 store 应在**每个后续轮追加新消息之前**调用它——覆盖第二次运行共享数组、两次 push 之间崩溃、从磁盘恢复历史等场景。
+
+### 3.3 thinking 回传字段随消息存放
+
+**规范：thinking 模型的续轮字段必须挂在 assistant 消息本体上**，随历史存续，而非事后重建。典型字段：`_geminiModelParts`（Gemini thought signatures）、`_reasoning` / `_thinkingBlocks`（OpenAI 兼容 / Anthropic 思考回传）。丢了它们的后果不是「答案变差」，而是**下一轮请求直接失败**——所以它们的生命周期必须与消息一致，trimHistory 只换 content 不删消息的策略（见 §3.6）也顺带保住了它们。
+
+### 3.4 serverTools 三态
+
+端点侧工具（provider 在**一次请求内部**自己运行的工具，如内建 web_search）与本地工具是两套独立控制：
+
+```ts
+serverTools?: "final-round-off" | "off" | "always";
+// final-round-off（默认）：强制成文那一轮撤下，避免收尾轮又跑去搜索
+// off：本任务永不放行
+// always：每轮都放行（典型：search 子代理——没有本地工具，但每轮都需要端点搜索）
+```
+
+陷阱：流中出现 `serverTool` chunk 时**只记日志，绝不能当作 tool_call 去回复**——端点已经自己消化了这次调用，本地再补一条 tool 回复反而破坏配对。
+
+另：`extraBody` 用于透传顶层请求字段（如 JSON mode 的 `response_format`）。**JSON mode 与 tool 调用在多家 provider 互斥**——使用 extraBody 做结构化输出的 preset 应保持 `tools: []`。
+
+### 3.5 临时提示：发出即撤
+
+**不变量：任何一次性的引导消息（强制成文提示、checkpoint 催写提示）都必须在请求发出后从 history 中 splice 撤回（放在 finally 里保证执行）。**
+
+陷阱（实际事故）：「本轮别再调工具了」的 user 提示留在了持久历史里，成为常任禁令——轮次上限那轮之后，助手在后续所有轮都不再读文件/执行操作，且屏幕上毫无解释。凡是「只对这一次请求说的话」，生命周期就只能是这一次请求。
+
+### 3.6 trimHistory：两段式轮内裁剪
+
+```ts
+export function trimHistory(history: StreamMessage[], ceilingTokens?: number): number
+// 返回被裁的消息数，供 emit context-trimmed
+```
+
+1. **图片先裁，且无条件裁。**只保留最新 N 张图（参考值 `MAX_IMAGE_RESULTS = 3`；模型工具读的图和用户附带的图**同等计数**——wire 上都是 base64，只盯一种，另一种就能绕过帽子）。为什么无条件：token 估算对图片按 provider 计费口径记平价，但 payload 是 base64、以 MB 计且跨轮存续——只靠 token 检查，一个读图会话会长出没有任何端点接受的请求体，而估算值还显示宽裕。被裁的消息**保留文字部分**，图片部分替换为占位文本。
+2. **超过 ceilingTokens 后，最老的 tool 结果先走。**它们既是体积增长的主体，又最不可能仍然有用。关键规范：**消息壳保留，只替换 content** 为形如 `"[earlier tool result dropped to stay within the model's context window]"` 的占位——删掉消息会制造无配对回复的 tool_call，在 OpenAI 与 Gemini 都是协议错误。逐条替换、每次替换后重估 token，达标即停。**system 与首轮种子文本永不触碰**：如果它们本身超限，那是上游预算规划的 bug，应当由 pre-flight 检查报出来，而不是在这里悄悄掩盖。
+
+分工（对话场景）：trimHistory 是**轮内**的第二道防线；轮与轮之间由 compaction（把整段旧轮折叠成滚动摘要）负责。trim 专门处理压缩管不到的两类增长：一轮之内的增长（折叠单位「完整轮」尚未成形），以及根本没有轮间时刻的一次性任务。
+
+### 3.7 checkpoint 机制（防裁剪失忆）
+
+对 `scratchpad: "required"` 的 preset：历史逼近上限的 85%（`CHECKPOINT_RATIO = 0.85`）时，插入一条一次性提示，催模型用 `write_note` 把已获结论写进磁盘笔记，**赶在** trimHistory 抹掉旧工具结果之前。三条配套规则：提示消息发完即撤（§3.5）；`checkpointArmed` 标志防止连轮重复提醒；真的发生裁剪后解除武装，下次再逼近时重新提醒一次。
+
+### 3.8 round limit：三出口与轮首暂停的干净性
+
+触发条件苛刻而精确：进入 `force-text` 任务的**最后一轮**、且 `round > 1`（单轮 preset 的一轮就是全部）、且有工具、且调用方提供了 `onRoundLimit`。此时模型前面每一轮都在调工具——正在干活中，强行成文等于拦腰砍断。
+
+**规范：询问点必须在强制成文之前（轮首），不能在之后**——工具一撤、文一写，运行已经结束，无从恢复。
+
+```ts
+// RoundLimitDecision 定义在 events.ts，runtime re-export——避免 import 环
+type RoundLimitDecision =
+  | { action: "extend"; rounds: number }   // maxRounds += rounds，继续
+  | { action: "finish" }                    // 走原有强制成文
+  | { action: "pause" };                    // 立即 return outcome: "paused"
+```
+
+- **pause 的干净性靠位置保证**：在轮首询问，上一轮的 tool_call 已全部配平，无需任何修补即是合法历史，可直接持久化、日后 resume。
+- **`onRoundLimit` 必须可选**：不是每个界面都能渲染这张卡片（无审批区的 modal、批量运行）。在渲染不了卡片的界面上阻塞 = 挂死在没人看得见的地方。不能渲染的界面保持硬停（不传 onRoundLimit）。
+- 「能否暂停」（canPause）应按**本次运行**评估（是否已有磁盘工作区），且在**到达上限那一刻**评估而非运行开始时——三轮前才建立的工作区也算数。
+
+---
+
+## 4. Preset 系统
+
+参考实现：simple-ai-writer `src/lib/agent/presets.ts`。
+
+```ts
+export interface TaskPreset {
+  id: string;
+  tools: readonly ToolId[];        // 空数组 = 纯单发流式，不进 tool loop
+  maxRounds: number;               // 模型↔工具轮数上限
+  finishPolicy: "force-text" | "allow-tool-end";
+  scratchpad?: "off" | "offered" | "required";  // 磁盘工作区：无 / 可用 / 可用 + checkpoint 催写
+  serverTools?: "final-round-off" | "off" | "always";
+}
+```
+
+### 4.1 preset 应当刻意薄
+
+**设计准则：preset 只管「循环怎么跑」，不管「说什么」。**没有 systemPrompt、温度、seedContext 字段——prompt 组装依赖大量应用侧状态（领域配置、i18n、检索注入），留在调用方更干净。新项目可以按需把 prompt 收进 preset，但参考实现的经验是：计划书里原本设计了 `systemPrompt(ctx)` / `seedContext(ctx)` / `output` 字段，落地时全部回到了调用方。
+
+### 4.2 preset 如何驱动 runtime
+
+- `getToolDefinitions(preset.tools)` 解析 wire 定义（保序）；
+- `executeRegisteredTool(call, preset.tools, ctx)` 以 `preset.tools` 为**白名单**——模型编造出不在名单里的工具名，得到 `Unknown tool` 文本结果而非崩溃；
+- `finishPolicy` + `tools.length` 决定最后一轮是否撤除工具；
+- `scratchpad` 决定是否启用 checkpoint 提示；
+- `serverTools` 决定端点侧工具何时放行。
+
+### 4.3 各预设一览（参考实现的完整清单，作示例）
+
+| preset | tools | maxRounds | 特点 |
+|---|---|---|---|
+| `CONTINUE_PRESET`（续写） | 7 个只读（列表/读领域条目、读图、列文件、读文件、搜文本） | 8 | force-text；`presetForTools("read")` 的落点 |
+| `LORE_IMPROVE_PRESET` | 3 个领域数据只读 | 4 | 改条目前可自查其它条目；落盘仍走 modal 人审 |
+| `FACET_ASSIST_PRESET` | 同上 | 4 | 单特征扩写/重构 |
+| `LORE_GENERATE_PRESET` | **[]** | 1 | JSON 结构化提取；JSON mode 与 tool 互斥所以单发，serverTools:"off" |
+| `LORE_SPLIT_PRESET` | **[]** | 1 | 同上，逐字拆分 |
+| `AGENT_ASSIST_PRESET` | **全家桶 27 个**（读 + L1 领域写 + L2 propose_* + 图片 + scratchpad） | **20** | force-text，scratchpad:"required"；对话助手与面板 Agent 模式共用 |
+| `SUB_PRESETS.search` | [] | 2 | serverTools:"always"（唯一每轮放行端点搜索的） |
+| `SUB_PRESETS.vision` | read_image、read_lore_image | 3 | 看图子代理 |
+| `SUB_PRESETS.longread` | read_file、search_text、list_files | 4 | 长文阅读子代理 |
+
+`maxRounds` 的取值经验（值得抄录的注释）：全量整理领域数据是「一个 list + 每实体一个 read，然后一轮 plan，才开始写」——轮数中途用尽在用户看来等于「agent 拒绝干活」。参考实现曾因此把 12 提到 20，并再补 onRoundLimit 卡片把硬停变成用户选择。**给 agentic preset 定上限时，按最重的真实任务的调用序列算一遍。**
+
+### 4.4 presetForTools：应用配置到 preset 的解耦映射
+
+```ts
+presetForTools(tools: "none" | "read" | "full"): TaskPreset | null
+```
+
+应用配置层（如按项目类型声明的工具档位）不直接依赖 agent 层类型，只声明档位字符串；由这个映射函数落到 preset 对象。**`"none"` 必须返回 null 而非空工具 preset**——null 是调用方「走简单流式路径、根本别进循环」的信号，两者语义不同。
+
+### 4.5 routeTools：每轮动态改写（概述）
+
+会话场景每轮以 `routeTools(basePreset, subAgents, workspace, models)` 生成**有效 preset 副本**：vision 子代理可用则从主模型剥掉读图工具；任一子代理可用且有工作区则追加 `delegate`；search 子代理可用则主模型自己的 serverTools 置 "off"。判定必须用「enabled + 绑定 + **能力核验**」（vision 必须 multimodal、search 必须带 web_search）——「已启用」≠「可用」；只看开关，绑错模型的 search 子代理会把主模型自己的搜索拿走，却什么都还不回来。详细路由规则与子代理体系见第 09 篇。
+
+---
+
+## 5. 事件系统
+
+参考实现：simple-ai-writer `src/lib/agent/events.ts` / `logModel.ts`。
+
+### 5.1 AgentEvent 全集
+
+```ts
+type AgentEvent = AgentEventScope & (
+  | { kind:"run-start"; task; modelName; agentic; at }      // 调用方发（只有它知道任务种类/展示名）
+  | { kind:"round-start"; round; maxRounds; estInputTokens; at }
+  | { kind:"tool-step"; step: ToolStep; at }                // 每次调用发两次：running → done/error
+  | { kind:"context-seeded"; documentName; recentChars; memoryChars; loreEntities; loreChars; at }
+  | { kind:"context-trimmed"; count; at }                   // trimHistory 抹了几条
+  | { kind:"context-compacted"; foldedTurns; fromTokens; toTokens; summary; at }
+  | { kind:"round-limit"; roundsUsed; decision; at }
+  | { kind:"reasoning"; round; text; done; elapsedMs?; at } // 同轮反复重发（流式增长）
+  | { kind:"turn-resumed"; round; leg; final; at }          // 端点分腿续传（一轮=多请求）可见化
+  | { kind:"output-truncated"; round; stopReason?; at }     // max_tokens 截断——最易误读的静默故障
+  | { kind:"run-done"; inputTokens; outputTokens; at }      // 调用方发
+  | { kind:"run-error"; message; at })                      // 调用方发
+```
+
+**所有权划分（规范）**：runtime 只发它才看得见的事件（round / tool-step / trim / reasoning / truncated / round-limit / turn-resumed）；启动运行的**调用方**负责包上 bracket 事件 run-start / run-done / run-error——任务种类、模型展示名、最终成本只有它知道。**非 agentic 的单发任务也要发 bracket 事件**——所有任务都进执行日志，不只 tool-using 的。
+
+reasoning 事件的计时细节（三个都是踩过的坑）：
+
+- 起点取**第一个 reasoning fragment 到达**而非轮开始——读完工具结果才思考的模型不应被记上等待时间；
+- `done` 在答案文本开始流出时翻转——否则散文都在流了，日志还显示「思考中」；
+- finally 里兜底翻转——工具轮没有散文、或半途失败，都不能让日志里永远留一行转圈。
+
+### 5.2 scope 机制：parentStep
+
+```ts
+type AgentEventScope = { parentStep?: string };
+```
+
+子代理（delegate）子运行的每个事件经 `ctx.onNestedEvent!({...e, parentStep: call.id})` 转发进父日志，`parentStep` = 那次 delegate 调用的 toolCallId。子代理结束时额外发一条**带 parentStep 的 `run-done`**——子代理花的是自己模型的钱，usage 统计按 parentStep 分桶（主运行 input/output vs 子代理 subInput/subOutput），不能混记。
+
+### 5.3 append 语义：原位替换
+
+```ts
+appendAgentEventTo(log: AgentEvent[], event: AgentEvent): AgentEvent[]
+```
+
+不可变追加，但两类事件**原位替换**而非追加新行：
+
+- `tool-step` 按 `(parentStep, toolCallId, name)` 匹配——running → done/error 是同一行的状态更新；
+- `reasoning` 按 `(parentStep, round)` 匹配——流式增长会重发无数次，日志只应显示一行。
+
+server-tool 日志行需要有状态工厂（query 随 call chunk 来、结果随 result chunk 来，中间用 Map 记住 query）——否则完成行只见结果不见问题。
+
+### 5.4 logModel：展示层折叠
+
+事件流是扁平时序（一次运行几十行对等事件），阅读需要的是三问分答：`summary + current`（一行现状）、`rounds: RoundGroup[]`（按 round-start 切段）、`subagents: SubAgentRun[]`（delegate 卡片 + 各自嵌套日志）。**规范：折叠逻辑做成纯函数（`buildLogModel(events, isRunning)`），同步、可脱离渲染器测试。**
+
+防坑细节（每条都对应真实故障）：
+
+- **`isRunning` 由调用方传入**（store 的活性标志），不能从「还没见到 run-done」推断——被关窗杀掉的运行没有终止事件，误读会让死轮永远转圈。
+- **delegate 参数用正则容错提取**而非 `JSON.parse`——日志层参数被 400 字符截断后 JSON 不完整。
+- 磁盘工作区文档（task.md）的重读信号数「已 settle」的 task_plan / task_progress 调用——计划本体在磁盘不在流里（参数会被截断，一份六步中文计划活不过 400 字符的截断线）。
+
+---
+
+## 6. 结构化输出在 agent 层的位置（简述）
+
+`runStructuredTask`（参考实现：simple-ai-writer `src/lib/agent/structured.ts`）是与 tool loop 并列的**单发**路径：主路径用强制 `tool_choice` 的伪工具拿结构（参数 schema 即输出 schema），失败时按**收紧过的能力错误判据**回退到「原生 JSON mode + prose 指令 + extractJsonObject」。三条与 runtime 相关的边界规范：
+
+- **单发是设计而非局限**：JSON mode / 强制 tool_choice 与自由工具循环在多家 provider 互斥。需要「调查 → 结构化产出」时，先跑 agent loop 收集材料，再把发现喂给 structured 调用（两段式）。
+- `serverTools` 显式置 undefined——结构化任务不上网；它作为模型级配置藏在 ConnOptions 里会搭车进来，不删掉的话强制 tool_choice 的请求会中途跑去 web 搜索。
+- 返回**未 parse 的 JSON 字符串**，schema 校验归调用方。
+
+回退判据、双路径完整细节见第 04 篇。
+
+---
+
+## 7. 本篇检查清单
+
+- [ ] runtime 内没有任何 `switch(toolName)`；工具执行全部经注册表分发，任务差异全部由 preset 数据表达。
+- [ ] `onOutputText` 是快照语义；工具轮结束时以 `committedText` 回滚，模型的过程性叙述不可能进入最终输出。
+- [ ] 唯一正常终止条件是「本轮无工具调用」；跑满上限的返回不丢 usage。
+- [ ] abort 到达在工具序列中间时，剩余 tool_call 全部补桩回复后才抛 AbortError；每个 tool call 前重查 `signal.aborted`。
+- [ ] 导出 `repairToolCallPairing`，且会话层在每次追加新轮之前调用它。
+- [ ] thinking 回传字段（`_reasoning` / `_thinkingBlocks` / thought signatures 等）随 assistant 消息存放，trim 时不丢失。
+- [ ] 一次性引导消息（强制成文提示、checkpoint 提示）在请求发出后 finally 中 splice 撤回。
+- [ ] trimHistory：图片无条件保最新 N 张；超限只替换旧 tool 结果的 content，消息壳保留；system 与种子永不触碰。
+- [ ] round limit 询问发生在轮首（强制成文之前）；`onRoundLimit` 可选，渲染不了卡片的界面不传、保持硬停。
+- [ ] 事件所有权正确：runtime 发轮内事件，调用方发 run-start / run-done / run-error；tool-step 与 reasoning 在日志中原位替换；子代理事件带 parentStep 且 usage 分桶。

--- a/docs/ai-agent-playbook/08-tool-registry-and-write-safety.md
+++ b/docs/ai-agent-playbook/08-tool-registry-and-write-safety.md
@@ -1,0 +1,283 @@
+# 08 · 工具注册、权限分级与写入安全
+
+> 本篇解决的问题：agent 拿到写盘能力的那一刻，「模型幻觉」就从答错话升级成数据事故。本篇规定工具体系的三根支柱：**注册表**（工具的定义、权限声明与执行器同址存放，白名单分发）、**三级权限**（只读 / 领域数据 L1 自动写 / 用户核心内容 L2 审批写）、**审批通道**（Promise 挂起 + 队列 + runId 作用域）。tool loop 本体见第 07 篇。
+>
+> 参考实现：simple-ai-writer `src/lib/agent/registry.ts` / `tools.ts` / `writeTools.ts` / `backup.ts` / `plan.ts`，及 `src/stores/agentStore.ts`。
+
+---
+
+## 1. 工具注册表
+
+### 1.1 结构
+
+```ts
+export type ToolAccess = "read" | "write-auto" | "write-approval";
+
+export interface RegisteredTool {
+  definition: ToolDefinition;      // OpenAI function schema：{type:"function", function:{name, description, parameters}}
+  access: ToolAccess;
+  execute: (call: ToolCall, ctx: ToolContext) => Promise<ToolResult>;
+  profileCategoryParams?: readonly string[];  // 需要在下发时按当前应用配置填 enum 的参数名
+}
+
+// ToolCall  = { id, name, arguments: string /* 原始 JSON */ }
+// ToolResult = { toolCallId, content: string, imageDataUrls?: string[] }
+
+const REGISTRY: Record<ToolId, RegisteredTool> = { … };
+```
+
+**规范：`ToolId` 必须是字面量联合类型**（参考实现是 28 个字面量的联合）。`Record<ToolId, RegisteredTool>` 使「加了工具名却漏了注册」成为**编译错误**，而不是运行时的 `Unknown tool`。
+
+### 1.2 ToolContext：执行器可用的全部钩子
+
+```ts
+export interface ToolContext {
+  projectPath: string;
+  loreIndex: LoreIndex;            // 领域数据索引——运行开始时的快照（陷阱见 §3.4）
+  multimodal: boolean;             // 当前模型能否收图（控制图片类载荷）
+  onLoreChanged?: () => void;      // L1 写完通知应用重扫（更新 UI，不更新本 ctx 的快照）
+  onMemoryChanged?: () => void;
+  requestApproval?: (proposal: Proposal) => Promise<ApprovalDecision>;   // L2 阻塞通道；缺席 → 工具报错
+  requestPlanApproval?: (plan: LorePlan) => Promise<PlanDecision>;       // 方案门控通道
+  lorePlan?: PlanGate;             // 本次运行的已批方案记录
+  taskWorkspace?: TaskWorkspaceHandle;   // 磁盘工作区句柄（惰性 ensure）
+  signal?: AbortSignal;            // 嵌套运行（delegate）必须共享同一 signal
+  onNestedEvent?: (event: AgentEvent) => void;   // 子代理事件转发（带 parentStep）
+  resolveSubAgent?: (kind) => Promise<AiConn | { error: string }>;  // 由调用方注入，避免 lib→store 反向依赖
+}
+```
+
+**设计准则：能力以「通道在不在」表达。**没有 `requestApproval` 的界面（批量运行、无审批区的 modal），L2 工具直接返回形如 `"Error: this surface cannot review manuscript changes — do not call propose_edit here."` 的文本——同一份注册表在不同界面**自动降级**，无需按界面维护 preset 变体。方案门控同理：`requestPlanApproval` 或 `lorePlan` 缺任何一个，领域写工具**拒绝而非无门放行**。`resolveSubAgent` 由 store 注入而非在 lib 里 import store——打破循环依赖的标准手法。
+
+### 1.3 分发与错误处理
+
+```ts
+export async function executeRegisteredTool(call, allowed, ctx): Promise<ToolResult> {
+  const isAllowed = (name): name is ToolId => (allowed as readonly string[]).includes(name);
+  const tool = isAllowed(call.name) ? REGISTRY[call.name] : undefined;
+  if (!tool) return { toolCallId: call.id, content: `Unknown tool: ${call.name}` };
+  try { return await tool.execute(call, ctx); }
+  catch (e) { return { toolCallId: call.id, content: `Error: ${String(e)}` }; }
+}
+```
+
+三条规范：
+
+1. **白名单是类型收窄（type guard），不是断言。**模型给出的 name 是任意字符串；写成双重 cast 会把 `undefined` 当 `RegisteredTool` 使用。
+2. **永不 throw。**任何执行错误捕获后转成 `Error: ...` 文本结果回给模型；runtime 以 `content.startsWith("Error") || startsWith("Unknown tool")` 判定日志行状态。坏调用是模型可纠正的信息，不是运行的死刑。
+3. **错误文案必须写成下一步动作指引。**如「Re-read the file and copy the target text exactly」「Call list_lore_entities first」。光拒绝不指路，模型会原样重试同一个坏调用（参考实现 plan.ts 的注释明确记载了这一点）。
+
+结果截断的分层：**日志层**截断（argumentSummary 保持合法 JSON 头以便提取标识参数；resultSummary 截头部若干字符）；**给模型的 content** 由各工具自己限幅（如 read_file 每次 4000 字符、search 40 行封顶）。两层各管各的，不要用日志截断值去喂模型。
+
+### 1.4 应用配置参数的下发时拷贝注入
+
+陷阱：REGISTRY 是模块级常量，import 时求值一次；而某些参数的合法值（如领域数据的分类枚举）由**当前应用配置**决定。把它们烤进定义，就冻结在最先加载的配置上——上一个项目的分类会留给下一个项目。
+
+规范：schema 里 enum 留空（`enum: []`），描述里放 `{{categories}}` 占位符；`getToolDefinitions` 每次下发时**拷贝**定义（绝不 mutate 共享常量）并按当前配置补齐 enum 与描述。**描述文字里的枚举和 enum 字段一样重要**——描述写着 "characters, world…" 会引导模型请求实际不存在的分类。
+
+---
+
+## 2. 工具清单（分组规范样例）
+
+以下为参考实现的完整清单，作为「一套成熟工具集长什么样」的样板。关键实现点列是规范的一部分——每条都对应一次事故或一个安全边界。
+
+### 2.1 只读（read）
+
+| 工具 | 关键实现点 |
+|---|---|
+| `list_lore_entities` | 直接 format ctx 快照：`[category]` + `- name: summary` |
+| `read_lore_entity` | 条目全文 + 全部子文件；**图库只给文件名 + 文字描述，绝不附图**（历史事故：一次 5 图 ~35MB 请求超时）；multimodal 与否只改提示语 |
+| `read_lore_image` | 按需取**一张**图为 dataUrl（走 imageDataUrls 通道）；text-only 模型直接报错；超单图字节上限拒绝 |
+| `read_image` | 项目内任意图片；包含校验对**项目根**（图片泄密面小，收窄反而破坏正常用例）；**`projectPath === ""` 直接拒绝——空前缀包含一切绝对路径**；尝试原样与 percent-decode 两种拼写 |
+| `list_files` | 递归列用户内容目录，`ls -R` 式分组输出（几百个文件不重复长前缀，省数千 token）；上限 300 条并提示分页；folder 参数过 `isPathWithin` 防 `../` |
+| `read_file` | 4000 字符/次、**按行边界切**、回报 `lines a-b of N` 与下一个 start_line；行号坐标与 search_text 输出直接衔接；限定用户内容目录（被 prompt 注入的模型不能借它读配置或领域数据源文件） |
+| `search_text` | 字面匹配、大小写不敏感、**明确不支持正则**（模型给的病态正则会卡死 UI 线程且无法中断）；全局 40 命中 / 单文件 8 命中封顶；长行按命中位置开窗 |
+| `read_memory` | 滚动记忆分段索引（segment i: chars from–to + summary），update_memory 的前置 |
+| `read_note` / `list_notes` | 工作区笔记读取/列表，行分页同 read_file 风格 |
+
+**只读工具三铁律：模型可控的路径参数一律做包含校验（`isPathWithin` 式前缀测试，注意空前缀陷阱）；输出限幅 + 分页；错误写成指引。**
+
+### 2.2 L1 自动写（write-auto）
+
+`create_lore_entity`、`update_lore_file`、`update_facet_meta`、`delete_lore_file`、`move_lore_entity`、`delete_lore_entity`、`update_memory`、`task_plan`、`task_progress`、`write_note`。
+
+即：**领域数据**（结构化的辅助知识，如设定条目）、**滚动记忆**、**scratchpad 三件套**（task_plan / task_progress / write_note——agent 私有草稿，无备份无门控）。详见 §3。
+
+### 2.3 L2 审批写（write-approval）
+
+`propose_lore_plan`、`propose_edit`、`create_chapter`、`move_chapter`、`delete_chapter`、`generate_image`、`edit_image`。
+
+即：**用户核心内容**（正文文档）的内容与结构操作、**花钱的操作**（图片生成）。详见 §3.5–§3.6。
+
+**特殊：**`delegate`（access: "read"）——分派子代理，本身不写任何东西，见第 09 篇。
+
+---
+
+## 3. 写入安全体系
+
+### 3.1 三级权限的实际语义
+
+| 级别 | 适用对象 | 机制 |
+|---|---|---|
+| **L0 read** | 只读工具 | 路径包含校验 + 输出限幅，无写入 |
+| **L1 write-auto** | 领域数据 / 记忆 / scratchpad | 立即落盘；**写前自动备份**；落盘前结构校验；领域数据类**另加方案门控**；写后回调（onLoreChanged 等）刷新 UI |
+| **L2 write-approval** | 用户核心内容的结构与内容、图片生成 | 只产生 Proposal，Promise 阻塞在用户卡片上；批准后由**审批方**应用（先备份）；拒绝理由原文回模型 |
+
+**为什么用户核心内容是 L2 而领域数据是 L1**（划线原则，按你的领域重演这个判断）：用户对核心内容（正文）的所有权感远强于辅助数据（设定），删一章的破坏性远大于改一个设定文件。且 L2 结构操作**不设方案门**——每操作一张卡，大改结构就是好几张卡，换来的是每步可见、可单独拒绝；「用户真觉得烦了再加门，比加了门再拆容易」。
+
+### 3.2 备份：「备份失败 = 写入失败」
+
+参考实现：simple-ai-writer `src/lib/agent/backup.ts`。
+
+```ts
+export async function backupFile(projectPath: string, absPath: string): Promise<string | null>
+```
+
+- 源不存在返回 null（新建文件无需备份）；**读/写失败直接 throw——调用方必须把失败的备份当失败的写入，绝不能照写。**所有 L1 工具都是「先 backup 再 write」的顺序，throw 会被注册表兜住变成模型可见错误，写入根本不会发生。
+- 备份目录：单一**扁平**目录（如 `.ai-writer/backups/`），一个地方装所有可恢复物。命名：`agent-<epoch毫秒>-<相对路径打平（/ → -）>`——打平让目录一眼可读，不复刻源目录树。
+- 文本用 read + write 复制。**二进制救不了**——所以删除整个含二进制资产的实体时不用 backupFile，而是**整个目录 `rename` 进备份区**（如 `backups/deleted-<ts>-<category>-<id>`）：二进制一并保住，一次 rename 也不存在半删除状态。删除用户核心文档同理：批准后移入备份区而非 unlink。
+- 删除类工具的细节：备份返回 null（源不存在）时**报错而不是静默成功**——备份就是删除操作的恢复路径；让模型报告一个用户永远无法检查的删除是不可接受的。
+
+### 3.3 L1 落盘前的结构校验
+
+原则：**坏载荷在落盘前拦下，转成模型可读的错误**；静默接受再让下游扫描器还原/丢弃，等于数据丢失。参考实现的契约清单（`writeTools.ts` 头注释）：
+
+- 写条目主文件：必须有可解析 frontmatter 且含 `name`；**禁改 category**——目录位置才是扫描器信任的真相，只改 frontmatter 下次重扫会被还原，换分类只能走 move 工具。
+- 现为结构化子文件（facet）的文件必须写完仍是合法结构（parse 通过），否则拒绝。
+- 应用托管的特殊文件（如图库清单）拒写；文件名参数一律 `/^[^/\\]+\.md$/ && !includes("..")`——模型可控参数不允许任何路径导航。
+- 元数据工具只重写 frontmatter，body 经 parse **原样带过**——「说好只改关键词，顺手把正文改写了」的漂移风险从机制上消除；未传字段保持原值；配置成「永远不会生效」的组合要在成功结果里明确警告。
+- 该类工具**从磁盘读当前状态而非运行快照**——同一次运行里刚创建的文件不在快照里（快照陷阱见 §3.4）。
+- 滚动记忆只能走既有的分段重写协议（段范围/哈希不可破坏，只换摘要文本）。
+
+### 3.4 运行快照 vs 磁盘现实（陷阱）
+
+`ctx.loreIndex` 是运行开始时的快照。三个后果与对策：
+
+- move/delete 成功后，同一运行的下一个调用会解析到已不存在的路径 → 工具成功后**手工修正快照**（`relocateInSnapshot` 式；`onLoreChanged` 触发的应用侧重扫到不了这个 ctx 对象）。
+- 本轮刚创建的子文件不在快照里 → 细粒度工具改为**从磁盘读当前状态**，写完再回填/剔除快照条目。
+- 对话场景每轮重建 toolContext 时，快照取应用 store 的**最新**索引——轮 N 写的数据轮 N+1 必须可见。
+
+### 3.5 方案门控：审批提前到「方案」层
+
+参考实现：simple-ai-writer `src/lib/agent/plan.ts` + `propose_lore_plan` 工具。
+
+问题：领域数据写如果升到 L2，批量整理十个条目就要弹十次卡。解法：**一张卡审一份方案，之后的 L1 写入必须逐条对得上方案。**
+
+```ts
+interface LorePlanStep { action: "create" | "update" | "move" | "delete"; entity: string; file?: string; detail: string; }
+interface PlanGate { steps: LorePlanStep[]; fulfilled: Set<number>; asked: boolean; }
+```
+
+机制全貌：
+
+- **`propose_lore_plan`（write-approval）**：校验每步（action 合法、entity/detail 非空——**detail 是用户据以决策的文本，必须具体**），`await ctx.requestPlanApproval(plan)` 阻塞。拒绝 → 拒绝理由 + 「不许在此期间写任何领域数据」回模型。批准 → 步骤**追加**进 `ctx.lorePlan.steps`——**不是替换**：运行中批的第二份方案不能悄悄撤销用户已签的第一份；返回文本里附「先前尚未兑现的步骤」清单以免被遗忘。
+- **每个 L1 领域写工具落盘前过 `checkPlan(gate, index, action, entity, file)`**：
+  - gate 不存在 → 「此界面无法审方案，报告你想改什么即可」；
+  - steps 为空 → 「先 propose_lore_plan」；若 `asked === true` 追加「上一份未获批，修改后重提」；
+  - 找覆盖步骤：action 相同 + `sameEntity`——**实体名经索引解析后比对**（方案写 "Ava"、写入用别名 "阿瓦" 不能误拒；create 尚无落盘实体，退回小写字符串比对）+ **file 规则：步骤声明了 file 就钉死那个 file；未声明则该实体下任意文件放行；file-scoped 步骤绝不放行无 file 的调用。**
+  - 命中 → `fulfilled.add(idx)`，返回步骤；未命中 → 错误文本附**已批步骤全清单** + 「要改就重提方案」。
+- **门控按运行/按轮存活**：会话场景每轮 `lorePlan: createPlanGate()` 新建——这一轮批的方案不悄悄授权下一轮。
+- 门控能核验「哪个实体、哪个文件、什么动作」，核验不了措辞——所以命中步骤的 `detail` 回写进工具成功结果（`Plan step: ${step.detail}`），用户在执行日志里能把「说要改什么」与「实际改了什么」并排看。
+- **门控时机在结构校验之后**（"Gated last"）：写入真的会发生，步骤才算兑现——被校验拦下的调用不该消耗方案额度。
+
+陷阱（真实越权洞）：文件匹配曾写成 `!s.file || !file || 同名`——步骤「delete Ava / armor.md」（删一个子文件）能授权删掉整个 Ava 实体（调用不带 file 时误命中）。修正即上面的黑体规则：**步骤声明了 file，调用就必须给出同一个 file**；删单个子文件与删整个条目从此是两条互不越权的步骤，审批卡上分别显示。
+
+### 3.6 L2 propose_edit 全链路（同步阻塞审批的标准样板)
+
+**工具侧**（参考实现：`writeTools.ts` 的 proposeEditTool）：
+
+1. 校验 path 在用户内容目录内、find/replace 是字符串、`ctx.requestApproval` 存在。
+2. **提案前预检**：读文件数 `find` 出现次数——0 次 → 「重读文件并精确复制目标文本」；>1 次 → 「加长上下文使其唯一」。保证卡片上的提案**至少在此刻可应用**。
+3. `const decision = await ctx.requestApproval({ kind:"edit", id:`edit-${++counter}`, path, find, replace, reason })` ——**tool loop 在此挂起**。
+4. 拒绝 → `The user REJECTED this edit — reason: …. Do not retry the same change; adjust per the reason or move on.`；批准 → `Edit approved and applied. Previous version backed up to <path>.`
+
+**审批侧**（参考实现：`src/stores/agentStore.ts` 的 approve → applyEdit）：
+
+- 先 `backupFile`。
+- **apply 时重新定位 find，不信提案时刻的位置**——卡片挂着的时候用户可能一直在编辑。定位规则：`indexOf < 0` → throw「Document changed — the target text no longer matches.」；`indexOf !== lastIndexOf` → throw「appears more than once — too ambiguous to apply automatically.」（草稿里重复行很平常，取第一个命中会改写用户从未批准的文字）。
+- **活动文档走编辑器 buffer**（编辑器 store 的 setContent）——保住未保存内容、改动立即可见并触发自动保存；非活动文档才直接读盘/写盘。
+- **`applyProposal` 的任何 throw 都被 approve 捕获并 `resolve({ approved:false, reason:`apply failed: ${e}` })`**——失败以拒绝形式回到模型，模型知道内容未动；绝不吞错报成功。
+
+其余 L2 工具的预检同样前置：create 类归一化扩展名并拒绝已存在路径；move 类源必须存在、目标不得存在（rename 永不覆盖）、拒绝移入自己的子树；delete 类**强制要 reason**（「用户只凭这一行做决定」）、**拒绝目录**（删除整个目录的爆炸半径应当是用户自己在 UI 里做的决定，不该运行中一张卡批掉）。多个 L2 工具共享一个入口函数（`manuscriptTarget()` 式）统一做 path 校验 + 审批通道存在性检查。
+
+---
+
+## 4. Proposal 判别联合与 ApprovalDecision
+
+```ts
+export type Proposal = EditProposal | CreateProposal | MoveProposal
+                     | DeleteProposal | IllustrateProposal;
+// 共同基底：{ id, path, reason? }
+// edit:   { kind:"edit", find, replace }          — find 必须在文件中恰好出现一次
+// create: { kind:"create", content }
+// move:   { kind:"move", newPath, isDir }
+// delete: { kind:"delete", chars }                — 提案时的字符数，卡片展示「删多少」
+// illustrate: { kind:"illustrate", prompt, destination, dest, note,
+//               modelId, modelName, costUsd, aspect?, sourcePath? }  — 唯一花钱的 kind
+
+export type ApprovalDecision =
+  | { approved: true; backupPath?: string | null }
+  | { approved: false; reason?: string };
+```
+
+两条规范：
+
+- **按 kind 打标签，不用一个宽对象。**审批卡渲染与落盘 switch 都靠判别收窄；TS 穷尽检查保证「加了 kind 却漏了卡片 body 或落盘分支」是**编译错误**。
+- **花钱的提案把价签带在身上**：`illustrate` 携带模型名/单价/预估费用——卡片必须展示「批准 = 花这笔钱」，且生成发生在**批准之后**（拒绝零成本）。
+
+---
+
+## 5. 审批队列与会话 store
+
+参考实现：simple-ai-writer `src/stores/agentStore.ts`。
+
+### 5.1 三条队列 + runId 作用域
+
+```ts
+pending: PendingApproval[]               // { proposal, resolve, runId, turnId?, signal? }
+pendingPlans: PendingPlan[]              // { plan, resolve, runId }
+pendingRoundLimits: PendingRoundLimit[]  // { id, roundsUsed, extension, canPause, resolve, runId }
+```
+
+- **入队模式统一**：`requestApproval / requestPlanApproval / requestRoundExtension` 都是 `new Promise(resolve => set(入队 {…, resolve, runId}))` ——**resolve 函数就存在队列元素里**。UI 卡片按队列渲染；用户点击时找到元素、出队、调用 resolve，被阻塞的 tool loop 就地恢复。
+- **RunId = 每次运行自己的 AbortController 对象**（`type RunId = unknown`，store 只做 `===` 比对）。为什么必须有作用域：面板任务和对话轮可以**同时**各有 pending 卡片，一个结束时的清扫不能误杀另一个的。
+- **不变量：`rejectAll(reason, runId)` 在每次运行的 finally 和 stop 里都必须调用。**按 runId 过滤三条队列并全部 resolve（approval/plan → `{approved:false, reason}`；roundLimit → `{action:"finish"}`，紧接着 runtime 会重查 aborted 信号）。悬挂的 Promise 会永久卡死后续运行——这是队列体系的头号生存法则。
+- **`turnId` / `signal` 在请求审批时显式绑定进队列元素**，不能在 apply 完成时用「当前轮是谁」推断。陷阱（真实事故）：批准生成图片后用户按停止，图画完了却丢了——批准瞬时、生成漫长，apply 可以活得比 run 长；停止早已清掉了「当前轮」标识，靠身份比对把用户已付费的产物丢掉了。`signal` 同理随绑定传入，让「已批准但很慢的 apply」可被取消。
+
+### 5.2 chatHistory 与 turns 双层结构
+
+- **`chatHistory: StreamMessage[]`（wire 层）**：与 runtime 原地 mutate 的是**同一个数组**。轮 N 的工具调用与结果留在上下文里供轮 N+1 指代（「把刚才那条也改了」）——这是真会话与重复单发的分水岭。
+- **`turns: ChatTurn[]`（展示层）**：`{ id, role, text, log: AgentEvent[], at, quote?, images? }`。每个 assistant 轮内嵌自己的执行日志；`text` 由 onOutputText 快照赋值（工具轮撤回叙述才成为可能）；`images` 由**审批方**以 turnId 填入——模型对「应用已把图放进转录」一无所知，靠模型自述会产出「抱歉我无法展示图片」。
+- **分层理由（规范）**：wire 数组要满足协议（tool_call 配对、顺序、压缩折叠），展示层要满足阅读（每轮日志、引用块、displayText 替身——resume 时发给模型的是整份任务文档，屏幕上只显示一行「继续任务 X」）。两者形状需求根本不同，硬用一个结构必然两头受伤。
+- **`chatMeta` 全部按消息对象身份记录，不用索引**：哪条是种子上下文、哪条是滚动摘要、每轮从哪条 user 消息开始、注入台账（条目 → {version, carrier 消息对象}）。原因：`repairToolCallPairing` 会 splice（索引位移），trimHistory 只换 content（对象身份存活）——索引在这套体系里没有稳定语义。
+- 配套细节：history 被原地 push 时数组引用不变，响应式 selector 看不见变化——凡历史构成变化的点都要 bump 一个版本号（`chatContextVersion`）。会话持久化每轮 finally 里 best-effort 执行（「丢会话的崩溃从不提前打招呼」），**序列化时剥离全部图片 base64**（路径留在转录里，可再读取）；持久化失败只降级为「不能跨重启」，绝不弄坏进行中的对话。
+
+### 5.3 sendChat 一轮的完整时序
+
+1. 解析模型/供应商/密钥；**一次性原子读取**当前文档焦点，整轮持有（不在轮中反复读取——用户可能正在编辑）。
+2. 组装本轮 wire 消息（引用段 + @引用素材前置；附图由模型 multimodal 能力与 vision 子代理可用性共同决定）。
+3. **首轮**：RAG 组装 → 产出**三条消息**（system / 种子上下文 / 问题——分开是为了日后压缩能只丢种子不丢问题）；建 meta、记轮起点、把种子携带的领域条目记入注入台账（否则轮 2 检索会重复注入刚给过的东西）；发 `context-seeded` 事件。**agent 行为指令拼进 system 层**而非首轮 user 层——陷阱：拼在首轮 user 里，轮 2 起只追加裸 user 消息，指令活不过第一轮，助手退化成「只给方案不动手」。
+4. **后续轮**：`repairToolCallPairing` → 超过触发线则轮间 compaction（best-effort，失败继续用未压缩历史）→ per-turn 注入（重跑检索，减去台账里已在场且未变的条目）→ push 问题消息。
+5. `routeTools` 生成有效 preset → `runAgent({ …, toolContext: { loreIndex: 最新索引, lorePlan: createPlanGate()（每轮新门）, taskWorkspace: 会话级句柄, requestApproval / requestPlanApproval → store 队列, … }, onRoundLimit → 队列, onEvent → patch 本轮 log + bump 版本号, onOutputText → patch 本轮 text })`。
+6. `outcome === "paused"` → 标记任务暂停 + 记录来源文档 hash（resume 时校验引用新鲜度）。
+7. 记账（usage 累计、run-done 事件、持久化用量）。
+8. **finally：`rejectAll("task ended", controller)`（只清本轮的）→ 清 running 态 → 持久化会话。**
+
+`resumeTask` 概述：**不回放旧对话**——读任务文档 + 笔记索引 + 来源引用哈希比对（改过/删了/读不了逐条标注），拼成一条干净的 user 指令重新开轮；展示层只显示一行「继续任务 X」（displayText 替身）。
+
+---
+
+## 6. 本篇检查清单
+
+- [ ] `ToolId` 是字面量联合，`REGISTRY: Record<ToolId, RegisteredTool>` 使漏注册成为编译错误；定义、access、执行器 collocate 在注册表一处。
+- [ ] `executeRegisteredTool`：白名单用类型收窄（type guard）而非 cast；永不 throw；错误文案写成下一步动作指引。
+- [ ] 需要按运行时配置变化的 schema 参数（enum 等）在 `getToolDefinitions` 下发时**拷贝后**注入，绝不 mutate 模块级常量；描述文字与 enum 同步。
+- [ ] 模型可控的路径参数全部过包含校验；`projectPath === ""` 显式拒绝（空前缀包含一切绝对路径）；文件名参数禁 `/`、`\`、`..`。
+- [ ] 界面能力以 ToolContext 通道的在/不在表达：无 `requestApproval` 的界面 L2 工具自动拒绝；无方案通道或无 gate 的界面领域写工具拒绝。
+- [ ] 所有 L1 写工具遵循「参数校验 → 结构校验 → 门控 → backup → write → 修快照 → 变更回调 → 带备份路径的成功回执」顺序；**备份 throw 时写入不发生**。
+- [ ] 含二进制资产的删除走整目录 rename 进备份区，不走文本复制；删除操作在备份缺席时报错而非静默成功。
+- [ ] 方案门控：批准是**追加**不是替换；file-scoped 步骤绝不放行无 file 的调用；实体名经索引解析比对；gate 按运行/按轮新建。
+- [ ] L2 propose_edit：提案前预检唯一性；apply 时重新定位（不见了/多于一处都转拒绝）；活动文档走编辑器 buffer；apply 失败以 `{approved:false, reason}` 回模型，绝不吞错报成功。
+- [ ] Proposal 是按 kind 的判别联合，穷尽检查覆盖卡片与落盘分支；花钱的 kind 把模型名与预估费用带在提案上，生成发生在批准之后。
+- [ ] 三条审批队列的元素内嵌 resolve；runId = 本次运行的 AbortController；**每次运行 finally 必调 `rejectAll(reason, runId)`**；产物归属的 turnId/signal 在请求审批时绑定。
+- [ ] wire 历史与展示层 turns 分层；meta 按消息对象身份记录（不用索引）；序列化剥离图片 base64；持久化 best-effort、失败不破坏会话。

--- a/docs/ai-agent-playbook/09-subagent.md
+++ b/docs/ai-agent-playbook/09-subagent.md
@@ -1,0 +1,385 @@
+# 09 · 子代理机制（Delegation / Sub-agent）
+
+> 本篇解决的问题：当 agent 需要联网搜索、读图、通读长文档这类**上下文密集**或**能力特定**的工作时，如何把它交给独立模型上的子代理去做，而不让原始材料（网页正文、图片 base64、长文切片）灌爆主模型的上下文。本篇给出 delegate 工具的完整契约、子代理的配置模型、确定性的能力路由规则，以及执行层的沙箱与记账规范。前置阅读：`10-context-management.md`（任务工作区）——**没有工作区，子代理机制不成立**。
+
+参考实现：simple-ai-writer `src/lib/agent/subagent.ts`、`routing.ts`、`registry.ts`、`presets.ts`。
+
+---
+
+## 1. 动机与总体设计
+
+### 1.1 四个现象，一个根因
+
+引入子代理之前，应当先确认你面对的是同一类病。典型观测（来自参考实现接入服务端 `web_search` 后的真实数据）：
+
+- 一次带搜索的任务 8 次搜索 / **123k input token**——网页正文、图片 base64、长文切片全部灌进主模型上下文；
+- 历史裁剪（trimHistory）为避免超窗把旧工具结果替换成 `[earlier tool result dropped…]`（破坏性裁剪），模型丢失中间结论后**再搜一遍**，又填满；
+- 撞 `maxRounds` 只有「继续加轮 / 强制收尾」两个出口，无法存档；
+- 重跑时历史里作者的 `continue`、`重试` 被当成新指令，agent 自我强化地继续。
+
+**根因只有一个：runtime 只有一种记忆——wire history。** 它落不了盘、挑不出重点，满了只能删（破坏性）或压（只服务轮间摘要）。子代理机制不是「多智能体框架」，而是给 runtime 补第二种记忆（落盘的 note）之后的自然延伸。
+
+### 1.2 四条设计目标
+
+1. **记忆落盘**——任务工作区（如 `.ai-writer/tasks/<taskId>/`），见 `10-context-management.md`；
+2. **状态化断点续跑**——恢复「任务状态」而非「对话记录」；
+3. **单层单向委托**——一个 `delegate` 工具，子代理独立模型 + 独立上下文，主模型只收「摘要 + 路径」；
+4. **确定性能力路由**——在**工具集层**而非提示词层做能力隔离。
+
+### 1.3 架构判断：「工作区是总线，子代理是设备」
+
+这是整套设计的核心判断（参考实现 HLD §2 原话）：子代理的产出**不整块塞回主上下文**——那只是把堆叠换个地方堆——而是落盘成 note，回给主模型「一段摘要 + 一个路径」。没有工作区，子代理只会把今天的问题复制到主 agent 身上。
+
+由此推出一条硬规则：**没有工作区的 surface 根本拿不到 `delegate` 工具**（由路由层落实，见 §4）。
+
+整套体系一句话概括：
+
+> **「记忆落盘 + 单层单向委托 + 工具集级能力路由 + 轮间折叠压缩」，四件事各管一段，互不越界。**
+
+---
+
+## 2. `delegate` 工具契约
+
+### 2.1 工具定义与 JSON schema
+
+工具名应当是 **`delegate`**（而非 spawn_subagent 之类），访问级别 `access: "read"`——它本身不写作者的任何东西，子代理只写自己的 notes。注册表定义（参考实现 `registry.ts` 原文）：
+
+```ts
+delegate: {
+  access: "read",
+  definition: { type: "function", function: {
+    name: "delegate",
+    description:
+      "Hand a context-heavy or capability-specific job to a specialist subagent " +
+      "running on its own model. The subagent works in a separate context, writes " +
+      "its full findings to a note file, and returns only a short summary plus the " +
+      "note path — so its raw material never enters this conversation. Use it for " +
+      "web research, reading images, and digesting long documents.",
+    parameters: {
+      type: "object",
+      properties: {
+        kind: { type: "string", enum: ["search", "vision", "longread"],
+          description: "search — look things up on the web; vision — describe or analyse images; longread — read long documents and report what matters." },
+        task: { type: "string",
+          description: "A complete, self-contained instruction. The subagent cannot see this conversation, so state everything it needs to know." },
+        refs: { type: "array", items: { type: "string" },
+          description: "Paths the subagent should work on (documents or images)." },
+      },
+      required: ["kind", "task"],
+    },
+  }},
+  execute: executeDelegate,
+},
+```
+
+三个值得照抄的细节：
+
+1. **`task` 的 description 直接教模型写法**——「子代理看不到这段对话，把它需要知道的都写进来」。任务传递就靠这一段文本，没有任何隐式上下文继承。
+2. **工具描述用领域中性词汇**——参考实现刻意用 `documents` 而不是「章节」：工具描述对所有 workspace profile 通用（跑团/文案项目不该读到小说词汇）。你的项目同理：工具描述不应泄漏某一种业务的词表。
+3. **`refs` 是路径数组**，是主模型「点名材料」的唯一通道（文档或图片路径）。
+
+### 2.2 任务下发：两条消息，零上下文渗透
+
+子代理拿到的应当是**现场构造的两条消息**，不继承主会话任何内容：
+
+```ts
+const messages: StreamMessage[] = [
+  { role: "system", content: i18n.t(`ai.instructions.subagent.${kind}`) },
+  { role: "user", content: refs.length
+      ? i18n.t("ai.instructions.subagentTaskWithRefs", { task, refs: refs.map(r => `- ${r}`).join("\n") })
+      : i18n.t("ai.instructions.subagentTask", { task }) },
+];
+```
+
+**不变量：有 refs / 无 refs 必须是两个模板键，不是一个键插空串。** 原因：带 refs 的模板自带「参考资源」小节标题，复用它插空串等于给子代理一条「去查这些来源」的指令而来源不存在。i18n 的 `defaultValue` 分叉也不行——键存在时 defaultValue 根本不会被采用。（参考实现 `delegateShape.test.ts` 对此有回归测试。）
+
+### 2.3 产出捕获：只能经 `onOutputText` 回调
+
+**陷阱：事后翻 `messages` 找最后一条 assistant 文本必然拿到空。** 可重入 runtime 的常见实现是成文轮直接 return，最终文本从不进 history（参考实现 `runtime.ts` 469-477 行）。所以子代理产出必须经 `onOutputText` 回调捕获（`output = text`，**累积快照赋值而非拼接**）。
+
+### 2.4 返回契约：落盘 note + 摘要 + read_note 指针
+
+成功路径应当是：
+
+1. 产出落盘：`writeTaskNote(projectPath, taskId, { slug, title, content: output, sources: refs })`。
+   - slug 只取指令前 **20 个码点**（`SLUG_HINT_CHARS`，如 `` `${kind}-${[...task].slice(0, 20).join("")}` ``）——「文件名是文件名，完整指令留在 note 首行标题里」；
+   - title 取 `task.slice(0, 80)`。
+2. 回给主模型的 tool result（content 是纯文本）：
+
+```
+The ${kind} subagent finished. Full findings saved to: ${note.path}
+Call read_note with that path when you need the detail.
+
+Summary:
+${clip(output, 800)}    // DELEGATE_SUMMARY_CHARS = 800
+```
+
+800 字符这个数的判据（参考实现注释原话）：「够判断『要不要展开读』，不够顺手替代读 note」——逼主模型在需要细节时走 `read_note` **分页**读，而不是把子代理原始产出全量吞回上下文。
+
+3. **空产出**（`!output.trim()`）直接返回 `Error: the ${kind} subagent returned nothing. Try a narrower task, or do it yourself.`，**不建 note**——不写空文件。
+
+### 2.5 错误与中止
+
+- 失败路径一律返回 `Error: ...` 前缀的 tool result——模型可读、可自纠；
+- **唯一例外：`AbortError` 必须重抛**，不得转成 tool error。转成 tool error 会让主模型把作者按的「停止」读成「搜索失败」并重试，作者的停止键失效。
+
+### 2.6 记账：独立 usage 行 + 带 `parentStep` 的嵌套事件
+
+- 每次子跑写**一行独立的 token_usage**：`persistUsage(projectPath, conn.model.id, in, out, cost, \`subagent:${kind}\`, cached)`——`model_id` 是**子代理的**模型；task 字段打 `subagent:search` 这类标签，用量面板可按 `task LIKE 'subagent:%'` 聚合。
+- 除 DB 行外，执行器还应当**手动发一条带 `parentStep` 的嵌套 `run-done` 事件**：`ctx.onNestedEvent({ kind: "run-done", inputTokens, outputTokens, parentStep: call.id, at })`。理由：DB 是永久账本但要打开设置页才看得见，而委托恰恰是作者**当下**要拍板花不花钱的那一步；`parentStep` 同时把这条事件排除在主 run 自身的 token 汇总之外（主 run 汇总只算主模型）。
+- 记账工具函数应当放在 lib 层（如 `lib/ai/usage.ts`），**lib 层不反向 import store**。
+- 解析连接就失败的 delegate **不发 run-done**——没花钱就不报花钱。
+
+---
+
+## 3. 子代理的配置与种类
+
+### 3.1 数据模型
+
+```ts
+export type SubAgentKind = "search" | "vision" | "longread";
+export const SUBAGENT_KINDS: readonly SubAgentKind[] = ["search", "vision", "longread"];
+
+export interface SubAgentConfig {
+  kind: SubAgentKind;
+  modelId: string | null;   // Model.id（配置行主键），null = 未绑定
+  enabled: boolean;
+}
+```
+
+**设计准则：内置种类，不做任意自定义。** 每个 kind 决定三件事——preset（工具集 + 轮数）、输入形状、产出形状——「它们是代码而不是配置」。用户能配的只有「这个种类用哪个模型、开不开」。**没有自定义 system prompt**：子代理的 system prompt 是代码资产（i18n 键 `ai.instructions.subagent.{kind}`）。
+
+### 3.2 每个 kind 的 preset（`SUB_PRESETS`）
+
+| kind | 定位 | tools | maxRounds | serverTools | 产出 note |
+|---|---|---|---|---|---|
+| `search` | 联网检索查证 | `[]`（无本地工具，搜索发生在端点内部） | **2** | `"always"` | `notes/search-*.md`（要求带原始 URL） |
+| `vision` | 图像理解 | `["read_image", "read_lore_image"]` | **3** | `"off"` | `notes/vision-*.md` |
+| `longread` | 长文精读提要 | `["read_file", "search_text", "list_files"]` | **4** | `"off"` | `notes/read-*.md` |
+
+三者一律 `finishPolicy: "force-text"`——子代理必须以文本收尾，那段文本就是产出。
+
+**陷阱：`serverTools` 必须是独立于「收尾轮撤工具」的概念。** 若 runtime 用 `preset.tools.length === 0 || 收尾轮` 一并撤掉服务端工具，则本地工具恒为空的 search 子代理**永远不联网**。应当把「没有本地工具」和「该收尾了」拆成两个概念：`TaskPreset.serverTools: "final-round-off"(默认) | "off" | "always"`，search 用 `always`。默认值使既有 preset 行为逐字不变，可整体回退。
+
+**边界：花钱且须逐次审批的动作（例：生图）有意不做成子代理。** 它必须走审批链路（提案 + 审批卡），与「子代理默默干活再交报告」的形态相反；塞进 delegate 只会绕过审批卡。
+
+### 3.3 持久化与悬空绑定清理
+
+- 配置应当是**应用级偏好**，不进项目目录——「它描述的是用户买了什么账号，不是这个项目的内容」。参考实现是 6 个 pref 键：`ai:subagent:{kind}:modelId` / `ai:subagent:{kind}:enabled`。
+- store 暴露 `subAgents: Record<SubAgentKind, SubAgentConfig>` + `setSubAgent(kind, patch)`。
+- **三处清理逻辑**保证绑定不会指向已删除的模型行：
+  1. `loadConfig`——配置刷新后逐一验 modelId 是否还在模型表；
+  2. `removeProvider`——删供应商连带清其模型的绑定；
+  3. `removeModel`——删单个模型清绑定。
+  这与「按用途绑一个模型」的其他偏好（如 memoryModelId/imageModelId）同一套模式。
+
+### 3.4 设置面板：警告但不阻止
+
+设置面板刻意做薄：每个 kind 只有**开关 + 模型下拉**。
+
+- 下拉候选过滤掉不能对话的模型（如 `models.filter(m => m.enabled && m.type !== "image")`）。
+- `warningFor(kind, model)` 就地内联警告：search 绑了无 `serverTools: ["web_search"]` 的模型、vision 绑了非 multimodal 模型时立即提示——「等运行时才报，作者已经白等一个往返，被告知一件这个界面早就知道的事」。
+- **警告但不阻止保存**（用户可能配到一半）。因此下游一律必须用 `subAgentModel()` 再验（见 §4.2）——面板的宽容以下游的严格为前提。
+
+### 3.5 会话级 chips：只减不增
+
+对话输入框上方渲染**可用**子代理的 chips，可单次点掉（参考实现 `SubAgentChips.tsx`）：
+
+- 显示条件是 `subAgentModel(k, models, subAgents) !== null`——「可用，不只是启用」；不可用的 kind 连 chip 都不出现（一个改变不了任何行为的开关不该展示）。
+- 覆盖状态存会话 store（如 `agentStore.disabledSubAgents: SubAgentKind[]`），**不落偏好**——它是「这次对话」的意思，不是设置。
+- **只减不增**：`withSessionOverrides(subs, disabled)` 把 disabled 里的 kind 强制 `enabled: false`，返回新对象。chip 只能关掉设置里已启用的，不能临时打开一个没绑模型的——「就这一次用一下」需要一个用户从未做过的绑定。
+- 对话变化时**全部清掉**：新建对话、切换会话、切换项目都置空。只清一处，用户在对话 A 关的联网会跟进从历史打开的对话 B。
+
+---
+
+## 4. 能力路由
+
+### 4.1 核心原则：路由 = 改工具集，不是改提示词
+
+规则是「主模型也支持、子代理也支持时，**优先子代理**」。落实方式：「**改主模型看得见的工具集，而不是在提示词里写一条偏好。偏好靠模型自觉，工具集是硬保证。**」
+
+`routeTools` 全文很短，应当整段照抄（参考实现 `routing.ts`）：
+
+```ts
+export interface RoutedTools {
+  tools: ToolId[];
+  serverTools: "final-round-off" | "off" | "always";
+}
+
+export function routeTools(
+  preset: TaskPreset,
+  subs: Record<SubAgentKind, SubAgentConfig>,
+  workspace: TaskWorkspaceHandle | undefined,   // 是句柄不是 boolean，见下
+  models: Model[],
+): RoutedTools {
+  let tools = [...preset.tools];
+  const live = (k: SubAgentKind) => subAgentModel(k, models, subs) !== null;  // 可用，不只是启用
+
+  // vision 接管看图：从主模型工具集里拿掉图片工具
+  if (live("vision")) tools = tools.filter((t) => t !== "read_image" && t !== "read_lore_image");
+
+  // 任一子代理可用 + 有工作区 ⇒ 追加 delegate
+  if (SUBAGENT_KINDS.some(live) && workspace && !tools.includes("delegate")) tools.push("delegate");
+
+  // search 接管联网：主模型不再持有端点搜索
+  const serverToolsPolicy = live("search") ? "off" : (preset.serverTools ?? "final-round-off");
+  return { tools, serverTools: serverToolsPolicy };
+}
+```
+
+四条要点：
+
+1. **longread 不接管 `read_file`**——主模型读一小段正文是日常工作，全部委托反而多一次往返；longread 是「通读一大摞」的加法，不是替代。接管应当只针对「主模型做会造成上下文灾难」的能力。
+2. **search 启用 ⇒ 主模型 `serverTools: "off"`**。这不只是优先级——更是把服务端搜索那套 `pause_turn`/续跑/`tool id not found` 的续跑复杂度**关进子跑里**：主 history 从此见不到 `web_search_tool_result` 这类块。
+3. **delegate 需要工作区**（子代理产出必须落盘），无工作区的 surface 不会莫名多出一个用不了的工具。
+   **陷阱（假守卫）**：参数不要收 `hasWorkspace: boolean`——若调用方总是无条件构造 handle，`Boolean(handle)` 恒真，「看起来像守卫的守卫从没守过任何东西」。应当传**句柄本身**（`TaskWorkspaceHandle | undefined`），`undefined` 才是真的「没有」。守卫参数要传能真正为空的东西。
+4. 模型幻觉调用被拿掉的工具（比如仍调 `read_image`）→ 注册表白名单返回 `Unknown tool: read_image`，模型可自纠。**不加特例映射**——「路由一旦按名字打补丁，就得为每一对『被谁接管』维护映射表」。
+
+### 4.2 「启用 ≠ 可用」：单一判断函数
+
+`subAgentModel(kind, models, subs)` 应当是可用性的唯一答案：
+
+```ts
+if (!cfg?.enabled || !cfg.modelId) return null;          // 开关 + 绑定
+const model = models.find((m) => m.id === cfg.modelId);
+if (!model) return null;                                  // 模型还在
+if (kind === "vision" && model.type !== "multimodal") return null;          // kind 前置条件
+if (kind === "search" && !model.serverTools?.includes("web_search")) return null;
+return model;
+```
+
+`routeTools`、chips、`chainCanSeeImages`、`resolveVisionConn`——所有 surface 全走它。不这么做的代价不止是多一个死按钮：**routeTools 见到 search 被启用就会关掉主模型自己的联网**——若那个子代理其实不能上网，用户「既失去主模型的联网，又什么都没换回来」（参考实现 `routing.test.ts` 对这条有专门用例）。
+
+### 4.3 连接解析：`resolveSubAgentConn`，无 fallback 链
+
+子代理**不继承主模型连接**，独立解析：`subs[kind]` → 查 Model 行 → 查 Provider 行 → `loadKey(provider.id)` 取密钥。四步任何一步失败返回判别联合 `{ error: string }`，错误文案都是「告诉用户去哪儿修」的形态。
+
+- **没有 fallback 链**——绑定失效就是 error，不会静默退回主模型。
+- **陷阱：密钥缺失不得降级成空串。** `loadKey() ?? ""` 会发一个无钥请求，401 回来被包装成「子代理坏了」，而真正的修法是去粘一个 key（参考实现测试注释：「`?? ""` here produced a 401 the author had to reverse-engineer」）。密钥缺失是**配置错误**，应当在解析层就返回指路的 error（「去 Settings → Providers 粘 key」）。
+- **依赖方向**：解析函数以**回调**形式注入 `ToolContext`（调用方 store 里构造 `(k) => resolveSubAgentConn(k, models, providers, subs, loadApiKey)`），不是让 lib 层读 store——避免 agent lib 成为 store 的下游。
+
+### 4.4 直接 UI 动作走同一优先级
+
+不经 agent 的直接 UI 动作（例：知识库词条的「AI 描述」按图生成）也应当是「vision 子代理可用就优先它，哪怕主模型自己也能看图」（参考实现 `resolveVisionConn`）。理由不是省事：`routeTools` 已在工具集层把图片工具从主模型手里拿走，若 UI 动作反过来优先主模型，**同一个开关在两处表示相反的事**——且对多模态主模型的用户，那个开关将永远无效。代价是多一跳，收益是「谁在这里读图」只有一个答案。
+
+### 4.5 两个能力概念分立：`chainCanSeeImages` vs `multimodal`
+
+- `chainCanSeeImages(mainModel, subs, models)`：主模型多模态 **或** 有可用 vision 子代理 ⇒ true。**只给 UI 灰显判断用。**
+- `ToolContext.multimodal`：「能否把 base64 塞进**当前这个模型**的请求」。
+
+**不变量：绝不用前者改后者的语义。** 改成「链路上有人能看图」会让纯文本主模型收到读不了的图片（烧 token 且可能被端点 400）。两个概念，两个名字，语义井水不犯河水。
+
+配套（引用注入侧）：图片附件的 UI 入口按 `chainCanSeeImages` 放宽后，发不出去的图片改为**列出路径**，并在有 vision 子代理时把告示从道歉改成指令——「用 `delegate(kind:"vision", refs:[路径])` 让它读」。只给文件名时，「模型看得见缺了什么，却没有任何办法去取」。
+
+---
+
+## 5. 执行细节
+
+### 5.1 复用同一个 runtime loop
+
+子代理**就是一次嵌套的 `runAgent` 调用**——同一个函数、同一个 tool loop，换一份连接参数（ConnOptions）+ 换一个 preset + 全新 2 条消息的 history。前提是 runtime 天然可重入：`messages`/`signal`/`onEvent` 全由调用方传入，无模块级状态。**机制上不存在任何「子代理框架」**，子代理只是一个工具的执行器。
+
+### 5.2 沙箱：四道闸
+
+子跑的 `toolContext` 现场构造，只给最小字段集：
+
+```ts
+toolContext: {
+  projectPath: ctx.projectPath,
+  loreIndex: ctx.loreIndex,
+  multimodal: conn.model.type === "multimodal",   // 子代理自己的能力，与主模型无关
+  taskWorkspace: undefined,                        // 沙箱
+  signal: ctx.signal,
+},
+```
+
+| 约束 | 落实处 | 机制 |
+|---|---|---|
+| **深度 1（防递归）** | `SUB_PRESETS[kind].tools` 不含 `"delegate"` + 注册表按 `allowed` 白名单查表 | 双保险：不在名单直接 `Unknown tool` |
+| **只读** | 不传 `requestApproval` / `requestPlanApproval` / `lorePlan` / `taskWorkspace` | 高危写工具缺审批通道自报错；计划门挡知识库写工具；工具集本身是第三道 |
+| **零上下文渗透** | messages 只有 2 条，现场构造 | —— |
+| **共享 signal** | `ctx.signal` 透传给 `runAgent`；`AbortError` 重抛不转 tool error | 用户点停止 ⇒ 子代理立即停，不后台烧钱 |
+
+注意 `taskWorkspace: undefined` 的连带效果：子代理调不动任何 scratchpad 工具（它们都要求 `ctx.taskWorkspace`）——子代理的产出由 `executeDelegate` 代为落盘，它自己不直接写 note。
+
+### 5.3 前置校验在 delegate 里做，零副作用
+
+`executeDelegate` 应当在发任何请求前检查：
+
+- ctx 四件套齐不齐（`taskWorkspace`/`signal`/`onNestedEvent`/`resolveSubAgent`，缺任一 → "this surface cannot run subagents"）；
+- kind 合法、task 非空；
+- 连接可解析；
+- **kind 前置条件**：search 模型必须有 web_search、vision 模型必须 multimodal。
+
+理由：绑错模型的子代理「要烧一整个往返才报告，而且报出来的形态是『子代理失败』而不是『配置不对』」。
+
+**不变量：前置校验失败零副作用。** 参考实现 `delegateShape.test.ts` 断言拒绝时 `sent.length === 0`（没发请求）且文件系统为空（**没建工作区**）。
+
+### 5.4 轮上限与收尾
+
+- 子跑**不传 `onRoundLimit`**：撞上限就按默认行为最后一轮撤工具、强制成文，「不去打扰作者」。round-limit 交互卡片只属于主 run。
+- `finishPolicy: "force-text"` 保证子跑总以文本结束；文本经 `onOutputText` 捕获（§2.3）。
+
+### 5.5 事件冒泡与去重
+
+- runtime 执行每个工具前把 `signal` 和 `onNestedEvent: opts.onEvent` 浅合并进 `ToolContext`，所以 delegate 拿到的 `onNestedEvent` 就是主 run 的 `onEvent`。
+- delegate 转发子跑事件时打作用域标记：`onEvent: (e) => ctx.onNestedEvent!({ ...e, parentStep: call.id })`——**`parentStep` = 这次 delegate 工具调用的 toolCallId**。
+- 事件类型用交叉类型加作用域字段：`AgentEvent = AgentEventScope & (成员联合)`——交叉类型分配到每个成员，不破坏 `kind` 判别收窄（事件联合没有公共基接口时给全体加字段的最小改法）。
+- **陷阱：去重键必须带 `parentStep`。** tool-step 按 `parentStep + toolCallId + name`，reasoning 按 `parentStep + round`。否则子跑的 round-1 reasoning 会顶掉主 run 第 1 轮的 reasoning 行（子跑轮次也从 1 开始）。
+- 日志 UI 从截断的参数摘要里抠字段（如 kind/task）应当用**正则不用 JSON.parse**：参数常被截断（参考实现截 400 字符），delegate 的 task 按设计是一整段话，JSON 常态性断在字符串中间 parse 不出来。
+
+### 5.6 串行执行，无并发编排
+
+机制上模型可以在一轮发多个 tool call，但 runtime 的工具执行循环应当 `for...of` **串行 await**——同轮多个 delegate 也是顺序执行。设计边界明说：**无子代理间通信、无并行编排、无递归。**
+
+---
+
+## 6. 测试应当锁定的契约（精选）
+
+以下契约值得在新项目里写成回归测试（参考实现 `subagent.test.ts` / `routing.test.ts` / `delegateShape.test.ts`）：
+
+**能力判断**
+- `chainCanSeeImages`：vision 子代理绑 **text 模型 ⇒ false**（设置面板允许错误绑定存在，信标志位就会点亮图片控件然后把图发给读不了的模型）；主模型可为 undefined。
+- `resolveVisionConn`：主模型自己是多模态时**仍优先子代理**；子代理绑 text 模型**穿透**回主模型；什么都不能看时返回**带原因的 error 而非 null**；密钥为 null 报「配置问题」而非发空钥请求吃 401。
+
+**路由**
+- 无子代理 ⇒ tools/serverTools 原样（默认 `final-round-off`）。
+- workspace 为 undefined ⇒ **无 delegate**。
+- 「启用≠可用」三连：search 绑不能上网的模型 ⇒ serverTools **不动**且无 delegate；vision 绑 text 模型 ⇒ read_image **留在**主模型手里；绑定的模型已删除 ⇒ 无 delegate。
+- 会话覆盖关掉某 kind 后**路由随之回退**（联网还给主模型、图片工具还回来、delegate 消失）——composer 与 resolver 必须读同一份生效配置；覆盖只减不增（对本就 off 的 kind 是 no-op 不是 toggle）。
+
+**delegate 形状**
+- 工作区标题**不是**委托指令（命名归 task_plan）；note 文件名是文件名不是句子，完整指令作为 note 首行标题存活。
+- 无 refs 时 user 消息**完全不含**「参考资源」小节；有 refs 时含路径。
+- 前置校验失败 ⇒ 没发请求、没建工作区（零副作用）。
+- 成功路径：usage 行的 model_id 是子代理的、task 打 `subagent:<kind>` 标签；tool result 含 note 路径与摘要；嵌套 run-done 事件带 `parentStep: call.id`；解析失败的 delegate 不发 run-done。
+
+---
+
+## 7. 「始终不做」边界清单
+
+边界即设计。以下各项**有意不做**，新项目不应「顺手补上」：
+
+- **子代理间通信**——总线就是 notes 目录，单向、经文件。
+- **并行编排**——工具循环串行 await，同轮多个 delegate 顺序执行。
+- **递归委托**——子代理工具集不含 delegate，注册表白名单双保险。
+- **子代理写用户内容**——子代理只读 + 产出由执行器代写 note。
+- **把「要花钱须审批」的动作塞进静默委托**（例：生图）——那会绕过审批卡。
+- **自定义子代理种类 / 自定义 system prompt**——kind 是代码，配置只有「哪个模型、开不开」。
+- **fallback 链**——绑定失效就是指路的 error，不静默退回主模型。
+- **用工作区替代压缩，或用压缩替代工作区**——工作区管「查到什么、做到哪」（任务事实），压缩管「聊过什么」（对话），见 `10-context-management.md`。
+
+---
+
+## 本篇检查清单
+
+- [ ] runtime 可重入（messages/signal/onEvent/onOutputText 全由调用方传入，无模块级状态），子代理只是「嵌套调一次 runAgent 的工具执行器」，没有独立框架。
+- [ ] `delegate` schema 的 `task` description 明确写出「子代理看不到这段对话」；有/无 refs 是**两个**模板键；工具描述用领域中性词汇。
+- [ ] 子代理产出经 `onOutputText` 回调捕获（不是翻 history）；落盘 note 后 tool result = 路径 + ≤800 字符摘要 + read_note 指引；空产出报错不建 note。
+- [ ] `AbortError` 是唯一重抛的异常，其余全部转 `Error: ...` 前缀的 tool result。
+- [ ] 沙箱四道闸齐全：白名单防递归、不传审批/计划门/工作区、两条现场消息、共享 signal。
+- [ ] 前置校验（ctx 四件套、kind/task、连接、kind 前置条件）全部在 delegate 里做，失败时零副作用（无请求、无工作区目录）。
+- [ ] 可用性判断只有一个函数 `subAgentModel`（开关 + 绑定 + 模型存在 + kind 前置条件），routeTools/chips/UI 动作/连接解析全走它；设置面板警告但不阻止，下游必须再验。
+- [ ] `routeTools` 改的是工具集不是提示词：vision 接管删图片工具、search 接管关服务端搜索、delegate 依赖**真正可为 undefined** 的工作区句柄。
+- [ ] 记账：每子跑一行独立 usage（model_id 是子代理的，task 打 `subagent:<kind>`）+ 一条带 `parentStep` 的嵌套 run-done；事件去重键带 `parentStep`。
+- [ ] 「始终不做」清单（§7）逐条确认没有被「顺手实现」。

--- a/docs/ai-agent-playbook/10-context-management.md
+++ b/docs/ai-agent-playbook/10-context-management.md
@@ -1,0 +1,285 @@
+# 10 · 长会话上下文管理：任务工作区、压缩与会话持久化
+
+> 本篇解决的问题：agent 的 wire history 是唯一记忆时，长任务必然走向「灌满 → 破坏性裁剪 → 丢结论 → 重做」的循环，长会话必然走向超窗，崩溃则丢掉一切。本篇给出三套互相咬合的机制：**任务工作区**（把任务事实落盘，让裁剪从破坏性变成可恢复）、**上下文压缩**（四层防线管住对话本身）、**会话持久化**（让会话活过重启且不被旧数据打崩）。工作区管「查到什么、做到哪」，压缩管「聊过什么」——两者平行，互不替代。
+
+参考实现：simple-ai-writer `src/lib/agent/taskWorkspace.ts`、`scratchpadTools.ts`、`compact.ts`、`compactRun.ts`、`chatRefs.ts`、`transcriptFold.ts`、`chatSession.ts`。
+
+---
+
+## 1. 任务工作区
+
+### 1.1 目录结构与归属
+
+```
+<projectPath>/.ai-writer/tasks/
+  └── 20260814-163000-a1b2c3/        ← taskId = YYYYMMDD-HHmmss-6位随机（时间序 + 唯一）
+        ├── task.md                   ← 机器元数据(注释头) + 人可读可手改的 markdown
+        └── notes/
+              ├── search-xxx.md       ← 中间结论：搜索/识图/长读/子代理产出
+              └── ...
+```
+
+归属规则：
+
+- 不进用户内容目录、不出现在文件树、不参与导出；
+- **进项目备份**——tmp 是 scratch 所以排除，tasks 是可恢复状态所以包含。这条应当写进备份模块注释，防止后人「顺手清理」。
+
+### 1.2 懒创建句柄 `TaskWorkspaceHandle`
+
+绝大多数 run 是短任务，不该凭空产生任务目录。核心抽象：
+
+```ts
+export interface TaskWorkspaceHandle {
+  readonly taskId: string | null;   // null = 这次运行还没用到工作区
+  ensure(title: string): Promise<{ taskId: string; dir: string }>;  // 首次创建/复用
+}
+```
+
+两个工厂：`createTaskWorkspace(projectPath, modelId)`（懒句柄，首次 `ensure` 才建目录写 task.md，然后异步 `void gcTasks(projectPath, keepId)`）与 `existingWorkspace(projectPath, taskId)`（恢复用）。
+
+**生命周期归属由 surface（调用方）决定，不由工作区自己决定：**
+
+- 单次编辑器任务 **per-run**——一个任务一个工作区，run 开始时置空上一个的；
+- 会话式 chat **per-session**——turn 3 存的 note 在 turn 9 还要能读，这正是落盘的意义；新对话时置空（「新对话不该继承上一个话题的笔记」）；
+- 无工作区的 surface（弹窗类小工具）不传 handle，scratchpad 工具返回统一错误文案。
+
+### 1.3 task.md 格式：单一事实源
+
+```markdown
+<!-- ai-writer-task
+{"taskId":"...","status":"in_progress","modelId":"mdl-7","createdAt":"...","updatedAt":"...","sourceRefs":[{"path":"writing/第03卷/第45章.md","hash":"3f8a9b1c"}]}
+-->
+
+# 调查东境贵族世系与魔法起源
+
+## 步骤 <!-- ai-writer-task-steps -->
+
+- [x] 检索东境三大家族设定
+- [/] 分析初代家主与禁忌魔法关联
+- [ ] 起草补充设定并更新词条
+
+## 进度记录 <!-- ai-writer-task-log -->
+
+- 16:32 家族关系网比对完成，见 `notes/search-east-nobles.md`
+```
+
+设计决策逐条（每条都是踩过坑的）：
+
+1. **不变量：JSON 注释头只放机器状态**（`TaskMeta`：taskId/status/modelId/createdAt/updatedAt/sourceRefs），**步骤的标题与状态只存在于正文的复选框列表里，JSON 里一个都不放**。工具按 **1 基序号**寻址步骤，连 step.id 都不需要。用户手改 `- [ ]` 为 `- [x]` 就是真的改了状态——不存在两份数据打架。这是「人可编辑文件 + 机器状态」共存的标准解法。第一版 JSON 和正文各存一份步骤，用户手改正文后即打架。
+2. **复选框字形即状态**：`[ ]` pending · `[/]` in_progress · `[x]` done · `[-]` skipped。**缩进的复选框也算一步**（STEP_RE 允许前导空白）：用户照渲染后的列表数序号，解析器漏一条会让其后每个序号错位、勾错行。
+3. **小节靠语言无关锚点注释定位**（`<!-- ai-writer-task-steps -->` / `<!-- ai-writer-task-log -->`），标题文本走 i18n（用户要读这个文件）。**陷阱**：按标题文本找小节，第一次切换应用语言就会把进度记录写到别处。
+4. 解析要宽容：`parseTaskDoc` 对损坏元数据返回 null 不抛；`taskTitle` 找不到 H1 返回 null（正文用户可任意编辑）。
+5. 小工细节：`appendLogToBody` 插到**小节末尾而非文件末尾**（用户在下面加了自己的小节后，追加到文件尾会把日志记到别人的标题下）；`withSteps` 替换整段时连空行一起换、每侧只写一个分隔（否则每次 re-plan 文件多长一个空行）。
+
+### 1.4 任务状态机
+
+```ts
+export type TaskStatus = "in_progress" | "paused" | "completed" | "failed";
+```
+
+```
+(无) --task_plan / 首次 write_note--> in_progress --步骤全部 done/skipped--> completed
+                                        │  撞轮上限选「存盘暂停」
+                                        ▼
+                                     paused --UI「继续」(resumeTask)--> in_progress
+                                        │  运行异常 / 恢复失败
+                                        ▼
+                                     failed
+```
+
+- `completed` 由 `task_progress` 自动判定：改完后 `parseSteps` 全部 done/skipped 且当前 `in_progress` ⇒ 置 completed。
+- `paused` 由调用方在 `runAgent` 返回 `outcome === "paused"` 后写（`markTaskPaused`：置状态 + 追加一条进度日志）。
+- **陷阱（僵尸任务）**：`markTaskResumed` 在恢复时**乐观**置回 in_progress；若恢复的发送根本没跑起来（报错），必须再 `markTaskPaused` 回去——「不留一个声称在跑的任务」。
+
+### 1.5 存盘暂停：round-limit 的第三个出口
+
+runtime 撞轮上限的回调契约不能是 `Promise<number>`——一个数表达不了「暂停」。应当用判别联合：
+
+```ts
+export type RoundLimitDecision =
+  | { action: "extend"; rounds: number }
+  | { action: "finish" }     // 撤工具、强制成文
+  | { action: "pause" };     // 不再发请求，直接收工
+
+// AgentRunResult 增 outcome: "completed" | "paused"
+```
+
+- **暂停必须发生在轮首**（进入 force-text 最后一轮前、且 round > 1、preset 有工具、调用方给了 onRoundLimit 时阻塞询问；选 pause 就地 return `outcome: "paused"`）。轮首暂停是干净的：上一轮的 tool_calls 全部已配对，history 合法，不需要 repair。
+- UI 卡片三个按钮：就此收尾 / 存盘并暂停 / 继续（再 N 轮）。
+- **陷阱（按钮出现在错误的 surface）**：「存盘并暂停」的可见性由 `PendingRoundLimit.canPause` 决定，**由发起 run 的一方在撞上限那一刻求值 `!!tw.taskId`**——不是 run 开始时（模型三轮前建的工作区也算）；也不能让共享的卡片组件自己去读会话状态，否则按钮会出现在没处理 paused 的一侧，「点下去整轮工作无声消失」。**每一个**处理 run 结果的调用方都必须处理 `outcome === "paused"`：`markTaskPaused` + `recordSourceRef`（当前文档路径 + FNV-1a 哈希），不再强跑成文轮。
+
+### 1.6 恢复：`buildResumeSeed`——恢复状态，不重放对话
+
+**陷阱（根病）**：恢复时重放旧 wire history，历史里用户的 `continue`、`重试` 会被当成新指令，agent 自我强化地继续。「继续」必须从**重放对话**变成**读取状态**：
+
+1. `loadTaskDoc` 读 task.md；
+2. **参考文件新鲜度**：逐条比对 `meta.sourceRefs` 的 FNV-1a 哈希，产出 `- path（已删除/已修改/无法读取）` 清单。sourceRefs 的**唯一写入方是暂停时刻**（recordSourceRef）——恢复要比对的正是「任务挂起时的那个状态」；给模型读过的每个文件都算哈希则要多一次整文件读。**准则：字段必须真有写入方——只声明而无人填，检查就永远不会触发。**
+3. notes 索引**只给标题 + 路径 + 字符数，不给正文**；
+4. 拼一条全新 user turn（模板含 task.md 正文 + 笔记索引 + 过期清单 + 「用 read_note 读详情」的指令），**不带任何旧 wire history**。
+
+恢复流程（参考实现 `resumeTask`）：停掉当前 → buildResumeSeed → markTaskResumed → **清空整个会话状态**（turns/history/meta/sessionId 全 null）但把工作区设为 `existingWorkspace(taskId)` → 发送种子（转录里显示友好的「恢复任务：xxx」而非整段种子，`displayText` 参数）。
+
+### 1.7 GC：排序淘汰，不豁免
+
+`MAX_SAVED_TASKS = 20`。排序规则：**已收尾（completed/failed）排前、优先淘汰**，同组内 updatedAt 旧的先删；只删超额部分；**绝不删当前 run 持有的 keepTaskId**；损坏目录按 failed 处理。
+
+**陷阱**：「未完成的优先留下，但**不豁免**」——第一版「未完成不清理」会让一串永不收尾的任务无界增长。触发点在 `ensure()` 建目录之后异步执行，失败只 warn。
+
+---
+
+## 2. Scratchpad 工具
+
+### 2.1 五个工具
+
+注册进同一个工具注册表，追加在主 agent 的 preset 工具表末尾：
+
+| 工具 | access | 参数 | 行为 |
+|---|---|---|---|
+| `task_plan` | write-auto | `{title, steps: string[]}` | 建立/重写标题与步骤表；**保留**进度记录小节与用户手写内容（re-plan 是正常动作，不能抹掉已做记录）；两参数都必填非空 |
+| `task_progress` | write-auto | `{action: "check"\|"start"\|"skip"\|"add_step"\|"log", step?, text?}` | 增量改一行；step 是 1 基序号，越界返回可读 error（含当前步数）；全部 done/skipped 自动置 completed |
+| `write_note` | write-auto | `{slug, title, content, sources?}` | 写 `notes/<slug>.md`，自动补 H1 标题 + 来源引用块；返回相对路径与字符数；撞名自动 `-2`/`-3` 后缀并**告知真实文件名**（renamedFrom） |
+| `read_note` | read | `{path\|slug, start_line?}` | 行号分页回读，单页 4000 字符按行边界切，回报 `[lines a-b of N]` 与下一个 start_line |
+| `list_notes` | read | `{}` | 列出 slug/标题/路径/字符数，**不给正文**；按 slug 排序（readDir 顺序不稳定，同一会话两次列表要长一样） |
+
+### 2.2 六条关键不变式
+
+1. **谁能创建工作区**：只有 `task_plan`（用真实标题——标题即计划主题）与 `write_note`（checkpoint 提示点名要它，拒绝会让提示变死路；但用**中性标题**建仓——「任务叫什么归 task_plan 管，让碰巧第一个落盘的笔记命名整个任务是抽彩票」）。`task_progress` **不创建**（`requireTaskId` 拒绝）。
+   **陷阱**：从 progress `ensure()` 会创建任务并顺带满足「要求先有计划」的检查，导致「先调 task_plan」的分支永远走不到，留下一个以空为题的工作区。另外新工作区**零占位步骤**——伪造「- [ ] 开始任务」会被 parseSteps 数进去，模型还会去勾一条它没写过的步骤。
+2. **路径沙箱靠 Unicode slug 清洗**：`sanitizeSlug` 用 `/[^\p{L}\p{N}-]/gu`——**保留任何文字系统的字母数字**。
+   **陷阱**：不能写 ASCII 白名单——纯中文 slug（「搜索结果」「第一章分析」）会全被清空、回落到同一个 `note.md` 互相覆盖，「正是工作区要防的那种丢失」。清洗后不可能含 `/` `\` `.`，拼进 notes 目录天然出不去，无须再叠路径包含检查。按**码点**截 60 字符（UTF-16 单位截断会切开代理对）。读侧 `noteSlugFromReference` 接受相对路径 / `<slug>.md` / 裸 slug 三种形态（前两种来自本应用自己的工具输出——拒绝良性输入报 security error，模型读到 "access denied" 倾向于原样重试而非改格式）；指向**别的任务**返回 null（「读一篇没被要求的 note 比找不到更糟」）。
+3. **绝不覆盖**（撞名加后缀）：静默覆盖等于丢数据，而模型没有任何办法察觉它发生过。
+4. **大小熔断**：note ≤ 100,000 字符、task.md ≤ 20,000 字符；超限返回 tool error **而非截断**（截断会让模型以为写成功了）。
+5. **不备份、不过审批门**：write-auto 在别处意味着「自动应用 + 写前备份」，但工作区是 agent 自己的草稿纸——备份无恢复价值只翻倍磁盘；审批门是为「改用户的内容」设的，「加门只会让模型在自己的笔记本上也要请示」。
+6. **写入串行化**：模型同轮可发多个 tool call，两个 task_progress 并发读改写会丢更新。所有 task.md 写入过 `serializeTaskWrite`（模块级 `writeChain: Promise` 链）。
+   **注意**：串行链应当放在**工作区模块**而不是工具文件——工具不是唯一写者，暂停/恢复/recordSourceRef 都在读改写同一文件，只覆盖工具的链会让它们与工具竞态。
+
+### 2.3 主/子 agent 的交接：单向、经文件
+
+子代理自己没有 scratchpad 工具（ctx 无 workspace），它的全部产出 = 最终成文文本 → delegate 执行器代写成一篇 note → 主模型拿到「摘要 + 路径」 → 需要细节时 `read_note` 分页读。主模型自己则用 `task_plan`/`task_progress` 维护计划、用 `write_note` 在裁剪来临前抢救结论。**没有共享内存、没有双向通信——「总线」就是 notes 目录。**
+
+### 2.4 checkpoint 注入：让模型真的用起来
+
+光有工具不够，模型不会主动用。preset 应当有三档 `scratchpad: "off" | "offered" | "required"`（默认 off ⇒ 整套机制可整体回退；主助手 preset 用 required）。required 时，轮循环顶部、裁剪逻辑**之前**：
+
+- 触发条件：`estimateMessagesTokens(history) > inputCeilingTokens * 0.85`（`CHECKPOINT_RATIO`，**必须早于**裁剪的 `> ceiling` 触发点——提醒发出时内容不能已经被删了）且 `!checkpointArmed`；
+- 注入一条 user 提示（「上下文接近上限即将裁剪，请用 write_note 把关键结论写进笔记」），**发出即撤**：finally 里按对象身份 splice 掉。
+  **陷阱**：一次性话术留在持久 history 里会变成「之后每一轮的常驻命令」——这正是「agent 不停告诉自己用户要求继续」那类故障的成因；
+- `checkpointArmed` 在裁剪**真正丢了内容**（dropped > 0）后重新置 false——只提醒一次的话，长任务后段照样丢。
+
+闭环由此成立：**接近上限 → 提醒落盘 → 裁剪（破坏的只是上下文里的拷贝）→ 需要时 read_note 取回。** 裁剪从破坏性变成非破坏性。
+
+---
+
+## 3. 上下文压缩
+
+压缩是**与工作区平行的另一层**：工作区管「查到什么、做到哪」（任务事实），压缩管「聊过什么」（对话）。互不替代。完整体系四层防线：
+
+| 层 | 时机 | 单位 | 性质 |
+|---|---|---|---|
+| ① compact（轮间折叠） | 每个 chat turn 开始前 | 整轮（turn） | 摘要化，非破坏（信息进 rolling summary） |
+| ② trimHistory（轮内裁剪） | 每个 round 请求前 | 单条工具结果/图片 | 破坏性兜底（配合 scratchpad 变可恢复） |
+| ③ checkpoint 注入 | 裁剪将至（85%） | —— | 提醒模型落盘 |
+| ④ transcriptFold | 渲染层 | 显示条目 | 纯展示折叠，不碰 wire history |
+
+### 3.1 触发与预算常量
+
+```ts
+COMPACT_TRIGGER = 0.7        // history 估算 token 超过输入上限的 70% 触发
+RETAIN_TARGET  = 0.45        // 折叠后目标降到 45%
+MIN_KEEP_TURNS = 2           // 无论多超，最近 2 轮永远原文保留
+SUMMARY_BUDGET_TOKENS = 1000 // rolling summary 的软上限
+FOLD_RESULT_CLIP = 200       // 喂给摘要器时每条工具结果截 200 字符
+FOLD_TEXT_CLIP   = 2000      // user/assistant 正文截 2000
+```
+
+**陷阱（prompt cache 被压缩杀死）**：trigger(0.7) 与 target(0.45) 之间必须留宽间隙。一个多工具轮能长几千 token，间隙太窄会**每轮都压**——每次都作废 prompt-cache 前缀。
+
+### 3.2 两个根本不变式
+
+1. **轮边界按消息对象身份记录，不按索引。** history 会被不知道「轮」概念的各方原地改：配对修复逻辑会 splice 插桩（索引全移位），裁剪换的是既有对象的 `content`（身份不变）。会话元数据的 `turnStarts: StreamMessage[]` 存的是**用户提问消息对象本身**，对两种改动都免疫。
+2. **折叠单位是整轮。** `role: "tool"` 回复必须紧跟发起它的 assistant 消息——主流 provider 都拒绝拆开的 pair，而坏掉的 history 是永久的（它就是会话本身）。user+assistant+tools 整轮一起折，永远不会撕开配对。
+
+### 3.3 折叠计划（planFold）
+
+`segmentHistory` 按 turnStarts 切出 prelude（system + seed + summary）与 turns → 未超 trigger 或可折轮数 ≤ 0 返回 null → 从最大折叠量倒着走，「有余量就多留一轮原文」，直到留存投影贴近 target（summary 按预算上限的最坏值计入）；就算最大折叠也够不到 target 仍返回 best effort（「释放大部分空间好过一点不放」）。首次折叠顺带丢 seed context（`dropSeed`）。
+
+### 3.4 摘要请求与重建
+
+- 时机：**每个 turn 的用户消息入 history 之前**（发送入口处），不是轮内。
+- 摘要 prompt：system 用专用指令模板；user = 已有摘要（**以纯文本传入**，不从 wire 消息剥块头）+ 折叠轮的降采样渲染。渲染格式是语言中立的数据行：`[user] ...` / `[assistant] ...` / `[tool call] name args截200` / `[tool result] 截200` / 图片替换为 `[image]`。摘要指令里应当要求「保留提到过的 notes/ 路径」，防止折叠吃掉 note 引用。
+- 摘要器就是**会话自己的模型**跑一次无工具 completion（独立函数，便于将来换专用摘要模型）。
+- **不变量（失败原子性）**：summarize 失败或返回空 ⇒ 返回 null，history 和 meta **一个字不动**，本轮不压缩继续跑（裁剪层仍兜底），下一轮阈值会再触发；只有 AbortError 上抛（那是用户取消了整次发送）。「压缩绝不能把一次网络抖动变成受损会话。」空摘要视为失败——「拿上下文换一行空白」不可接受。`buildCompactedHistory` 返回**新数组**，调用方在摘要成功后才换入。
+- 重建后的 history：`[prelude(去掉 seed 与旧 summary)] + [summary 消息(role: user, 【历史摘要】块)] + [保留轮原文]`。**summary 紧贴 system 之后**——让稳定前缀最大化，保 prompt caching。同时更新 meta：turnStarts 换成保留轮的 start；注入台账按 carrier 是否还活着逐出（见 §3.6）。
+
+### 3.5 @引用注入：三道预算与顺序渲染
+
+用户显式 `@` 的引用应当**内联而非只报名**——「作者已经决定助手该看它，让这变成模型可跳过的建议是赌博，还多花一次往返」。预算三道（参考实现 `chatRefs.ts`）：
+
+- `REF_CHAR_CAP = 6000`：单个引用最多内联 6000 字符，超出部分截断并注明「`用 read_file 于 <path> 读全文`」（**绝不静默截断**）；
+- `REF_TOTAL_CHAR_BUDGET = 18_000`：一条消息全部引用的总预算。**顺序渲染而非 Promise.all**——每个引用的额度取决于前面用了多少，「前几个完整到达、尾部退化成指针」，好过全部被均匀截成残段；预算耗尽的引用只报名 + 路径；
+- `MAX_MESSAGE_IMAGES = 4`：单消息图片数上限（与裁剪层的会话级图片上限分立——那是管累计，这是管「必须先成功的那一个请求体」）。
+
+消息拼装顺序：【选中内容】→【引用资料】→【附图】（带编号文件名——parts 数组不带文件名，「第二张图里的外套」要能解析）→ 未发送图片告示 → **用户原话放最后**（最新读到的东西；上面全是执行材料）。图片 parts 排在文本后。
+
+### 3.6 注入台账：version 指纹 + carrier 逐出
+
+自动检索注入的知识块（如 lore 实体）需要会话级去重台账：
+
+- `meta.injected: Map<dirPath, { version, carrier }>`：version 是内容指纹（元数据 JSON 的哈希，不读文件）；carrier 是**携带它入会话的那条消息对象**。
+- 每轮检索时：台账里且版本未变的实体**跳过不再注入**；实体被编辑过（指纹变了）会重新匹配、重新注入、覆盖台账条目。
+- 折叠时 carrier 消息**整条跳过不进摘要**（「检索块是可复现数据，摘要预算不该花在索引本来就知道的东西上」）；重建后 carrier 不在新 history 里的条目被逐出台账——「那个实体已不在会话里，之后再提到必须重新注入」。
+- 模型**自己用工具读的**内容刻意不入台账：「那是它的工作记忆——折掉即忘，它随时可以再读」。
+
+### 3.7 transcriptFold：显示层折叠
+
+与 wire 完全无关的第四层：`FOLD_KEEP_ENTRIES = 8`（最近 8 条 user/assistant 恒显示），`FOLD_MIN_HIDDEN = 4`（藏不满 4 条就不出折叠条——「两条消息藏在控件后面比两条消息更糟」）。`foldBoundary` 的切点**向回走到 user 条目**——可见转录必须以问题开头，「一个问题被藏起来的回答读起来像在回复虚空」。折叠逻辑应当抽成纯函数单独成文件以便测试（组件文件常拖着测试环境加载不了的宿主 import）。
+
+---
+
+## 4. 会话持久化
+
+一个会话 = 显示轮（turns）+ wire history + 会话元数据 + 累计用量，压成**一个 JSON blob** 存一行（参考实现 `MAX_CHAT_SESSIONS = 5`，写入路径 GC）。每个 turn 结束（成功或失败）都 `void persistChat()`——「丢会话的崩溃从不提前打招呼」。
+
+### 4.1 对象身份的序列化：身份 → 索引
+
+这是本模块拥有的那个非显然问题：会话元数据按**对象身份**引用 history 消息（turnStarts、seed、summary、每个注入 carrier），而 JSON 没有身份。规范：
+
+- 序列化把每个引用转成 **history 索引**（`indexOf`，-1 表示 null；injected 存 `[dirPath, version, carrierIndex]` 三元组）；
+- 反序列化把索引重新连回新解析出的对象；
+- 解析不到的引用（损坏行、越界索引）**丢弃而非猜测**。
+
+### 4.2 图片剥离
+
+`withoutImageData` 把 history 里的 base64 换成占位文案（「图片未保存在会话里——需要就再读一次」）。一张图 1–12MB data URL、blob 每轮重写一次；恢复的会话也用不上像素（问题已答完，路径都在转录里，模型可再读一次）。**不变量：拷贝不改原对象、顺序 1:1 保留**——meta 的索引是对原数组算的。
+
+### 4.3 偏执反序列化
+
+`v !== 1`、任何形状不对 ⇒ 返回 null，调用方开新会话。「恢复不了是不便，半恢复的 history 是之后每一轮的协议错误。」
+
+### 4.4 事件格式迁移
+
+会话 blob 比写它的代码活得久——**持久化的事件载荷实际上是 wire format**。参考实现的真实事故：round-limit 事件从 `granted: number` 改成 `decision` 判别联合后，一条旧行到达渲染层读 `event.decision.action` 把整个 AI 面板打穿 error boundary。规范：
+
+- 给旧格式写迁移函数（`migrateLogEvent`：`granted > 0` 映射为 `{action: "extend", rounds}`、否则 `{action: "finish"}`）；
+- 认不出的条目返回 null 被丢弃——「丢一行日志值得，丢一个会话不值得」。
+
+### 4.5 其余要点
+
+- **`maxTurnId`**：turn 计数器随应用重启归零，恢复会话时必须抬高计数器，否则会铸出与屏上已有 turn 撞号的 id——React key 静默复用错误子树。
+- **persist 竞态防护**：写完只在会话没被换掉时（`get().chatHistory === chatHistory`）采纳返回的行 id。
+- 明确「尚未持久化」的项要写下来：参考实现的 `chatTaskWorkspace` 不进 blob（重开旧会话开新工作区，标注为后续工作）；会话级子代理开关也不进（「临时开关不值得为它改格式」）。
+
+---
+
+## 本篇检查清单
+
+- [ ] `TaskWorkspaceHandle { taskId: string | null; ensure(title) }` 懒创建；生命周期归属由 surface 决定（单次任务 per-run，会话 per-session）；备份包含 tasks 目录并写明理由。
+- [ ] task.md：JSON 注释头只放机器状态；步骤只存在于正文复选框（`[ ]`/`[/]`/`[x]`/`[-]`，1 基序号，缩进也算）；小节用语言无关锚点注释定位；损坏元数据返回 null 不抛。
+- [ ] 五个 scratchpad 工具齐全，六条不变式逐条落实：只有 task_plan（真标题）与 write_note（中性标题）建仓、Unicode slug 清洗按码点截断、绝不覆盖（后缀 + renamedFrom）、超限报错不截断、不备份不过审批门、写入串行链放在工作区层。
+- [ ] checkpoint 注入：三档开关默认 off；85% 阈值早于裁剪阈值；提示**发出即撤**（finally splice）；裁剪真丢内容后重新武装。
+- [ ] `onRoundLimit` 返回判别联合 `{extend | finish | pause}`；pause 在轮首退出（history 天然配对完整）；`canPause` 由发起方在撞墙时刻求值 `!!tw.taskId`；每个调用方都处理 `outcome === "paused"`（markTaskPaused + sourceRefs 哈希）；恢复失败回滚 paused。
+- [ ] `buildResumeSeed` = task.md 正文 + notes 索引（只标题/路径/字符数）+ sourceRefs 过期清单 ⇒ 一条全新 user turn，**不重放旧 wire history**。
+- [ ] 排序 GC：已收尾优先淘汰、未完成不豁免、绝不删当前 keepTaskId。
+- [ ] 压缩两不变式：轮边界按消息对象身份、折叠单位是整轮；0.7/0.45 宽间隙；摘要失败返回 null 一字不动（原子性），summary 紧贴 system 保 prompt cache。
+- [ ] 注入台账 `Map<key, {version, carrier}>`：未变不重注、变了重注、carrier 折掉即逐出、模型自读的不入账；@引用三道预算顺序分配，绝不静默截断。
+- [ ] 持久化：身份→索引序列化（解析不到就丢弃）、图片剥离不改原数组、版本不对返回 null 开新会话、旧事件格式有迁移函数、恢复时抬高 `maxTurnId`、persist 带换会话竞态防护。

--- a/docs/ai-agent-playbook/11-pitfalls.md
+++ b/docs/ai-agent-playbook/11-pitfalls.md
@@ -1,0 +1,218 @@
+# 11 · 坑大全（现象 → 原因 → 对策）
+
+全部来自 simple-ai-writer 的代码注释、设计文档与真实事故记录。按主题分组，组内大致按
+危险程度排序——**静默失败在前**（不会报错、只能靠对照发现的最危险）。每条都可以当作
+新项目的回归测试清单。
+
+## A. 协议层 · 静默失败类
+
+1. **Anthropic 不回传 thinking block → 思考静默消失。**
+   现象：无任何报错，模型只是不再思考（唯一判据：响应里还有没有 thinking block）。
+   原因：Anthropic 对不合法思考历史的反应是静默剥离而非 400（DeepSeek 相反：不回传就 400）。
+   对策：工具轮 assistant 消息原样带回全部 thinking/redacted_thinking 块（含 signature，
+   顺序不动）；`redacted_thinking` 只有不透明 data 也要回。
+
+2. **Gemini 中继发 snake_case 图片字段 → 图片静默不可见。**
+   原因：proto3 JSON 让官方 `inline_data`/`inlineData` 两种都收，中继只收文档写的那种，
+   未识别键被忽略而非拒绝。
+   对策（可移植规则）：面向兼容层时，在「官方两种都收」的地方**选中继文档写的那一种**。
+
+3. **换模型不剥 thinking block → 静默计费。**
+   别的模型不拒绝、静默忽略、照 input 计费。对策：回传载体带 `modelId`，不匹配整组丢弃。
+
+4. **`display` 默认 omitted → 付了全额思考费拿不到一个字。**
+   当前代 Claude 的 thinking 默认 `"omitted"`（省延迟不省钱）。对策：恒发
+   `display:"summarized"`（schema 里没这个字段的方言除外——文档没写的不发）。
+
+5. **静默截断 prompt（ollama 等本地栈）。**
+   现象：200 + 看似正常的回复，system 指令悄悄没了。原因：超窗从头部丢弃。
+   对策：发送前 `ContextSizeError` 估算拦截 + 探测 truncation check + 读实际生效的 `num_ctx`。
+
+6. **HTTP 200 + 体内错误的两种拼法。**
+   SSE 体内 `data:{"error":...}`；MiniMax `base_resp.status_code`。只认一种会把过期密钥
+   读成正常空回复。对策：两条错误通道都解析；**「200 且没有任何内容」当可疑而非成功**。
+
+7. **内容拦截在半截文本后到达。**
+   Gemini blocked finishReason / Anthropic `refusal` / OpenAI `content_filter` 都可能在
+   文本已开始流出后到。对策：一律 throw 而非当正常结束——已交付的文本需要作废。
+
+8. **`stream_options.include_usage` 是兼容层最先没实现的东西。**
+   现象：usage 全 0 不报错。对策：照发，但把 0 当「没报」处理；探测标 `no-usage-reported`。
+
+## B. 协议层 · 会响但难排查类
+
+9. **MiniMax Anthropic 端点：turn 停在搜索结果上报 `end_turn`，且拒收自己发的块。**
+   兼容层「响应侧抄全了、请求侧没抄」的典型。对策：以「结果之后模型说话了吗」为续跑
+   判据；续跑退化为纯文本 transcript（见 05 篇）。
+
+10. **tool_calls 流式拼接键用 id → 交错调用拼错。**
+    id 自身也可能分片。对策：按 `index` 分组，id 累积拼接。
+
+11. **强制 tool_choice 撞上思考模型/被砍档端点。**
+    对策：结构化输出必有「强制失败→JSON mode」降级链，降级路径仍带原生 JSON 参数；
+    回退判定正则要求「能力词 + not supported」**同现**——裸子串会把无关上游错误
+    （"does not support streaming for this region"）也吞进回退，翻倍花钱且掩盖真错。
+
+12. **`json_object` 的 "json" 字面量前置条件。**
+    prompt 里没有 "JSON" 字样会报错或产生无限空白流。对策：检测 prompt，缺则追加 cue；
+    prompt 可编辑的系统不能把它当既成事实。
+
+13. **兼容层把思维链塞进正文 `<think>…</think>`，标签跨 chunk 分片。**
+    对策：状态机切分器——只认响应开头、`danglingPrefix` 扣住可能成为标签的尾巴、
+    流结束未闭合按 reasoning flush；切出的思考只展示不回传。
+
+14. **Anthropic base URL 约定与 OpenAI 生态相反。**
+    OpenAI/Gemini 的 base 自带版本段，Anthropic 的 base 是根地址（客户端补 `/v1/messages`）。
+    对策：不对称归一化；绝不给 OpenAI base「修复性」补 `/v1`（中继合法路由在 /v1 之下）。
+
+15. **鉴权头两套一等约定（Anthropic 生态）。**
+    `x-api-key` 与 `Authorization: Bearer` 各有网关只认一种。对策：compat 端点提供
+    default/bearer/both 三模式；官方端点只给 default（api.anthropic.com 拒绝双凭证）。
+
+16. **usage 口径：Anthropic 三桶要相加、Gemini 思考在 candidatesTokenCount 之外。**
+    直接读 `input_tokens` 会少报一个数量级；只读 candidates 会漏掉最贵的思考。
+    对策：归一化为 input/output/cached（cached 是 input 子集）三字段再入库。
+
+## C. Runtime 与工具系统
+
+17. **中断把会话永久搞坏。**
+    现象：停止任务后每个 provider 拒绝后续请求，只能新建对话。
+    原因：assistant 的 tool_calls 已入历史，k<N 的 tool 回复=永久畸形转录。
+    对策：abort 中途逐个补 `[not run]` 桩、配平后才抛 AbortError；外加
+    `repairToolCallPairing` 在每次追加历史前兜底。
+
+18. **助手「只给方案不动手」。**
+    原因 A：agent 指令拼在首轮 user 层，活不过第一轮——必须并入 **system 层**。
+    原因 B：所需工具根本不存在，或轮数中途用尽。对策：补齐工具、放宽 maxRounds、
+    上限时用卡片问作者（extend/finish/pause）而非硬停。
+
+19. **一次性提示变常驻指令。**
+    「本轮别再调工具」「快用 write_note 落盘」等提示留在持久 history 里成永久禁令/命令。
+    对策：**发出即撤**——请求发出后 finally 里 splice 掉。同类事故：作者中断后敲的
+    "continue" 混进 tool_result 信封被跨 39 轮反复重发（对策：合并时给作者文本打标签）。
+
+20. **工具轮叙述混进正文。**
+    「我先去找文件列表。」被插进用户文档。对策：onOutputText 用**快照**语义，工具轮
+    结束整段回滚，只累计以散文收束的轮。
+
+21. **base64 图片挤爆请求体而 token 估算无感。**
+    估算按计费口径记平价，payload 却是 MB 级且跨轮存续。对策：trimHistory 图片优先、
+    无条件、上限 N 张；会话序列化时全部剥离图片。
+
+22. **plan 门控越权洞：file-scoped 步骤放行了无 file 的调用。**
+    「delete Ava / armor.md」（删一个文件）授权了删整个实体。对策：步骤声明了 file，
+    调用就必须给出同一个 file。
+
+23. **审批 apply 不重定位 → 改写作者从未批准的文字。**
+    卡片挂着时作者可能一直在打字。对策：apply 时重新 `find` 定位——消失或出现多于
+    一处都以拒绝回模型；apply 抛错一律 resolve 成拒绝，绝不吞错报成功。
+
+24. **悬挂的审批 Promise 永久卡死后续运行。**
+    对策：每次运行 finally 必 `rejectAll(runId)`；runId=本次运行的 AbortController 对象，
+    保证并行运行互不误杀。
+
+25. **备份失败照写 → 不可恢复的破坏。**
+    对策：「备份失败=写入失败」（backup throw 即写入不发生）；二进制/整目录删除用
+    rename-into-backups 而非 unlink。
+
+26. **空 projectPath = 全盘可读。**
+    路径包含校验是前缀测试，空前缀包含一切绝对路径。对策：显式拒绝空 projectPath；
+    一切模型可控路径参数过 `isPathWithin` 式校验。
+
+27. **模型给的正则会卡死 UI 线程。**
+    搜索工具只做字面匹配、明确拒绝正则（病态 pattern 无法中断）。
+
+28. **模块级常量冻结运行时配置。**
+    注册表 import 时求值一次，动态 enum（如分类表）必须在下发时**拷贝后**注入，
+    不能 mutate 共享常量。
+
+29. **运行快照与磁盘漂移。**
+    move/delete 后同一运行的下一个调用解析到不存在的目录。对策：写工具落盘后手工回填
+    快照；细粒度工具从磁盘读当前状态而非快照。
+
+30. **一次读取附带全部图片 → 35MB 请求超时。**
+    对策：读实体只回文件名+文字描述，真要看再按名取一张；单图字节上限。
+
+## D. 子代理与上下文管理
+
+31. **搜索子代理永远不联网。**
+    原因：`withholdTools` 把「没有本地工具」和「该收尾了」并成一个判断，而 search
+    子代理本地工具恒为空。对策：`serverTools: "final-round-off"|"off"|"always"` 独立
+    策略字段，search 用 always。
+
+32. **子代理产出取到空。**
+    runtime 成文轮直接 return，最终文本从不进 history——事后翻 messages 必空。
+    对策：产出只能经 `onOutputText` 回调捕获（快照赋值）。
+
+33. **委托产出整块回填 = 把堆叠换个地方堆。**
+    对策：落盘 note，tool result 只回「路径 + ≤800 字符摘要」，细节走 read_note 分页。
+
+34. **「启用」当「可用」用，双输。**
+    search 绑了不能上网的模型时，路由照样关掉主模型联网——作者失去主模型联网又什么都
+    没换回来。对策：单一判断函数（开关+绑定+模型存在+能力前置条件），所有调用点共用；
+    设置面板警告但不阻止，下游必须再验。
+
+35. **子代理 AbortError 转成 tool error → 作者的「停止」被读成「搜索失败」而重试。**
+    对策：AbortError 是唯一重抛的异常，其余转模型可读的错误文本。
+
+36. **密钥缺失降级空串 → 要逆向工程的 401。**
+    对策：解析层直接返回指路的配置错误（"去 Settings → Providers 粘 key"），绝不发无钥请求。
+
+37. **`Boolean(handle)` 恒真的假守卫。**
+    routeTools 收 `hasWorkspace: boolean` 而调用方总是无条件构造 handle。
+    对策：守卫参数要传**能真正为空的东西**（handle 本身，undefined 才是没有）。
+
+38. **嵌套日志顶掉主日志行。**
+    子跑 round 也从 1 开始，去重键只有 round/toolCallId 会互相覆盖。
+    对策：事件去重键带 `parentStep`。
+
+39. **ASCII slug 白名单让中文笔记全坍缩进 `note.md` 互相覆盖。**
+    对策：Unicode 属性类 `\p{L}\p{N}` 清洗、按码点截断、绝不静默覆盖（撞名加后缀并告知）。
+
+40. **task_progress 悄悄创建无名工作区。**
+    它的 ensure() 既建了任务又满足了「要求先有计划」的检查。对策：只有 task_plan
+    （真标题）与 write_note（中性标题）能建仓。
+
+41. **步骤数据双事实源打架。**
+    JSON 和正文各存一份步骤，作者手改后不一致。对策：步骤只存在于正文复选框，
+    1 基序号寻址；JSON 注释头只放机器状态。
+
+42. **task.md 小节按标题文本定位 → 换语言后写错位置。**
+    对策：语言无关 HTML 注释锚点（`<!-- task-steps -->`）。
+
+43. **同轮并发写丢更新。**
+    模型一轮可发多个 tool call。对策：工作区写入过模块级 Promise 链串行化，
+    且链放在 workspace 层（写者不止工具，暂停/恢复也在写）。
+
+44. **恢复对话而非恢复任务。**
+    旧 history 里的 "continue" 被当新指令自我强化。对策：resume 种子 = task.md +
+    notes 索引 + sourceRefs 过期清单，**不重放旧 wire history**。
+
+45. **压缩把网络抖动变成坏会话。**
+    摘要失败后仍折叠。对策：失败返回 null、history 一字不动、只在成功后换入新数组。
+
+46. **压缩杀死 prompt cache。**
+    触发线与目标线太近导致每轮都压，每压一次前缀作废。对策：0.7 触发 / 0.45 目标的
+    宽间隙；summary 消息紧贴 system 之后，稳定前缀最大化。
+
+47. **轮边界按索引记录 → repair/trim 后错位。**
+    对策：一切 meta 按**消息对象身份**记录；序列化时身份→索引，反序列化重连，
+    解析不到的引用丢弃而非猜测。
+
+48. **旧格式事件打崩整个 UI。**
+    会话 blob 比写它的代码活得久，事件载荷实际是 wire format。对策：迁移函数，
+    认不出的条目丢弃（丢一行日志值得，丢一个会话不值得）。
+
+49. **GC 豁免未完成任务 ⇒ 无界增长。**
+    对策：「未收尾优先保留但不豁免」的排序 GC；绝不删当前运行持有的任务。
+
+50. **恢复失败留下「在跑」的僵尸任务。**
+    对策：乐观置回 in_progress 后，若启动失败再置回 paused——不留一个声称在跑的任务。
+
+## E. 文档与调研方法
+
+51. **指南页 ≠ 参考页。** 判断能力边界看 API 参考页；大文档抓原文自己搜（网页摘要工具
+    连续漏掉 295KB 参考页里的关键定义，curl+grep 一次找到）。
+52. **兼容层文档四条规律**：结构照抄；扩展在响应侧；枚举是子集；最需要确认的部分
+    （流式格式、错误通道、回传规则）不写且滞后上游一年。推论：兼容层文档不能当能力
+    清单——「没列」按「未知、需实测」处理。

--- a/docs/ai-agent-playbook/12-migration-roadmap.md
+++ b/docs/ai-agent-playbook/12-migration-roadmap.md
@@ -1,0 +1,161 @@
+# 12 · 分阶段落地路线图（按依赖顺序的最小实现清单）
+
+把整套体系搬进新项目的推荐顺序。模块名沿用参考实现（simple-ai-writer）的命名，接口
+签名可直接照抄。标 ★ 的是「没有它其他都白搭」的正确性核心。每个阶段可独立交付、
+独立回退。
+
+## 阶段 0 · 协议层类型与词汇（无依赖）
+
+- [ ] `types.ts`：`ApiStandard`（族 × official/compat）、`familyOf()` ★、`AuthMode` +
+      `authModesFor()`、`ContentPart`/`MessageContent`、`ToolDefinition`/
+      `AssistantToolCall`/`AccumulatedToolCall`、`StreamMessage`（OpenAI 形状 + `_` 前缀
+      载体字段）★、`StreamChunk`（key 判别变体联合）★、`StreamOptions`、
+      `ContextSizeError`、`applyPrefix()`。
+- [ ] `reasoning.ts`：六档强度自有词汇 ★、`ThinkingDialect`、三族翻译表 +
+      `reasoningBody()`/`thinkingBody()`、`NativeReasoning`（原名奉还载体）★、
+      `REASONING_CONTENT_FIELDS` 候选表、`createThinkTagSplitter()` ★。
+- [ ] `urls.ts`：三族默认 base 常量、不对称归一化（`trimBase`/`anthropicRoot`）★、
+      各族 URL 拼接、读取时幂等迁移。
+
+## 阶段 1 · 协议适配器（依赖阶段 0 + 一个 fetch 包装）
+
+- [ ] `openai.ts`：SSE 行缓冲 ★、`_` 前缀剥除 + `_reasoning` 原名回写 ★、index 键
+      tool_calls 累积 ★、`json.error` + `base_resp` 双错误通道 ★、content_filter/length
+      处理、think-tag 切分接入、`stream_options.include_usage`。
+- [ ] `gemini.ts`：消息转换（id→name 表、`_geminiModelParts` 原样回传 ★）、
+      systemInstruction hoist、「chunk 是完整对象不是 delta」★、thought part 分流、
+      三层错误（promptFeedback / blocked finishReason / request-fault 集合）★、
+      `candidatesTokenCount + thoughtsTokenCount` ★、自造 functionCall id。
+- [ ] `anthropic.ts`（最重）：交替律修补 + tool 消息合并 + labelAuthorText ★、三模式
+      鉴权 + pinned 版本头、`max_tokens` 兜底 ★、thinking 方言与 toolChoice 降级、
+      类型化事件解析（块整存）★、usage 三桶求和 ★、refusal/pause_turn；续跑循环
+      （verbatim + transcript）可后补，先把 pause_turn 当已知未完成态报警。
+- [ ] `serverTools.ts`（可选）：版本化 wire type 表、`max_uses` 刹车、两阶段事件、
+      防御读取、纯文本渲染兜底。
+
+**只接 OpenAI 系兼容层时，第一天就要有的三样**：SSE 行缓冲、双错误通道、`<think>`
+切分——它们对应的失败全是静默的。
+
+## 阶段 2 · 统一入口与横切（依赖阶段 1）
+
+- [ ] `index.ts`：`streamCompletion` = familyOf 分发 ★ + prefix 合并 + ContextSizeError
+      预检 + 日志接线。
+- [ ] `jsonMode.ts`：`jsonModeShaping()` ★（Anthropic 无参数只有 cue）、`mentionsJson`
+      前置条件、`extractJsonObject`。
+- [ ] `structured.ts`：强制 pseudo-tool → 收紧正则判定 → JSON mode 回退（仍带原生参数）★。
+- [ ] `apiLog.ts`：JSONL 日志（request / request-body 带 leg / response / error），key
+      永不落盘、图片裁剪、写串行化。**强烈建议第一批做**——后续所有兼容层坑都靠它定位。
+- [ ] `conn.ts`：`ConnOptions`/`connOptions()`/`pickConnOptions()`/`resolveConn()` ★
+      （调用点 ≥3 个时就该收口，别等 16 个）。
+
+## 阶段 3 · 配置与探测（产品层，可后补）
+
+- [ ] Provider/Model 两张表（L2/L3）+ authMode 列（default 存 NULL）+ 读取时幂等迁移。
+- [ ] `providerProbe.ts`：/models 优先 + compat 降级 completion probe（不可能模型名 +
+      错误形状判定）★。
+- [ ] `usage.ts`：persistUsage（best-effort 永不抛）+ rollup 读侧（total 从明细派生）。
+- [ ] `modelHealth.ts`：safety-block 粘性标记。
+- [ ] `endpointProbe.ts` + `probeAnalysis.ts`：四步递进探测；判断逻辑与 HTTP 管线分文件
+      （前者无网络可单测）；探测前告知预估成本。
+
+## 阶段 4 · Agent runtime（依赖阶段 0–2）
+
+- [ ] `events.ts`：AgentEvent 联合 + `appendAgentEventTo`（tool-step/reasoning 原位替换）
+      + `AgentEventScope.parentStep`；`RoundLimitDecision` 放这里（避免 import 环）。
+- [ ] `registry.ts`：`ToolAccess`、`ToolId` 字面量联合、`RegisteredTool`、`ToolContext`
+      （审批/门控/工作区全部**可选通道**）、`Proposal` 判别联合、`getToolDefinitions`
+      （拷贝式动态注入）、`executeRegisteredTool`（白名单类型收窄 + 错误转文本）★。
+      先实现 3–4 个只读工具即可跑通全链路；每个工具：路径包含校验、输出限幅+分页、
+      错误写成下一步指引。
+- [ ] `presets.ts`：`TaskPreset { id, tools, maxRounds, finishPolicy, scratchpad?,
+      serverTools? }` + `presetForTools`（"none" → null 走单发路径）。
+- [ ] `runtime.ts`：`runAgent` 循环 + `trimHistory` + `repairToolCallPairing`。必守
+      五不变量：① 每个 tool_call 必有回复（abort 补桩后才抛）★ ② 无工具调用即完成
+      ③ force-text 最后一轮撤工具 + 临时提示请求后撤回 ④ onOutputText 快照 + 工具轮
+      回滚 ⑤ thinking 回传字段随 assistant 消息保存 ★。
+
+## 阶段 5 · 写入安全（依赖阶段 4）
+
+- [ ] `backup.ts`：写前快照进单一扁平备份目录；**throw = 写入不发生** ★；二进制/整目录
+      删除用 rename-into-backups。
+- [ ] L1 工具模板：参数校验 → 结构校验 → （门控）→ backup → write → 修快照 →
+      onChanged 回调 → 带备份路径的成功回执。
+- [ ] L2 工具模板：可行性预检 → 构造 Proposal → `await ctx.requestApproval` → 决定转
+      结果文本（拒绝理由原样回 + 「勿原样重试」）。
+- [ ] `plan.ts`（若有「批量自动写」域）：PlanGate + checkPlan（实体经索引解析比对；
+      file-scoped 步骤不放行无 file 调用 ★）+ 追加式批准 + 按轮存活。
+- [ ] 审批 store：三队列 + `new Promise(resolve => 入队)` + runId(=AbortController)
+      作用域 + **finally 必 rejectAll** ★；approve = 备份 → apply（find 重定位 ★，
+      活动文档走编辑器 buffer）→ 失败 resolve 成拒绝；turnId/signal 请求时绑定。
+- [ ] 会话双层：chatHistory（wire，交给 runtime 原地长）+ turns（展示）；meta 按消息
+      对象身份记录；每轮 finally best-effort 持久化（序列化剥图片）。
+
+## 阶段 6 · 任务工作区（可独立交付，解掉大半长任务问题）
+
+- [ ] `TaskWorkspaceHandle { taskId: string|null; ensure(title) }` 懒创建句柄；生命周期
+      归属由 surface 决定（单次任务 per-run，会话 per-session）。
+- [ ] `task.md`：JSON 注释头只放机器状态；步骤只在正文复选框（1 基序号）★；小节用
+      语言无关锚点注释。
+- [ ] 5 个工具：task_plan / task_progress / write_note / read_note（行分页）/ list_notes
+      （只给索引）。不变式：只有 plan 与 note 能建仓、Unicode slug 清洗、绝不覆盖、
+      超限报错不截断、写入串行化（链放 workspace 层）、不备份不过审批门。
+- [ ] checkpoint 注入：85% 阈值早于裁剪阈值、**发出即撤** ★、裁剪真发生后重新武装。
+- [ ] 排序 GC（已收尾先淘汰、未完成不豁免、保当前）。
+
+## 阶段 7 · 存盘暂停与恢复（依赖阶段 6）
+
+- [ ] `onRoundLimit` 返回判别联合 `{extend|finish|pause}`；pause 在**轮首**退出
+      （history 天然配对完整）★；`AgentRunResult.outcome`。
+- [ ] `canPause` 由发起方在撞上限那一刻求值；每个调用方都处理 paused（置状态 +
+      记 sourceRefs 哈希）。
+- [ ] `buildResumeSeed`：task.md + notes 索引（只标题路径）+ sourceRefs 过期清单 ⇒
+      一条全新 user turn，**不重放旧 history** ★。
+- [ ] 持久化过事件/会话的：写旧格式迁移函数（认不出的丢弃）。
+
+## 阶段 8 · 子代理（依赖阶段 6）
+
+- [ ] `delegate(kind, task, refs?)` 一个工具；kind 内置枚举（preset 是代码，配置只有
+      「哪个模型、开不开」）。
+- [ ] 每 kind 一个 SUB_PRESET（小轮数、force-text、最小工具集）；执行器 = 嵌套
+      runAgent：全新 2 条消息、独立连接、子 ctx 不传审批/门控/工作区（沙箱）★、
+      共享 signal、AbortError 重抛 ★。
+- [ ] 产出经 `onOutputText` 捕获 ★ → 落盘 note → tool result = 路径 + ≤800 字符摘要 +
+      「细节用 read_note」★；空产出报错不建 note。
+- [ ] 前置校验全在 delegate 里（ctx 齐全、能力条件），失败零副作用；密钥缺失是配置
+      错误不是空串。
+- [ ] 记账：每子跑一行独立 usage（task 打 `subagent:<kind>` 标签）+ 带 parentStep 的
+      嵌套 run-done 事件；事件去重键带 parentStep ★。
+- [ ] `routeTools`：可用性判断走单一函数（开关+绑定+存在+能力前置）★；vision 接管 ⇒
+      删主模型图片工具；search 接管 ⇒ 关主模型服务端搜索；有可用子代理且有工作区 ⇒
+      加 delegate。**改工具集，不写提示词偏好。**
+- [ ] 配置面：每 kind 开关+模型下拉+就地警告（警告不阻止，下游再验）；三处悬空绑定
+      清理；会话 chips 只减不增。
+
+## 阶段 9 · 长会话压缩（与 6–8 正交，可先可后）
+
+- [ ] 轮边界按**消息对象身份**记录 ★；折叠单位是**整轮**（不拆 tool-call 配对）★。
+- [ ] planFold：0.7 触发 / 0.45 目标（宽间隙保 prompt cache）/ 最近 2 轮永不折 /
+      best effort。
+- [ ] 摘要失败返回 null 一字不动 ★；summary 消息紧贴 system。
+- [ ] 注入台账：`Map<key, {version 指纹, carrier 消息对象}>`——未变不重注、变了重注、
+      carrier 折掉即逐出；模型自读的不入账。
+- [ ] @引用内联三预算（单条上限 / 总预算顺序分配 / 图片条数），超预算退化成
+      「名字+路径+读取指令」，绝不静默截断。
+- [ ] 持久化：身份→索引序列化、图片剥离、偏执反序列化（坏了返回 null 开新会话）、
+      事件格式迁移。
+
+## 始终不做（边界即设计）
+
+子代理间通信、并行编排、递归委托、子代理写用户内容、把「要花钱须审批」的动作（如
+生图）塞进静默委托、用工作区替代压缩或用压缩替代工作区、`DeepSeekProvider extends
+OpenAIProvider` 式的供应商子类。
+
+## 迁移时最容易忽略、代价最大的七件事
+
+1. tool_call 配对不变量（含 abort 路径的补桩）。
+2. 每次运行 finally 里的 `rejectAll(runId)`。
+3. 备份失败 = 写入失败。
+4. 审批 apply 时的 find 重定位与失败转拒绝。
+5. 模型可控路径参数的包含校验（含空前缀陷阱）。
+6. thinking/签名类载体的原物整存与按 modelId 剥离。
+7. 一次性提示的「发出即撤」。

--- a/docs/ai-agent-playbook/README.md
+++ b/docs/ai-agent-playbook/README.md
@@ -1,0 +1,93 @@
+# AI Provider 协议层 + Agent/子代理体系 · 复用规范文档集
+
+这套文档提炼自 simple-ai-writer（Tauri + React 桌面写作应用）的 AI 层实战：它同时对接
+OpenAI Chat Completions、Google Gemini generateContent、Anthropic Messages 三个协议族与
+大量第三方兼容中继（New API、MiniMax、DeepSeek、OpenRouter、Ollama、LM Studio…），并在
+统一 tool loop 之上实现了权限分级、审批通道、子代理委派与长会话上下文管理。
+
+文档以**通用规范**口吻撰写，可直接放进新项目的 `docs/` 作为搭建标准；关键处均标注
+simple-ai-writer 的参考实现文件，迁移时可对照抄写接口与骨架。
+
+## 目录
+
+### A. 协议层（多家 AI API 的统一封装）
+
+| 篇 | 主题 | 一句话 |
+| --- | --- | --- |
+| [01](01-provider-layering.md) | 分层模型与统一抽象 | L1 协议族 / L2 端点 / L3 模型 + 探测维；加一家供应商 = 加一行数据，不是加一个文件 |
+| [02](02-protocol-differences.md) | 三家协议差异对照 | 消息/工具/流式/鉴权/URL 的逐字段对照表与适配器转换规则 |
+| [03](03-reasoning.md) | 思考/推理统一处理 | 强度、取回、回传义务三分；跨轮回传的东西原物整存 |
+| [04](04-structured-output.md) | 结构化输出与降级链 | 强制 pseudo-tool → 收紧判据 → JSON mode 回退 |
+| [05](05-tools-and-server-tools.md) | 工具协议与 server tools | tool_call 配对不变量；pause_turn 续跑循环 |
+| [06](06-errors-probing-observability.md) | 错误、usage、探测与可观测性 | HTTP 200 ≠ 成功；API 日志是兼容层第一调试工具 |
+
+### B. Agent 体系（tool loop、工具系统、写入安全）
+
+| 篇 | 主题 | 一句话 |
+| --- | --- | --- |
+| [07](07-agent-runtime.md) | tool loop、preset 与事件系统 | runtime 只做循环不做策略；出散文即完成；abort 也必须配平 |
+| [08](08-tool-registry-and-write-safety.md) | 工具注册、权限分级与审批 | read / write-auto（备份先行）/ write-approval（Promise 挂起等卡片） |
+
+### C. 子代理与长会话
+
+| 篇 | 主题 | 一句话 |
+| --- | --- | --- |
+| [09](09-subagent.md) | 子代理机制 | 子代理只是一个工具；产出落盘，只回摘要+路径；路由=改工具集 |
+| [10](10-context-management.md) | 工作区、压缩与会话持久化 | 记忆落盘 + 轮间折叠 + 轮内裁剪 + checkpoint 四层防线 |
+
+### D. 横切
+
+| 篇 | 主题 |
+| --- | --- |
+| [11](11-pitfalls.md) | 坑大全（现象 → 原因 → 对策，按危险程度与主题分组） |
+| [12](12-migration-roadmap.md) | 分阶段落地路线图（按依赖顺序的最小实现清单） |
+
+## 体系鸟瞰
+
+```
+UI（面板 / 对话 / 各类 modal）
+   │  以 TaskPreset 启动，提供回调（onEvent / onOutputText / requestApproval…）
+   ▼
+会话 store          审批三队列（proposal/plan/roundLimit，runId 作用域）
+                    + chatHistory（wire 数组）/ turns（展示层）双层会话
+   ▼
+agent/runtime       runAgent：多轮 tool loop、trimHistory、checkpoint、round-limit、abort 配平
+agent/registry      REGISTRY：工具定义 + access 分级 + 执行器；ToolContext 钩子
+agent/presets       TaskPreset：tools / maxRounds / finishPolicy / scratchpad / serverTools
+agent/subagent      delegate 工具：嵌套 runAgent，产出落盘 note，只回摘要+路径
+agent/taskWorkspace .ai-writer/tasks/<id>/{task.md, notes/}：可暂停、可恢复的磁盘记忆
+agent/compact       轮间折叠压缩（0.7 触发 / 0.45 目标，保 prompt cache）
+   ▼
+ai/index            streamCompletion：familyOf 分发 + 预检 + 日志接线
+ai/{openai,gemini,anthropic}   每协议族一个 adapter（供应商是数据行，不是子类）
+ai/reasoning        六档强度词汇、thinking 方言、思维链切分与回传载体
+ai/conn             ConnOptions 配置收口（加字段 = 改一处）
+```
+
+## 六条贯穿性设计原则
+
+比任何单条协议事实都耐用，全部文档反复引用：
+
+1. **每协议族一个 adapter，供应商是数据行不是子类。** 只有「body 形状不同」才配一个
+   枚举值；鉴权、默认值、私有字段全用配置数据表达。（01 篇）
+2. **最小公倍数发送、最大宽容接收。** 主动发出的每个字段都是某个中继可以 400 的字段；
+   官方端点可乐观，兼容端点不行。（01/02/03 篇）
+3. **凡跨轮回传的，原物整存。** thinking blocks、thoughtSignature、encrypted_content、
+   reasoning 的字段名——「理解后重建」恰好丢掉的就是完整性校验依赖的那部分。（03/05 篇）
+4. **先问失败会不会响。** 会响的（400）靠错误驱动降级即可；不响的（静默降级/截断/忽略）
+   必须主动验证，且只有这类才值得预先花设计预算。（03/06 篇）
+5. **runtime 只做循环，策略全在数据（preset）里；权限不在 runtime 执行，在工具执行器
+   内执行；能力以「通道在不在」表达。** 同一注册表在不同界面自动降级。（07/08 篇）
+6. **协议完整性是生死不变量。** 每个 tool_call 必有配对回复（abort 中途也要补桩）；
+   history 即会话，一次畸形永久报废。（05/07 篇）
+
+## 如何使用这套文档
+
+- **新项目起步**：直接读 [12 落地路线图](12-migration-roadmap.md)，按阶段勾检查项；
+  每个阶段的细节回到对应主题篇。
+- **只接一个协议族**：读 01/06 + 对应族在 02/03 中的列即可。
+- **排查线上怪问题**：先查 [11 坑大全](11-pitfalls.md)——大部分「看起来成功其实失败」
+  的现象都有先例。
+- **对照源码**：参考实现均位于 simple-ai-writer 仓库的 `src/lib/ai/`、`src/lib/agent/`、
+  `src/stores/`；设计文档见其 `docs/`（provider-standards、subagent-lld、
+  unified-agent-plan 等）。

--- a/docs/plans/2026-08-ai-improvement-plan.md
+++ b/docs/plans/2026-08-ai-improvement-plan.md
@@ -1,0 +1,271 @@
+# AI 能力改进计划与高层设计（2026-08）
+
+**输入**：[2026-08 AI 能力审查报告](../reviews/2026-08-ai-capability-review.md)（下称「审查报告」）+ [ai-agent-playbook](../ai-agent-playbook/README.md)（下称 playbook）+ 产品决策（见 M3 前提）。
+**性质**：路线计划 + 高层设计（HLD）。不含逐行实现；每个里程碑开工前按此文档拆实现任务。
+
+---
+
+## 0. 总览
+
+三个里程碑，按依赖与风险排序：
+
+| 里程碑 | 内容 | 规模 | 依赖 |
+| --- | --- | --- | --- |
+| **M1 · Bug 修复** | 审查报告 P0 五项 + 顺手的 P1 小项，外科手术式修复 | 小（数天） | 无 |
+| **M2 · 协议层重构** | 把「加固模式」从散落的实现提炼为共享机制，Gemini 路径对齐，纪律清零 | 中（1–2 周） | M1（M1 的两个小 helper 是 M2 的种子） |
+| **M3 · 知识库子代理** | delegate 工具 + 可复用子代理循环 + 笔记存储；识图留在主模型 | 大（分三期） | 与 M2 无硬依赖，M1 后即可并行 |
+
+原则（来自 playbook 12 路线图）：每个里程碑独立交付、独立回退；每期结束 `flutter analyze` 零问题 + 新增测试钉住不变量。
+
+---
+
+## 1. M1 · Bug 修复排期
+
+审查报告 §3/§6 的 P0 项，全部按「目标形态」修（即 M2 要提炼的共享 helper 在这里首次落地，避免修两遍）：
+
+| # | 项 | 位置 | 做法 | 测试 |
+| --- | --- | --- | --- | --- |
+| 1 | Gemini 流式 SSE（B1） | `gemini_chat_protocol.dart:178-197` | 跳过 `event:` 行 → 改用共享 `sseDataPayload` → catch 只吞解析错误，错误信封在 try 外抛 | 新增 `test/gemini_stream_test.dart`：无空格 `data:`、注释行、`data: [DONE]`、裸 event 行四用例 |
+| 2 | 状态码优先 + 形状保护（B2） | gemini_chat / imagen / veo | 新增共享 `decodeJsonBody()`（见 M2 §2.2，M1 先落最小版）并让三处 Gemini 协议接入 | HTML 502 → 报错含状态码；JSON 数组 body 不炸 |
+| 3 | Imagen 零图抛错（B3） | `gemini_imagen_protocol.dart:76-90` | `images.isEmpty` → throw（附 body 摘要），对齐 openai/xai images | 空 predictions 用例 |
+| 4 | 计费遗漏（B4） | `llm_service.dart` | ① Imagen 返回非空 metadata（至少 request 计数信息）；② `startLongRunning` 成功后记一行 usage（request_count=1、token 0） | usage 落库断言 |
+| 5 | `_isRetryable`（B5） | `llm_service.dart:161` + 各协议 | 引入 `LLMApiException`（见 M2 §2.1）最小版：先让 Gemini/openai/anthropic 的非 200 抛结构化异常，`_isRetryable` 优先读 `statusCode`，字符串正则仅作 legacy 兜底且收窄锚定 | `retry after 500ms` 不重试；真 502 重试 |
+
+顺手项（同 PR 或紧随）：rename agent 补桩或注释声明前提（B10）、debug logger 递归长串裁剪（B9，机制级，一处改动覆盖全协议）、MJ 非流式超时豁免（B7）。
+
+**退出标准**：审查报告 §3 的 B1–B5 状态翻绿；`flutter analyze` 零问题；上表测试全部落仓。
+
+---
+
+## 2. M2 · 协议层重构 HLD
+
+### 2.1 目标与非目标
+
+审查结论是：协议层的**骨架是对的**（三层收窄、单点路由、配对纪律），问题在于加固模式靠「逐协议手工复制」传播，Gemini 路径掉队、xai/videos 各漏一块。所以这不是推倒重来，而是**把加固模式下沉为共享机制，让协议实现无法再漂移**。
+
+非目标：不改三层架构本身；不改 wire 类型（`LLMMessage`/`LLMResponse`）；不动 Anthropic 路径已验证的实现（它是标杆，只往它看齐）。
+
+### 2.2 四个共享机制（下沉到 `protocols/protocol.dart` / 新文件）
+
+**① `LLMApiException` — 结构化错误（替代字符串捞状态码）**
+
+```dart
+class LLMApiException implements Exception {
+  final int? statusCode;      // HTTP 状态码；body 内错误信封时为 null
+  final String message;       // 人类可读，含 body 摘要（≤500 字符）
+  final Uri? url;             // playbook 6.15：错误一律带实际请求 URL（脱敏后）
+  final bool isEnvelope;      // 200 + body 错误信封
+}
+```
+
+- 所有协议的非 200 与信封错误统一抛它；`throwIfEnvelopeError` 改抛它。
+- `_isRetryable` 变成：`e is LLMApiException ? (5xx || 429) : (Timeout/Socket)`——彻底废掉三位数正则（B5 根治）。
+- URL 入异常前过 `redactUrl`（playbook 6.16：错误消息永不带 key）。
+
+**② `decodeJsonBody(http.Response response, {Uri? url})` — 统一响应解码**
+
+固化「正确顺序」：先判状态码（非 2xx → `LLMApiException` 带状态码+摘要）→ `jsonDecode`（FormatException → 明确的「端点返回了非 JSON（HTML？）——base URL 可能指向了不是 API 的东西」，playbook 6.34）→ 形状保护（非 Map → 报错）→ `throwIfEnvelopeError`。**10 个协议全部迁移到它**，逐协议手写的 decode 顺序从此不存在。
+
+**③ SSE 消费统一**：`sseDataPayload` 已存在（`protocol.dart:170`），M2 把三个流式协议（openai/gemini/anthropic）的行处理收敛为同一骨架（跳 `event:` 行 → `sseDataPayload` → 宽容 decode → 信封检查在宽容 try 之外）。openai 路径已是这个形状，gemini 在 M1 对齐，M2 补 anthropic 侧核对 + 把骨架写进 dartdoc 作为新协议模板。
+
+**④ debug 日志机制级脱敏**：`LLMDebugLogger._sanitize` 增加协议无关的递归裁剪（任何 >2048 字符的字符串截断为 `<N chars omitted>`，playbook 6.26），废除逐协议手工 safe-payload 的必要性（已有的保留不动）。URL 落日志前统一 `redactUrl`（消除对 `_sanitize` 正则兜底的依赖）。
+
+### 2.3 纪律清零（审查报告 §4）
+
+| 项 | 目标形态 |
+| --- | --- |
+| V1 硬编码 Bearer | `openai_videos` submit 改 `request.headers.addAll(target.headers())`（照 `openai_images:61-68` 的既有修法，multipart 移除 Content-Type） |
+| V2 `mock-` 嗅探 | `ModelDescriptor.isMockModel` getter，dispatcher 消费 |
+| V3 wizard 嗅探 | 删除 contains 链，调用 `ModelFamilyClassifier.inferTag` |
+| V4 裸 vendor id | `Vendors` 上补齐 id 常量，wizard/edit dialog 全部替换；`database_migrations.dart` 在 llm-three-layer.md 红线清单补「迁移代码冻结豁免」条款 |
+| V5 下载认证头 | `VendorProfile.downloadHeaders(String apiKey)`（按 auth scheme 返回正确头），`task_executors` 消费 |
+| 备注项 | `isNijiVariant`/`acceptsImageInput` 的 id 规则收拢进 classifier/capabilities 表（Layer 3 内部整理） |
+
+完成后更新 [llm-three-layer.md](../architecture/llm-three-layer.md) 的 greppable 红线清单并全仓 grep 验证清零。
+
+### 2.4 覆盖补齐
+
+- `checkOperation` 对 MJ 返回原始任务 JSON、对其他家族返回 Veo 信封的契约不统一 → 统一为 Veo 信封（dispatcher 内翻译，调用方已按信封消费）。
+- `redacted_thinking` 原物留存（审查 B6）：`LLMMessage` 增加不透明块载体（`List<Map> rawThinkingBlocks`，带 modelId，playbook 3.27/G3），④ 解析侧留存、回传侧按原序还原、换模型整组剥离。此项动 wire 类型持久化，放 M2 尾期单独 PR。
+
+### 2.5 可选扩展（M2+，按需单独立项）
+
+- **①族 reasoning 请求侧**（playbook 03 六档词汇 + 按族翻译表）：现有 `enableThinking` 布尔升级为强度档位，④ 现行为不变，①族翻译为 `reasoning_effort`。
+- **渠道「测一下」按钮**（playbook 6.31-6.35）：`/models` 优先 + 错误形状判定 + compat 降级。
+
+### 2.6 退出标准
+
+analyze 零问题；红线 grep 清零；`test/gemini_stream_test.dart` + `decodeJsonBody` 单测 + usage 覆盖断言全绿；`docs/architecture/llm-three-layer.md` 更新（新协议接入模板指向共享机制）。
+
+---
+
+## 3. M3 · 知识库子代理 HLD
+
+### 3.1 前提与产品决策
+
+- **本项目主力模型默认多模态** → **识图（`view_image`）留在主模型**，不做 vision 子代理。这是对 playbook 09 的有意偏离（playbook 的 vision 接管前提是主模型可能纯文本），记录为本项目的决策。
+- 子代理负责**知识库检索/通读**：把「读很多页 markdown、消化、给结论」这种上下文灾难型工作移出主上下文。
+- 写入（`write_knowledge_file`）**永远留在主模型**：审批链（staging → Apply 卡片）与 read-before-write 铁轨都锚定在主会话，子代理是只读沙箱（playbook 9.28/9.53②）。
+
+### 3.2 目标 / 非目标
+
+**目标**
+1. 主上下文不再被 KB 原文淹没：研究产出以「摘要 + 笔记引用」回到主对话（playbook 9.3「工作区是总线」）。
+2. 研究深度与主会话剩余窗口解耦：子代理在自己的全新上下文里翻页，read cap 按**它自己的**模型窗口计算。
+3. 主会话 context-exhausted 后仍能继续研究：现在 `read_knowledge_file` 被摘掉就断粮（`prompt_optimizer_agent.dart:1058`），此后 delegate 仍在。
+
+**非目标**（playbook 9.64-9.71 逐条对齐）：不做子代理间通信、不做并行编排、不做递归委托（子代理工具集不含 delegate）、不做自定义子代理种类/自定义 system prompt、不做 fallback 链（绑定失效就报配置错误，不静默退回主模型）、写入与审批动作不进子代理。
+
+### 3.3 架构总览
+
+```
+PromptOptimizerAgent.runTurn（主循环，不变）
+   │  工具集组装（§3.6 路由）
+   ├─ delegate 工具 ──→ SubAgentRunner.run（新，可复用有界 tool loop）
+   │                       │  全新 2 条消息（零上下文渗透，playbook 9.53③）
+   │                       │  工具：list_knowledge_files / read_knowledge_file
+   │                       │  自己的 ContextBudget（子代理模型的窗口）
+   │                       ▼
+   │                    产出文本 ──→ AssistantNoteStore 落盘（§3.7）
+   │                       │
+   │  tool result ◄────────┘  {status, note: {id, title}, summary ≤800字符}
+   ├─ read_note 工具 ──→ 分页读回笔记（复用 pageBoundaries）
+   └─ read_knowledge_file（保留！§3.6）
+```
+
+### 3.4 `SubAgentRunner` — 可复用的有界 tool loop（新文件 `lib/services/sub_agent_runner.dart`）
+
+从 `runTurn` 的经验提炼，但**不是**重构 `runTurn`——是一个独立的、无持久化、无 UI 耦合的小循环（playbook 9.52：子代理就是一次嵌套的 agent 调用，前提是循环可重入）：
+
+```dart
+class SubAgentResult { final String output; final bool cancelled; final int turnsUsed; }
+
+class SubAgentRunner {
+  static Future<SubAgentResult> run({
+    required dynamic modelIdentifier,
+    required String systemPrompt,
+    required String task,                    // 现场构造的 user 消息
+    required List<LLMTool> tools,
+    required Map<String, dynamic> Function(LLMToolCall) executeTool,  // 同步执行器
+    int maxTurns = 6,
+    bool Function()? isCancelled,
+    void Function(String)? onLog,            // 嵌套日志（前缀由调用方加）
+    String? contextId,
+  });
+}
+```
+
+**不变量**（每条都有 playbook 出处，测试钉住）：
+1. **配对纪律与主循环同标准**：工具异常 → error 结果；批内取消 → 剩余调用逐个补 `cancelled` 桩，配平后才返回（G6/7.19-7.21）。实现上把 `runTurn` 的补桩逻辑提炼为共享私有 helper 供两处使用，顺便解决审查 B10 指出的双标准问题（`ai_rename_agent` 后续也迁移到它）。
+2. **最后一轮撤工具强制成文**（playbook 7.12 `withholdTools`）：`turn == maxTurns - 1` 时不发 tools，逼出散文交付。子代理不打扰用户，撞上限就收尾（playbook 9.58）。
+3. **产出 = 最后一条纯文本回复**（本项目是同步循环，最终文本就是返回值，不存在 playbook 9.13 的 onOutputText 陷阱——但在 dartdoc 里记录这个差异，防止未来改流式时踩坑）。
+4. **空产出 → 调用方收到 error 结果，不建笔记**（playbook 9.18）。
+5. **取消传播**：`isCancelled` 透传主任务的取消信号；子循环取消后 `SubAgentResult.cancelled = true`，delegate 执行器返回 `{'status':'cancelled'}`——与主循环既有的取消桩语义一致（playbook 9.19 的 AbortError 语义在本项目的协作式取消模型下等价于此）。
+6. **自己的上下文预算**：用子代理模型自己的 `context_window` 建 `ContextBudget`，`read_knowledge_file` 的 per-call cap 按子循环内的 occupied 重算（复用现有公式）；子循环不做 elide/compact——6 轮的循环装不满就不需要，装满即强制成文。
+
+### 3.5 `delegate` 工具契约
+
+进 `_knowledgeTools` 同级的新常量组（仅在子代理可用时进入工具集，§3.6）：
+
+```json
+{
+  "name": "delegate",
+  "description": "把一个知识库研究任务交给子代理。子代理看不到本对话的任何内容——把它需要知道的全部背景写进 task。它会自行检索并通读知识库，把完整发现存为一条笔记，返回摘要。",
+  "parameters": {
+    "kind":  { "enum": ["knowledge"] },
+    "task":  { "type": "string" },
+    "paths": { "type": "array", "items": {"type": "string"}, "description": "可选：点名要读的 KB 文件相对路径" }
+  },
+  "required": ["kind", "task"]
+}
+```
+
+- `kind` 现在只有一个值，但保留枚举位——未来加种类（§3.10 任务拆分）= 加数据不加协议（playbook 9.6-9.7）。
+- description 直接教模型「零上下文继承」（playbook 9.8）；措辞领域中性（9.9）。
+- **有 paths / 无 paths 是两个 prompt 模板**，不是一个模板插空串（playbook 9.12 不变量，曾是真实 bug；用测试钉住）。
+- 执行器前置校验零副作用（playbook 9.56-9.57）：kind 合法、task 非空、子代理可用（§3.8 单一判断函数）、KB 可用；任一失败 → error 结果指路，不发请求不建笔记。
+- 子代理 system prompt 是代码资产（i18n 键），不可用户自定义（playbook 9.25）；内容要点：你是知识库研究员、先 list 后按需分页 read、输出结构（结论 + 依据文件路径 + 未决问题）、引用时带相对路径。
+- tool result 形状（playbook 9.16-9.17）：
+
+```json
+{ "status": "ok",
+  "note": { "id": 3, "title": "…" },
+  "summary": "≤800 字符 —— 够判断要不要展开读，不够替代读笔记" }
+```
+
+### 3.6 能力路由 = 改工具集（playbook 9.36）
+
+改动点即现有组装处 `prompt_optimizer_agent.dart:978-986`：
+
+| 条件 | 工具集变化 |
+| --- | --- |
+| 子代理可用 且 mode ∈ {knowledgeBase, knowledgeEdit} | **追加** `delegate` + `read_note` |
+| 子代理不可用 | 完全不出现（模型幻觉调用 → 既有 default 分支的 error 结果自纠，不加特例映射，playbook 9.43） |
+| contextExhausted（`:1058`） | 现行为：摘 `read_knowledge_file`。新行为：摘 `read_knowledge_file`，**保留 `delegate` 与 `read_note`**——耗尽后研究能力不清零 |
+
+**与 playbook 9.38（vision 接管）的两处有意偏离，记录进架构文档**：
+1. `view_image` 不路由走（产品决策：主模型多模态）。
+2. `read_knowledge_file` **不被 delegate 接管**（对齐 playbook 9.41 longread 判据：主模型定点读一小段是日常工作，接管只针对「造成上下文灾难」的通读；且 **read-before-write 铁轨锚定在主会话的活读上**——`_liveReadPages` 只认主 history 里的 `read_knowledge_file` 结果，笔记与子代理的读**不授权写入**，knowledgeEdit 模式因此必须保留主模型直读）。工具 description 分工引导：`read_knowledge_file` 注明「定点读已知文件/写前必读」，`delegate` 注明「跨文件研究、找答案、不确定读哪些时用」。
+
+### 3.7 笔记存储 `AssistantNoteStore`
+
+playbook 9.3「产出落盘，只回摘要+路径」的本项目形态。KB 是本地可重读的，笔记的价值是**已消化的研究结论可廉价复取**（否则复问 = 再跑一次子代理）。
+
+- **新表** `assistant_notes(id, session_db_id → assistant_sessions ON DELETE CASCADE, slug, title, content, created_at)` + repository；随会话保留策略一起 GC（复用 `enforceRetention` 的删除路径）。
+- **会话作用域**：笔记属于会话（同 playbook 10.5 chat 场景 per-session 判断）；跨重启随会话恢复——`fromStored` 重建时 delegate 调用映射为惰性 chip（笔记在 DB，`read_note` 重启后仍可读，比 kbEdit 卡片的处境好）。
+- **约束**（playbook 10.29/10.33/10.35/10.36）：slug 用 Unicode 属性类清洗（`\p{L}\p{N}-`，中文标题不得坍缩）；撞名加 `-2` 后缀并在结果中告知；单笔记上限 64k 字符，**超限报错不截断**；绝不覆盖。
+- **`read_note` 工具**（read）：`{note_id, page?}`，复用 `KnowledgeBaseService.pageBoundaries` 的分页（页大小 8000，页号稳定规则同 KB 读），受既有 read cap 闸门管；结果进入既有 elide 规则（>300 字符的 tool result 会被折叠——「读过即忘、随时再读」与 KB 读一致）。
+- **明确不做**：笔记不授权写入（§3.6）；不做跨会话共享；不做磁盘任务工作区（本项目没有 pause/resume 需求时，SQLite 会话作用域已够——若未来做断点续跑再按 playbook 10.1-10.5 升级，两套设计兼容）。
+
+### 3.8 配置与可用性
+
+- 设置页新增：知识库子代理开关 + 模型选择（默认「跟随会话模型」；可绑更便宜的长上下文模型）。应用级偏好，不入项目/会话（playbook 9.29）。
+- **单一可用性函数**（playbook 9.44-9.45，防「启用≠可用」双输）：
+
+```dart
+/// 唯一答案：开关开 && (跟随会话 || 绑定模型仍存在且 enabled)
+static Future<bool> knowledgeDelegateAvailable(sessionModelId) …
+```
+
+  路由（§3.6）、设置页警告、transcript chip 显隐全部走它。绑定模型被删 → 不可用（设置页就地警告，不静默退回，playbook 9.46-9.47）。
+- 首期默认**关**（灰度），行为可整体回退（playbook 10.40 精神）。
+
+### 3.9 计费、日志与 UI
+
+- **计费**：子代理每次 LLM 请求经现有 `LLMService.request` 自动落 usage（模型 id 记的是子代理模型，天然正确）。补：`options` 透传一个 usage 标签（`task: 'subagent:knowledge'`）以便 metrics 页聚合（playbook 9.20）——需要 `_recordUsage` 接受调用方 task_id，属小改。
+- **transcript**：新 entry kind `subagent`（折叠卡：task 摘要 → 运行中 spinner → 完成后摘要 + 笔记 chip）；子循环的 onLog 以 `[KB 子代理]` 前缀并入任务日志。恰好落在审查 §5.7 可观测性改进的同一批 UI 工作里，建议同期做停止按钮。
+- **失败呈现**：子代理 LLM 报错 → error 结果回主模型（含「可自行用 read_knowledge_file 继续」的指引，playbook 8.9 错误写成下一步动作）；不中断主 turn。
+
+### 3.10 展望：任务拆分（M3.3，本期只留接口）
+
+`kind` 枚举的扩展方向（每个都是「加数据行」）：
+- `draft`：批处理场景按参考图逐张起草 prewrite prompt（主模型只做终审合成）——最对症的第二个 kind，因为批量草稿正是「上下文灾难型」工作。
+- `longread`：通读单个超长 KB 文件出结构化提要。
+扩展前提：M3.1/3.2 的 SubAgentRunner 与笔记存储已稳定。**不做**并行编排——同轮多个 delegate 顺序执行（playbook 9.63）。
+
+### 3.11 分期与退出标准
+
+| 期 | 内容 | 退出标准 |
+| --- | --- | --- |
+| **M3.1** | SubAgentRunner + delegate（digest-only：结果只回 ≤2000 字符摘要，暂无笔记）+ 设置开关（默认关） | Runner 单测（配对/取消桩/最后轮撤工具/空产出）；模板不变量测试（有/无 paths）；路由测试（不可用→无工具；exhausted→保留 delegate）；真机验证一次典型 KB 研究任务的主上下文占用对比 |
+| **M3.2** | AssistantNoteStore + `read_note` + summary 收敛到 800 + 会话恢复 chip + usage 标签 | 笔记 CRUD/GC/恢复测试；elide 对 read_note 结果生效；`flutter test test/screenshots` 过 transcript 新卡片 |
+| **M3.3** | `draft` kind（批处理拆分）——单独立项再细化 | — |
+
+### 3.12 风险与开放问题
+
+1. **子代理模型不支持工具调用**（审查 §5.1 的老问题在子代理复现）：子循环连续纯文本但无交付时，把最后文本当产出返回（force-text 语义天然兜住）；若首轮即散文且无任何工具调用，结果照收——研究质量差但不失败。设置页对绑定模型无诊断信号的问题记录在案，依赖 M2+ 的探测项。
+2. **摘要质量**：主模型可能只看 800 字符摘要不读笔记导致引用失真。缓解：摘要模板强制含「依据文件路径」列表；不够再调。
+3. **read-before-write 的交互成本**：knowledgeEdit 模式下模型可能先 delegate 研究、被写入拦截后再直读一遍目标文件（多一轮）。接受此成本——它正是铁轨在起作用；description 引导「要改哪个文件就直接 read_knowledge_file 它」。
+4. **同轮多个 delegate**：顺序执行，耗时叠加且 UI 只有 spinner。M3.1 观察真实调用形态，必要时在子代理 system prompt/description 引导单次委托。
+
+---
+
+## 4. 执行顺序建议
+
+```
+M1（bug 修复，数天）
+ ├─→ M2（协议层重构，1–2 周，含纪律清零与覆盖补齐；M2+ 可选项单独立项）
+ └─→ M3.1（子代理 MVP，默认关）→ M3.2（笔记存储）→ M3.3（任务拆分，另行细化）
+```
+
+M2 与 M3 无硬依赖，可按人力并行；共同的前置只有 M1（M3 的 SubAgentRunner 会复用 M1 里为 rename agent 补桩时提炼的配对 helper）。

--- a/docs/reviews/2026-08-ai-capability-review.md
+++ b/docs/reviews/2026-08-ai-capability-review.md
@@ -1,0 +1,293 @@
+# AI 能力实现审查报告（2026-08）
+
+**审查基准**：[docs/ai-agent-playbook/](../ai-agent-playbook/README.md)（README + 01~12，六条贯穿性原则 + 52 条坑清单）
+**审查范围**：协议层 `lib/services/llm/`（全部 25 个文件）+ Agent 体系（`prompt_optimizer_agent.dart`、`ai_rename_agent.dart`、`context_budget.dart`、`knowledge_base_service.dart`、task executor 中的 agent 调用方）
+**方法**：三路并行探索（playbook 规范提炼 / 协议层现状 / Agent 与上下文现状）→ 逐条人工读代码核实行号与语义 → 按「违反 / 真 bug / 合理取舍」三分归类。所有条目均标注对应 playbook 编号（Gx=贯穿原则，Px=坑清单，数字=主题篇条目）。
+
+---
+
+## 1. 总评
+
+本项目的 AI 层整体成熟度高于 playbook 所警示的大多数反面案例：三层架构（协议/vendor/模型）的层间收窄、tool-call 配对纪律、写入审批安全这三块不是模板代码，而是与 playbook 同源的「踩坑后写回去」的实现，多处不变量有 dartdoc 论证和测试钉住。
+
+审查发现的问题集中在四处：
+
+1. **Gemini 路径是三个协议族中最旧的一条**，没有跟上 openai/anthropic 已完成的两轮加固（共享 SSE helper、状态码优先、`is Map` 保护、空结果抛错）。本报告确认的高严重度 bug 几乎全部落在这里（§3 B1–B4）。
+2. **纪律执行有 5 处漏网**，其中硬编码 Bearer 和 setup wizard 的 id 嗅探直接违反项目自己在 [llm-three-layer.md](../architecture/llm-three-layer.md) 写明的红线（§4）。
+3. **计费有系统性遗漏**：Imagen 与全部视频生成（Veo/Sora/xAI）不产生任何 usage 记录（§3 B4）。
+4. **与 playbook 的最大结构性差距**在 Agent 体系：无子代理/任务工作区、无结构化输出降级链、无能力探测、prompt cache 零考虑（且 elide 机制每轮击穿隐式前缀缓存）。这些是设计缺口而非 bug，按路线建议列出（§5）。
+
+---
+
+## 2. 符合项（与 playbook 对齐的部分，审查时确认不应改动）
+
+| 实现 | 位置 | 对应 playbook |
+| --- | --- | --- |
+| `LLMTarget` 把 vendor 收窄为 `headers()`/`decorateUrl()` 两个出口，协议层拿不到 `vendor.id` | `protocols/protocol.dart:24-39` | G1、G5 |
+| dispatcher 单点路由，4 个穷尽 switch 全按 `vendor.family` 一级分支；`vendor.id ==` 全仓 0 处 | `llm_dispatcher.dart` | 1.9 红线 |
+| 供应商是数据行：`VendorProfile` 仅 5 个字段，12 个 profile 全声明式；`decorateUrl` 穷尽 switch 防止新 auth scheme 继承 `?key=` 约定 | `vendors/vendor_profile.dart:93-180` | G1、2.26 |
+| `ChatProtocol.generateStream` 签名级禁止流式工具调用（注释写明 arguments 跨 chunk 分片、index 才是分组键的理由） | `protocols/protocol.dart:44-72` | 2.10、P10 |
+| 跨轮回传原物整存：①族按 `reasoningFieldName` 原名奉还、③族 `thoughtSignature` 逐 part 回传、④族 thinking block+signature 整块回传且排在 text/tool_use 之前、无签名则不发 | `openai_chat_protocol.dart:770-773`、`gemini_payload.dart:310-318`、`anthropic_chat_protocol.dart:102-128` | **G3**、3.23-3.27、P1、P3 |
+| 只在带 tool_calls 的 assistant 轮携带 reasoning 回传 | 同上 | 3.26 |
+| Anthropic usage 三桶求和后以 inclusive `prompt_tokens` 发布；`_extractCacheTokens` 三家 key 归一化且 clamp 防负数 | `anthropic_chat_protocol.dart:401-432`、`llm_service.dart:294-309` | 6.1-6.3、P16 |
+| 「200 但空响应必须抛」贯彻 openai / anthropic / gemini_chat 同步路径三处 | `openai_chat_protocol.dart:379-386`、`anthropic_chat_protocol.dart:508-514`、`gemini_chat_protocol.dart:73-83` | 6.14、P6 |
+| `throwIfEnvelopeError` 双错误通道（`error` + MiniMax `base_resp`），流式路径特意放在宽容 try 之外 | `protocols/protocol.dart:137-151` | 6.9-6.10、P6 |
+| `<think>` 跨 chunk 状态机（`_partialTagSuffix` 最长前缀回退），切出的思考不回传 | `openai_chat_protocol.dart:171-222` | 3.30-3.33、P13 |
+| 交替律修补：连续同角色合并、tool 结果并入 user 消息、空 turn 不发、空 tool 输出补 `'(no output)'` | `anthropic_chat_protocol.dart:67-139` | 2.1、5.13 |
+| 「没报 usage」区别于「0」（`promptTokensOf` 返回 null） | `llm_service.dart:319-333` | P8 |
+| Agent「出散文即完成」唯一终止判据 | `prompt_optimizer_agent.dart:1117` | 7.16 |
+| tool-call 配对三路补桩（异常→error 结果、取消→cancelled 桩、未知工具→error），批内取消仍逐个配平后才 return | `prompt_optimizer_agent.dart:1178-1260` | **G6**、7.19-7.21、P17 |
+| `ask_user` 单独成批铁轨（`canStageAskUser`）+ 悬空自愈（`_cancelDanglingAskUser`/`_pairDanglingAskUser` 相邻性二次检查） | `prompt_optimizer_agent.dart:2099-2176` | 5.12、G6 |
+| 写入安全：`write_knowledge_file` 纯 staging 从不落盘、UI Apply 审批、read-before-write 铁轨（elide 掉的读取不再授权写入）、写后 `knowledgeStaleAt` 失效 | `prompt_optimizer_agent.dart:1882-1922、2044-2077` | 7.3、8.23 |
+| 上下文三层：elide（无损、保留全部 reasoning 载体字段）/ compact（失败回退硬截断、不动原历史）/ read cap（per-call 重算而非 per-turn） | `prompt_optimizer_agent.dart:1583-1745`、`context_budget.dart` | 10.45-10.57、P45 |
+| `context_window` tri-state 单点解码（null/≤0/>0），unlimited 用常量防 `0 × ratio == 0` | `context_budget.dart:108-110` | 类比 1.27 |
+| charsPerToken 事后校准（clamp [0.5,6.0]），中文知识库不再按英文估值溢出 | `context_budget.dart:63-69` | 6.38 精神 |
+| 「从历史推导而非 Set 追踪」liveness（`_liveReadPages`/`_liveViewedPaths`/`pendingAskUser`），架构文档记录了 Set 模式的死锁教训 | `prompt_optimizer_agent.dart:1513-1572` | 与 10.51「按对象身份不按索引」同源 |
+| KB 路径安全：绝对路径拒绝、隐藏段拒绝、符号链接解析后二次包含检查、深度上限防环 | `knowledge_base_service.dart:98-149、203` | 8.13、P26 |
+| ④ server tool 只读上报不配对回复，孤儿 result 保留不炸 | `anthropic_chat_protocol.dart:341-369` | 5.15-5.16、5.21 |
+
+---
+
+## 3. 确认的 bug（按严重度排序）
+
+每条格式：现象 → 位置 → playbook 对应 → 修复方向。行号均经人工核实（2026-08-15，main @ 6a4920d）。
+
+### B1 · Gemini 流式解析会被任何非 JSON SSE 行整条打断【高】
+
+[gemini_chat_protocol.dart:178-197](../../lib/services/llm/protocols/gemini_chat_protocol.dart)
+
+```dart
+String dataLine = line;
+if (line.startsWith('data: ')) {   // 只认带空格的拼写
+  dataLine = line.substring(6);
+}
+try {
+  final chunkData = jsonDecode(dataLine);
+  ...
+} catch (e) {
+  if (e is Exception) rethrow;      // FormatException implements Exception
+  // Ignore parse errors for empty/non-json lines
+}
+```
+
+两个叠加的问题：
+
+1. **没有使用共享的 `sseDataPayload`**（[protocol.dart:170-181](../../lib/services/llm/protocols/protocol.dart)）。该 helper 存在的全部理由（其 dartdoc 原文）就是「`data:` 后的空格在 SSE 语法里是可选的」——中继发 `data:{...}` 时这条路径会把整行（含 `data:` 前缀）拿去 jsonDecode。
+2. **catch 分支与注释语义相反**：`jsonDecode` 抛的 `FormatException` 实现了 `Exception`，会被 `rethrow` 而不是被忽略。于是无空格的 `data:{...}`、keep-alive 注释行（`:`）、中继补发的 `data: [DONE]`、裸 `event:` 行——任何一个都会**终止整条流并报错**，而注释声称要忽略它们。
+
+openai（`sseDataPayload` + 宽容 try）和 anthropic（类型化事件）路径都已修对，这是同类问题在 gemini 路径的漏网。
+
+- **playbook**：2.9/2.11（malformed SSE 行直接忽略）、P11 精神、12.2「第一天就要有的三样」之一
+- **修复方向**：改用 `sseDataPayload`（先跳过 `event:` 行），catch 只 rethrow 由错误信封分支主动抛出的异常（例如改为先解析、解析成功后再在 try 外检查 error），与 openai 路径对齐。
+
+### B2 · Gemini 三个协议先 jsonDecode 再判状态码；error 检查无 `is Map` 保护【高】
+
+[gemini_chat_protocol.dart:56-69](../../lib/services/llm/protocols/gemini_chat_protocol.dart)、[gemini_imagen_protocol.dart:64-74](../../lib/services/llm/protocols/gemini_imagen_protocol.dart)、[gemini_veo_protocol.dart:67-77](../../lib/services/llm/protocols/gemini_veo_protocol.dart)
+
+三处的顺序都是 `jsonDecode(response.body)` → `data['error']` → `statusCode != 200`。后果：
+
+- 网关/CDN 返回 HTML 502 时，用户看到的是 `FormatException: Unexpected character`，**真实状态码永远不出现在错误里**，`_isRetryable` 也无法识别为 5xx 可重试。
+- `data['error']` 在 `data` 不是 Map（如 JSON 数组或裸值）时直接 `NoSuchMethodError`。openai/anthropic 路径都是先判状态码、且有 `is Map` 保护，顺序相反。
+
+- **playbook**：6.34（错误判定读「回话的形状」，HTML/非 JSON body 意味着 base URL 指向了不是 API 的东西）、6.15（错误消息带上实际 URL/状态码）
+- **修复方向**：与 openai 对齐——先判状态码（非 200 时把状态码+body 摘要放进异常），200 再 decode，decode 前后加形状保护。
+
+### B3 · Imagen 零图片静默成功【高】
+
+[gemini_imagen_protocol.dart:76-90](../../lib/services/llm/protocols/gemini_imagen_protocol.dart)：`predictions` 为 null、为空、或全部 base64 解码失败时，返回 `LLMResponse(text:'', generatedImages:[], metadata:{})`——一次「成功但什么都没有」。这正是 [openai_images_protocol.dart:160-168](../../lib/services/llm/protocols/openai_images_protocol.dart) 与 [xai_images_protocol.dart:137-140](../../lib/services/llm/protocols/xai_images_protocol.dart) 显式修掉的模式（xai 的注释还点名了 moderation 过滤场景），Imagen 是漏网的第三个。
+
+- **playbook**：6.14（「200 且没有任何内容」当可疑而非成功）、P6 推论
+- **修复方向**：`images.isEmpty` 时抛异常并附 body 摘要，与另外两个 images 协议一致。
+
+### B4 · 计费系统性遗漏：Imagen 与全部视频生成不记账【高】
+
+两处叠加：
+
+1. `LLMService` 只在 `metadata.isNotEmpty` 时调 `_recordUsage`（[llm_service.dart:98,125,235](../../lib/services/llm/llm_service.dart)），而 Imagen 恒返回 `metadata: {}`（B3 同一行）——**Imagen 请求连 request-count 计费都不落库**。
+2. `startLongRunning` / `checkOperation`（[llm_service.dart:339-371](../../lib/services/llm/llm_service.dart)）完全不经过 `_recordUsage`——**所有视频生成（Veo/Sora/xAI/wan/kling）零计费记录**，metrics 页对视频消费是盲的。
+
+- **playbook**：6.6（persistUsage 覆盖所有路径）、9.20 精神（每次运行都要有独立的 usage 行）
+- **修复方向**：Imagen 至少发布 request-count 元数据（或 `_recordUsage` 改为按请求无条件记 request）；视频路径在 submit 成功时记一次 request（token 数为 0），有 usage 信息的（Sora 部分中继报）再补。
+
+### B5 · `_isRetryable` 用错误串里第一个三位数当 HTTP 状态码【中】
+
+[llm_service.dart:150-170](../../lib/services/llm/llm_service.dart)：
+
+```dart
+final statusCodeMatch = RegExp(r'(\d{3})').firstMatch(errorStr);
+```
+
+抓的是异常文本里**第一个**三位数字，不限定它是状态码。误判两个方向都存在：错误体里先出现 `"max_tokens": 512`、`retry after 500ms` 之类的数字会把 4xx 误判成可重试 5xx（重试是重发钱包）；真正的 5xx 若前面先出现别的三位数则不重试。
+
+- **playbook**：6.19（只对真正的 transient 错误重试；4.11 的教训同型——判定正则必须窄，宽判定「翻倍花钱 + 掩盖真实错误」）
+- **修复方向**：协议层抛错时把状态码作为结构化字段（自定义异常类型）而不是让上层从文本里捞；或至少收窄正则锚定 `failed: (\d{3})` 之类协议层实际使用的格式。
+
+### B6 · Anthropic `redacted_thinking` 块被丢弃，不回传【中】
+
+[anthropic_chat_protocol.dart:371-373](../../lib/services/llm/protocols/anthropic_chat_protocol.dart) 解析侧对 `redacted_thinking` 明确「nothing to show and nothing to count」——既不展示（正确）也不留存；回传侧（[:110-116](../../lib/services/llm/protocols/anthropic_chat_protocol.dart)）只重建带签名的 `thinking` 块。若一个工具调用轮同时含 `tool_use` 与 `redacted_thinking`，回传历史会缺块。
+
+- **playbook**：3.29（redacted_thinking 必须回传，过滤条件应是「是思考类块」而非精确 type 匹配）、3.25/P1（④ 对不合法思考历史的反应是**静默剥离思考而非报错**——最危险的失败形态：thinking 悄悄失效、照常计费）
+- **注**：这是「理解后重建」路线（把 thinking 拆成 `reasoningContent`/`reasoningSignature` 字段再拼回）的固有代价，playbook G3 主张的「整块留存原物」正是为了这类块。当前影响面：Anthropic 渠道 + enableThinking + 工具调用（即 Prompt Assistant 的 ④ 通道）。
+- **修复方向**：在 `LLMMessage` 上增加不透明原始块载体（或至少把 redacted_thinking 的 `data` 存进 metadata 随消息持久化），回传时按原顺序还原。
+
+### B7 · Midjourney 非流式路径必然 120 秒超时【中】
+
+`LLMService.request` 对非流式 `generate` 施加 `.timeout(120s)`（[llm_service.dart:119](../../lib/services/llm/llm_service.dart)），而 MJ 的 `generate` 内部是最长 10 分钟的提交+轮询循环（[midjourney_protocol.dart:45-65](../../lib/services/llm/protocols/midjourney_protocol.dart)，`_maxWait = 10min`，MJ 典型耗时 30–120s）。流式路径靠进度 chunk 重置超时（协议注释明写此设计），非流式路径没有这个机制——任何以 `useStream: false` 调用 MJ 模型的路径在 120s 处稳定失败。当前主流程（批处理图像任务）走流式所以未爆发，属于埋着的地雷。
+
+- **playbook**：6.21（超时策略要按 surface 区分；长生成合法）
+- **修复方向**：dispatcher 对 MJ 的非流式调用放宽/豁免超时，或内部统一走流式再聚合。
+
+### B8 · xai_images 缺信封错误检查与形状保护【低】
+
+[xai_images_protocol.dart:113-147](../../lib/services/llm/protocols/xai_images_protocol.dart)：没有调 `throwIfEnvelopeError`（200 + body 错误信封会走到「no image data」的间接报错，掩盖真实原因）；`items` 元素与 `data['usage']` 均无 `is Map` 保护（对照 openai_images 同位置全部做了保护）。有零图抛错兜底，所以降为低。
+
+- **playbook**：P6、5.21（认不出的容器形状不该抛裸异常）
+- **修复方向**：decode 后先 `throwIfEnvelopeError`，遍历时 `item is Map` 过滤，usage 读取加形状判断。
+
+### B9 · debug 日志把完整请求体（含 base64 图片）原样落盘【低】
+
+openai_chat 与 anthropic_chat 的四处 `startLog` 均传 `'body': payload` 原样（[openai_chat_protocol.dart:343,508](../../lib/services/llm/protocols/openai_chat_protocol.dart)、[anthropic_chat_protocol.dart:479,578](../../lib/services/llm/protocols/anthropic_chat_protocol.dart)）。带图附件的请求会把整段 base64（MB 级）写进 `api_logs/`。imagen/veo（`getSafePayload`）、MJ、xAI 都做了裁剪，chat 两族是漏网。另外 Gemini 系 14 处 `'url': url.toString()` 带 `?key=`，目前依赖 `_sanitize` 的正则兜底救回——链路正确但脆弱，不如源头 `redactUrl`（[gemini_veo_protocol.dart:41](../../lib/services/llm/protocols/gemini_veo_protocol.dart) 已示范）。
+
+- **playbook**：6.26（base64 替占位符 + 协议无关的递归长串裁剪）、6.16/6.25（key 永不落日志）
+- **修复方向**：`LLMDebugLogger._sanitize` 增加递归长字符串裁剪（>2048 字符截断），从机制上兜住所有协议，而不是逐协议手工 safe-payload。
+
+### B10 · AiRenameAgent 批内取消不补桩（隐患）【低】
+
+[ai_rename_agent.dart:199-208](../../lib/services/ai_rename_agent.dart)：工具批执行循环里 `if (isCancelled()) return;` 直接退出，此时带 `toolCalls` 的 assistant 消息已在 `messages` 里而结果缺失——违反配对不变量。**当前无实际危害**：`messages` 是方法内局部变量、每批丢弃、不持久化。但与 `PromptOptimizerAgent` 用 40 行注释+三条路径守住的纪律（[prompt_optimizer_agent.dart:1149-1260](../../lib/services/prompt_optimizer_agent.dart)）相反，且没有注释说明为什么这里允许——一旦有人照 optimizer 的样子给它加会话持久化，就是即刻的会话级 bug。
+
+- **playbook**：G6、5.12（可中途退出的实现必须二选一）、P17
+- **修复方向**：补桩（照抄 optimizer 的 cancelled 桩逻辑），或至少加注释声明「本历史不持久化，允许不配平」的前提。
+
+---
+
+## 4. 层间纪律违规
+
+对照基准：项目自身红线（[llm-three-layer.md](../architecture/llm-three-layer.md) 的 greppable 清单）+ playbook G1/G5/1.9。
+
+### V1 · `openai_videos_protocol.dart:50` 硬编码认证头【应修】
+
+```dart
+request.headers['Authorization'] = 'Bearer ${config.apiKey}';
+```
+
+全仓唯一绕过 `VendorProfile.headers()` 的协议代码。同文件的 poll 用的是 `target.headers()`，且 [openai_images_protocol.dart:61-68](../../lib/services/llm/protocols/openai_images_protocol.dart) 的注释正是在讲这个 bug 曾在 images 路径被修掉——这是同类问题的漏网。后果：任何非 bearer 认证的 vendor（未来接入）走 Sora 视频提交时认证错误。修复：换成 `request.headers.addAll(target.headers())`（multipart 需像 images 那样移除 Content-Type）。
+
+### V2 · `llm_dispatcher.dart:192` model-id 嗅探【应修】
+
+`config.modelId.startsWith('mock-')`。红线明写 `modelId.startsWith(` 只允许出现在 `model_family.dart`/`model_descriptor.dart`。修复：把 mock 判定挪进 `ModelDescriptor`（如 `isMockModel` getter），或统一走 `options['simulation']`。
+
+### V3 · `setup_wizard.dart:499-506` id 子串嗅探【应修】
+
+```dart
+final id = selected.modelId.toLowerCase();
+if (id.contains('vision') || id.contains('image')) { _modelTag = 'multimodal'; }
+else if (id.contains('gemini')) { _modelTag = 'multimodal'; }
+```
+
+直接违反红线一，且 `ModelFamilyClassifier` 已有推断逻辑——这是会独立漂移的第二套规则。修复：调用 Layer 3 的既有推断（models 屏的对应逻辑），删除本地 contains 链。
+
+### V4 · channel wizard/edit dialog 成片裸 vendor id 字面量【建议修】
+
+`channel_wizard_dialog.dart` 15 处、`channel_edit_dialog.dart:53` 直接写 `'newapi-openai'`/`'newapi-gemini'`/`'midjourney-proxy'`/`'google-genai-rest'` 字符串（红线四：vendor id 引用应使用 `Vendors.*` 常量）。拼写错误只能在运行时暴露（`Vendors.byId` 对未知 id 静默回退 `openAIRest`，错误会被吞掉）。`database_migrations.dart` 中的裸串属迁移代码需冻结，可豁免但建议在红线文档补一条豁免说明。
+
+### V5 · `task_executors.dart:459-463` 认证逻辑写在 Layer 2 之外【建议修】
+
+视频下载按 `vendorFamily == ProtocolFamily.gemini` 选 `x-goog-api-key` vs `Bearer`。注释的理由成立（不嗅探 URL host），但「某 vendor 的资源下载用什么头」本质是 Layer 2 知识——正确归属是 `VendorProfile` 上的一个方法（如 `downloadHeaders(apiKey)`），executor 只消费。当前写法意味着未来新增非 bearer vendor 时这里会静默用错头（且注释说错头会被忽略——恰好是不会响的失败）。
+
+### 备注（合法但值得整理）
+
+`ModelDescriptor.isNijiVariant`（`contains('niji')`）与 `acceptsImageInput`（`contains('deepseek')`）位于允许嗅探的 Layer 3 内，不违规；但 niji 规则与 `ModelFamilyClassifier` 的规则表重复、deepseek 规则绕开规则表单独存在，把「单一规则表」拆成了三处真相源。建议收拢进 classifier/capabilities 表。
+
+---
+
+## 5. 能力缺口与取舍
+
+以下是 playbook 有、本项目没有的能力。**标「取舍」的是可辩护的设计选择**（列出以便未来决策时有据可查），**标「缺口」的建议排入路线**。
+
+### 5.1 结构化输出无降级链【缺口】
+
+playbook 04 的方案是两级组合：强制 pseudo-tool → 收窄判据的错误回退 → JSON mode + cue。本项目全部结构化输出（`submit_prompt`/`select_images`/`rename_file`/`ask_user`）只有 pseudo-tool 一级，唯一的软降级是 web_scraper 的 nudge-once（[web_scraper_service.dart:370-379](../../lib/services/web_scraper_service.dart)）。后果：**不支持 function calling 的模型/中继在本 App 里没有任何可用路径，也没有任何诊断信号**——表现为「模型只会聊天，永远不交付」，用户无从判断是模型问题还是配置问题。最小改进：agent 循环里当模型连续 N 轮纯文本回答时，给用户一条明确的「该模型/渠道可能不支持工具调用」日志（不必先建完整降级链）。
+
+### 5.2 ①族（OpenAI 系）无 reasoning 请求侧控制【半取舍半缺口】
+
+`enableThinking` 只作用于 ④ 族（`anthropic_chat_protocol.dart:228-232`，UI 也只在 Anthropic 渠道显示）。①族既不发 `reasoning_effort` 也不发任何 thinking 开关——DeepSeek-R1、o 系列、经 OpenAI-compat 中继的 gemini thinking 都无法控制强度，只能吃端点默认值。playbook 03 的六档强度词汇 + 按族翻译表是现成方案。取回侧（`REASONING_CONTENT_FIELDS` 式候选字段表 + `<think>` 切分）本项目已有等价实现，缺的只是请求侧。
+
+### 5.3 能力探测零支持【取舍，建议补最小闸】
+
+playbook 06 的三分法：**声明 / 运行时降级 / 花钱实测**。本项目只有第一层（family 表 + id 规则 + 3 条 override），[llm-three-layer.md](../architecture/llm-three-layer.md) 的「遗留与已知取舍」承认了这点（第三方中继乱起名会误判，「只理结构、不做增强」）。这个取舍成立，但两个最便宜的探测值得单列：
+- **连接测试**（playbook 6.31-6.35 providerProbe）：渠道配置界面目前没有「测一下」按钮；`/models` 探测 + 错误形状判定几乎零成本。
+- **上下文窗口的发送前拦截**（playbook 1.21）：Prompt Assistant 已有字符域预算，但普通聊天/批处理路径超窗时只能吃端点报错（或更糟——本地栈静默截断，P5）。
+
+### 5.4 无子代理 / 任务工作区【缺口（中长期）】
+
+playbook 09/10 的核心：记忆落盘 + 单层委托 + 工具集级路由。本项目的 Prompt Assistant 把知识库通读、看图、压缩摘要、KB 编辑全部压在单 agent 主上下文里，read cap + 分页 + elide 是在**症状层**打补丁（正是 playbook 9.1 描述的病症的知识库版本）。同时缺「任务状态」这层记忆：撞 `maxTurns` 只有「停下」一个出口，无存档/断点续跑（playbook 10 的 task.md + resume seed 模式）。knowledgeEdit 模式 `baseTurns` 被抬到 24 本身就是单上下文承压的信号。若排期，playbook 的最小路径是：先做任务工作区（落盘 note + read_note），再做 delegate（knowledge-reader 子代理最对症——KB 通读的产出天然是「结论 + 路径」形态）。
+
+### 5.5 prompt cache 零考虑，且 elide 逐轮击穿隐式缓存【缺口（省钱项）】
+
+写入侧无任何 `cache_control` breakpoint（全仓 grep 仅命中文档）。更实质的是：**Layer 1 elide 每次请求都会改写历史前缀**（读取结果换占位、附件摘除、write 参数替换，边界随用户轮滚动）——对 OpenAI/Gemini/Anthropic 的前缀匹配式自动缓存是逐轮击穿的。playbook P46/10.50/10.58 的对策（压缩触发/目标留宽间隙、summary 紧贴 system 稳定前缀）在这里的等价物是：elide 边界只在压缩时移动、或对已 elide 的前缀保持字节稳定。长会话 + 大 system prompt（README 全文注入）场景下这是真金白银。
+
+### 5.6 KB 写入无备份、Apply 后无回退【半取舍】
+
+playbook 8.25-8.28「备份失败 = 写入失败」+ 备份先行。本项目的防线是审批卡 + read-before-write + 「只能新增或替换、永不销毁」的模式不变量，但用户点 Apply 后 `KnowledgeBaseService.writeFile` 直接覆盖（[knowledge_base_service.dart:246-269](../../lib/services/knowledge_base_service.dart)），无回退路径。审批制减轻了风险但没消除（陈旧预览覆盖新内容的窗口仍在，`fromStored` 的惰性化注释自己就在讲这个风险）。写前备份到 KB 根下隐藏目录是低成本补强。
+
+### 5.7 可观测性缺口【缺口（低成本高收益）】
+
+- **助手面板无停止按钮**：取消一个跑飞的 turn 要切到批处理页找任务（全仓 `cancelTask` 仅 task_queue_screen 调用）。
+- **撞 `maxTurns` 静默**：[prompt_optimizer_agent.dart:1266](../../lib/services/prompt_optimizer_agent.dart) 只 onLog 一行（仅批处理页日志可见），transcript 无条目——用户看到的是「agent 干了一堆事然后安静地停了」。playbook 7.46：轮数中途用尽在用户看来等于「agent 拒绝干活」。
+- **promptRefine 路径不发任何 `TaskEvent`**（对比 aiRename 有 textChunk）：五种事件类型对这条路径全部沉默，含 error。
+- `finish_reason == 'length'` 只记日志不补救（截断的 `submit_prompt` 白烧一轮）。
+
+### 5.8 其余工程健壮性备注
+
+- `runTurn` 无 re-entrancy 守卫（并发保护全靠 UI `isBusy` + 队列并发上限 2；同 session 两个 promptRefine 任务同时到达会并发写同一 history）。
+- 重试退避固定 2s 无抖动（playbook 6.19 线性退避已是底线）。
+- KB 全部同步 IO（`readAsStringSync`/`listSync`）跑在 UI isolate。
+- turn 内不落盘：24 轮 knowledgeEdit 中途崩溃丢整轮（`_syncPersistence` 只在 turn 首尾）。
+- 流式路径写入 `_sessions` 的 assistant 消息不带 reasoning 字段（[llm_service.dart:104-107,241-244](../../lib/services/llm/llm_service.dart)）——当前无消费方，若未来复用该 session 做工具调用会踩 ①族 400（playbook 3.23）。
+
+---
+
+## 6. 整改建议（按优先级）
+
+### P0 —— 真 bug，建议尽快修（全部是小改动）
+
+| # | 项 | 文件 | 工作量 |
+| --- | --- | --- | --- |
+| 1 | Gemini 流式改用 `sseDataPayload` + 修 catch 语义（B1） | gemini_chat_protocol.dart | 小 |
+| 2 | Gemini 三协议状态码优先 + `is Map` 保护（B2） | gemini_chat / gemini_imagen / gemini_veo | 小 |
+| 3 | Imagen 零图抛错（B3） | gemini_imagen_protocol.dart | 极小 |
+| 4 | Imagen + 视频 LRO 计费落库（B4） | llm_service.dart、gemini_imagen_protocol.dart | 中 |
+| 5 | `_isRetryable` 状态码结构化（B5） | llm_service.dart + 各协议异常构造 | 中 |
+
+P0 第 1-3 项修完后，Gemini 路径即与 openai/anthropic 同一代加固水平；建议同时为 gemini 流式补一个与 `test/openai_chat_payload_test.dart` 对应的 SSE 解析测试（无空格 `data:`、注释行、`[DONE]`、HTML 502 四个用例），防止再次掉队。
+
+### P1 —— 纪律漏网与地雷
+
+| # | 项 | 文件 |
+| --- | --- | --- |
+| 6 | 硬编码 Bearer → `target.headers()`（V1） | openai_videos_protocol.dart:50 |
+| 7 | `mock-` 嗅探挪进 Layer 3（V2） | llm_dispatcher.dart:192 |
+| 8 | setup wizard 嗅探改用 classifier（V3） | setup_wizard.dart:499 |
+| 9 | MJ 非流式超时豁免（B7） | llm_dispatcher.dart 或 llm_service.dart |
+| 10 | rename agent 补桩或注释声明前提（B10） | ai_rename_agent.dart:199 |
+| 11 | debug logger 加递归长串裁剪（B9） | llm_debug_logger.dart |
+| 12 | 裸 vendor id 字面量收敛为常量（V4）、下载头挪进 VendorProfile（V5） | channel_wizard_dialog.dart 等 |
+| 13 | `redacted_thinking` 原物留存回传（B6） | anthropic_chat_protocol.dart、llm_types.dart |
+
+### P2 —— 能力建设（按性价比排序，各自独立可做）
+
+1. **可观测性三件套**（§5.7）：助手面板停止按钮、maxTurns 撞顶的 transcript 提示、promptRefine 的 TaskEvent 接线。改动小、用户感知直接。
+2. **渠道「测一下」按钮**（§5.3）：providerProbe 的 `/models` + 错误形状判定，配置期把「base 填错 / key 过期 / 中继没有 /models」三类问题前置暴露。
+3. **①族 reasoning 请求侧**（§5.2）：六档自有词汇 + 按族翻译，UI 复用现有 ④ 开关。
+4. **结构化输出的诊断信号**（§5.1）：先做「疑似不支持工具调用」的显式提示，降级链视需求再排。
+5. **KB 写前备份**（§5.6）。
+6. **prompt-cache 友好的 elide/compact**（§5.5）：长会话省钱项，动 elide 边界策略，需要设计。
+7. **任务工作区 → 子代理**（§5.4）：中长期，建议按 playbook 12 的依赖顺序（工作区先行，delegate 其次），首个子代理选 knowledge-reader。
+
+---
+
+## 附录 · 审查追溯
+
+- 探索与核实日期：2026-08-15，基线 main @ 6a4920d。
+- 报告中每条 bug/违规的行号均经人工 Read 核实原文；探索 agent 的两项原始结论在核实中被降级：`ModelDescriptor` 的 id 嗅探（位置合法，降为「规则重复」备注）、MJ 超时（触发面窄于原始描述，标为地雷而非现行 bug）。
+- playbook 编号索引：Gx = README 六条贯穿性原则；数字条目 = 对应主题篇（01 分层 / 02 协议差异 / 03 reasoning / 04 结构化 / 05 工具 / 06 错误 / 07 runtime / 08 权限 / 09 子代理 / 10 上下文）；Px = 11-pitfalls 坑清单。

--- a/lib/services/ai_rename_agent.dart
+++ b/lib/services/ai_rename_agent.dart
@@ -196,10 +196,25 @@ class AiRenameAgent {
         toolCalls: response.toolCalls,
       ));
 
+      // Pairing invariant (same rule PromptOptimizerAgent enforces): once the
+      // assistant message with tool calls is in [messages], every call gets a
+      // paired result before this method returns — a cancellation mid-batch
+      // stubs the remaining calls instead of leaving them dangling. Today
+      // [messages] is batch-local and discarded, so an unpaired history could
+      // not hurt anyone yet; the stubs keep the invariant true so the day this
+      // history is persisted or reused does not turn a quirk into a bug.
+      var cancelledMidBatch = false;
       for (final call in response.toolCalls) {
-        if (isCancelled?.call() ?? false) return;
-
-        final result = _executeTool(call, chunk, proposals, onLog);
+        final Map<String, dynamic> result;
+        if (cancelledMidBatch || (isCancelled?.call() ?? false)) {
+          cancelledMidBatch = true;
+          result = {
+            'status': 'cancelled',
+            'message': 'The task was cancelled before this tool ran.',
+          };
+        } else {
+          result = _executeTool(call, chunk, proposals, onLog);
+        }
         messages.add(LLMMessage(
           role: LLMRole.tool,
           content: jsonEncode(result),
@@ -207,6 +222,7 @@ class AiRenameAgent {
           toolName: call.name,
         ));
       }
+      if (cancelledMidBatch) return;
     }
   }
 

--- a/lib/services/llm/llm_debug_logger.dart
+++ b/lib/services/llm/llm_debug_logger.dart
@@ -81,6 +81,12 @@ class LLMDebugLogger {
   static final RegExp _bearerToken =
       RegExp(r'(Bearer\s+)[A-Za-z0-9._~+/=-]+');
 
+  /// Any string value longer than this is truncated in the log. Catches
+  /// base64 image payloads (MB-sized) protocol-agnostically: the chat
+  /// protocols log their request map as-is, and per-protocol "safe payload"
+  /// helpers only exist where someone remembered to write one.
+  static const int _maxStringChars = 2048;
+
   static dynamic _sanitize(dynamic obj) {
     if (obj is Map) {
       return obj.map((k, v) {
@@ -97,9 +103,14 @@ class LLMDebugLogger {
     } else if (obj is List) {
       return obj.map((e) => _sanitize(e)).toList();
     } else if (obj is String) {
-      return obj
+      final masked = obj
           .replaceAllMapped(_keyQueryParam, (m) => '${m[1]}***MASKED***')
           .replaceAllMapped(_bearerToken, (m) => '${m[1]}***MASKED***');
+      if (masked.length > _maxStringChars) {
+        return '${masked.substring(0, _maxStringChars)}'
+            '…<${masked.length - _maxStringChars} chars omitted>';
+      }
+      return masked;
     }
     return obj;
   }

--- a/lib/services/llm/llm_dispatcher.dart
+++ b/lib/services/llm/llm_dispatcher.dart
@@ -52,6 +52,23 @@ class LLMDispatcher {
         model: ModelDescriptor.of(config.modelId),
       );
 
+  /// How long a synchronous [generate] may run before the caller times it
+  /// out.
+  ///
+  /// Midjourney is the outlier: its generate() *contains* the whole
+  /// submit → poll → download cycle (up to 10 minutes, see
+  /// [MidjourneyProtocol]), so the 120 s guard that fits a single chat
+  /// completion would fail every non-streaming Midjourney call at exactly
+  /// 120 s. The streaming path is unaffected — progress chunks reset the
+  /// caller's timeout — which is why this only ever mattered for
+  /// `useStream: false`.
+  Duration generateTimeout(LLMModelConfig config) {
+    final target = resolveTarget(config);
+    return target.vendor.family == ProtocolFamily.midjourney
+        ? const Duration(minutes: 11)
+        : const Duration(seconds: 120);
+  }
+
   // ---------------------------------------------------------------------------
   // Synchronous generation
   // ---------------------------------------------------------------------------

--- a/lib/services/llm/llm_service.dart
+++ b/lib/services/llm/llm_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
-import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
 
 import '../database_service.dart';
 import 'llm_config_resolver.dart';
@@ -116,7 +117,7 @@ class LLMService {
             options: options,
             tools: tools,
             logger: (msg, {level = 'INFO'}) => onLogAdded?.call(msg, level: level, contextId: contextId),
-          ).timeout(const Duration(seconds: 120));
+          ).timeout(_dispatcher.generateTimeout(config));
           if (response.text.isNotEmpty) {
             onLogAdded?.call('[AI]: ${response.text}', level: 'INFO', contextId: contextId);
           }
@@ -138,7 +139,7 @@ class LLMService {
         }
       } catch (e) {
         attempt++;
-        if (attempt > maxRetries || !_isRetryable(e)) {
+        if (attempt > maxRetries || !isRetryable(e)) {
           rethrow;
         }
         onLogAdded?.call('Request failed: $e. Retrying in 2 seconds...', level: 'WARN', contextId: contextId);
@@ -147,21 +148,32 @@ class LLMService {
     }
   }
 
-  bool _isRetryable(Object e) {
-    // Only retry on network errors or 5xx server errors
-    // The providers throw Exception('... statusCode - body') on non-200 responses
+  /// Whether a failed attempt is worth retrying: network-level failures and
+  /// transient HTTP codes (5xx / 429), nothing else.
+  ///
+  /// Structured errors ([LLMApiException]) answer directly. The regex is a
+  /// legacy fallback for protocols still throwing plain Exceptions with
+  /// `... failed: <status> - <body>` prose — anchored to that shape because
+  /// the old version grabbed the *first* three-digit number anywhere in the
+  /// message, which read "retry after 500ms" in an error body as a server
+  /// error and re-sent a request that was going to fail (and bill) again.
+  @visibleForTesting
+  static bool isRetryable(Object e) {
+    if (e is TimeoutException) return true;
+    if (e is LLMApiException) return e.isTransient;
+
     final errorStr = e.toString();
-    
-    // Check for common network exceptions
-    if (e is TimeoutException || errorStr.contains('SocketException') || errorStr.contains('Connection closed')) {
+    if (errorStr.contains('SocketException') ||
+        errorStr.contains('Connection closed')) {
       return true;
     }
 
-    // Check for 5xx status codes in the exception message
-    final statusCodeMatch = RegExp(r'(\d{3})').firstMatch(errorStr);
+    final statusCodeMatch =
+        RegExp(r'failed:?\s+(\d{3})\b').firstMatch(errorStr);
     if (statusCodeMatch != null) {
       final code = int.tryParse(statusCodeMatch.group(1)!);
-      if (code != null && code >= 500 && code < 600) {
+      if (code != null &&
+          (code == 429 || (code >= 500 && code < 600))) {
         return true;
       }
     }
@@ -246,7 +258,7 @@ class LLMService {
         return; // Success, exit retry loop
       } catch (e) {
         attempt++;
-        if (deliveredAnyChunk || attempt > maxRetries || !_isRetryable(e)) {
+        if (deliveredAnyChunk || attempt > maxRetries || !isRetryable(e)) {
           rethrow;
         }
         onLogAdded?.call('Stream failed: $e. Retrying in 2 seconds...', level: 'WARN', contextId: contextId);
@@ -346,12 +358,20 @@ class LLMService {
       modelIdentifier,
       logger: (msg, {level = 'INFO'}) => onLogAdded?.call(msg, level: level, contextId: contextId),
     );
-    return await _dispatcher.startLongRunning(
+    final operationName = await _dispatcher.startLongRunning(
       config,
       messages,
       options: options,
       logger: (msg, {level = 'INFO'}) => onLogAdded?.call(msg, level: level, contextId: contextId),
     );
+    // Video jobs never flow back through request()/requestStream(), so the
+    // accepted submission is the only moment they can be billed at all —
+    // without this every Veo/Sora/xAI generation was invisible to the metrics
+    // page and to request-billed channels. Providers report no token usage at
+    // submit time; the row records the request itself (tokens 0).
+    _recordUsage(config.modelId, config, const {'operation': 'submit'},
+        modelDbId: modelIdentifier is int ? modelIdentifier : null);
+    return operationName;
   }
 
   Future<Map<String, dynamic>> checkOperation({

--- a/lib/services/llm/llm_types.dart
+++ b/lib/services/llm/llm_types.dart
@@ -6,6 +6,37 @@ import 'package:http/io_client.dart';
 
 enum LLMRole { system, user, assistant, tool }
 
+/// A failed API call, structured enough that retry policy can be decided
+/// without parsing exception prose.
+///
+/// Protocols throw this for non-2xx responses (with [statusCode] set) and for
+/// 200-with-error-envelope bodies ([isEnvelope] true, [statusCode] null).
+/// `LLMService` retries only transient codes (5xx / 429). Before this existed
+/// it fished the first three-digit number out of `e.toString()` with a regex,
+/// which read "retry after 500ms" in an error body as a server error — and
+/// missed real 5xxs whose message led with some other number.
+class LLMApiException implements Exception {
+  final String message;
+
+  /// HTTP status of the failed response, or null when the failure was carried
+  /// inside a 2xx body ([isEnvelope]) or never reached HTTP at all.
+  final int? statusCode;
+
+  /// True when a 2xx response body was an error envelope (`error` field or
+  /// MiniMax `base_resp`). Envelope errors are never retried — the transport
+  /// succeeded; the request itself was rejected.
+  final bool isEnvelope;
+
+  LLMApiException(this.message, {this.statusCode, this.isEnvelope = false});
+
+  bool get isTransient =>
+      statusCode != null &&
+      (statusCode == 429 || (statusCode! >= 500 && statusCode! < 600));
+
+  @override
+  String toString() => message;
+}
+
 enum LLMReferenceType {
   media,
   asset,

--- a/lib/services/llm/protocols/anthropic_chat_protocol.dart
+++ b/lib/services/llm/protocols/anthropic_chat_protocol.dart
@@ -492,7 +492,9 @@ class AnthropicChatProtocol implements ChatProtocol {
 
       if (response.statusCode != 200) {
         logger?.call('Request failed with status: ${response.statusCode}', level: 'ERROR');
-        throw Exception('Anthropic API Request failed: ${response.statusCode} - ${response.body}');
+        throw LLMApiException(
+            'Anthropic API Request failed: ${response.statusCode} - ${response.body}',
+            statusCode: response.statusCode);
       }
 
       logger?.call('Response received, parsing data...', level: 'DEBUG');
@@ -592,7 +594,9 @@ class AnthropicChatProtocol implements ChatProtocol {
       }
       client.close();
       logger?.call('Stream request failed with status: ${response.statusCode}', level: 'ERROR');
-      throw Exception('Anthropic API Stream Request failed: ${response.statusCode} - $body');
+      throw LLMApiException(
+          'Anthropic API Stream Request failed: ${response.statusCode} - $body',
+          statusCode: response.statusCode);
     }
 
     logger?.call('Stream connection established, waiting for chunks...', level: 'DEBUG');

--- a/lib/services/llm/protocols/gemini_chat_protocol.dart
+++ b/lib/services/llm/protocols/gemini_chat_protocol.dart
@@ -53,20 +53,7 @@ class GeminiChatProtocol implements ChatProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      final data = jsonDecode(response.body);
-
-      // Check for System-level errors (Section 3.3)
-      if (data['error'] != null) {
-        final err = data['error'];
-        final msg = 'Google GenAI Error: [${err['code']}] ${err['message']} (${err['status']})';
-        logger?.call(msg, level: 'ERROR');
-        throw Exception(msg);
-      }
-
-      if (response.statusCode != 200) {
-        logger?.call('Request failed with status: ${response.statusCode}', level: 'ERROR');
-        throw Exception('Google GenAI Request failed: ${response.statusCode} - ${response.body}');
-      }
+      final data = decodeJsonBody(response, apiName: 'Google GenAI');
 
       logger?.call('Response received, parsing data...', level: 'DEBUG');
 
@@ -75,7 +62,7 @@ class GeminiChatProtocol implements ChatProtocol {
       // have. Only the synchronous path can judge this: in a stream a chunk
       // carrying nothing but usageMetadata is perfectly normal, so
       // parseGoogleChunks must stay tolerant of it.
-      final candidates = data is Map ? data['candidates'] : null;
+      final candidates = data['candidates'];
       if (candidates is! List || candidates.isEmpty) {
         final body = response.body;
         throw Exception('Google GenAI returned no candidates: '
@@ -141,25 +128,20 @@ class GeminiChatProtocol implements ChatProtocol {
     final response = await client.send(request);
 
     if (response.statusCode != 200) {
-      // Try to parse error from body if possible
       final body = await response.stream.bytesToString();
       if (debugFile != null) {
         await LLMDebugLogger.appendLine(debugFile, 'Error Status: ${response.statusCode}');
         await LLMDebugLogger.appendLine(debugFile, 'Error Body: $body');
       }
       client.close();
-      try {
-        final data = jsonDecode(body);
-        if (data['error'] != null) {
-          final err = data['error'];
-          final msg = 'Google GenAI Stream Error: [${err['code']}] ${err['message']}';
-          logger?.call(msg, level: 'ERROR');
-          throw Exception(msg);
-        }
-      } catch (_) {}
-
       logger?.call('Stream request failed with status: ${response.statusCode}', level: 'ERROR');
-      throw Exception('Google GenAI Stream Request failed: ${response.statusCode}');
+      // The shared decoder owns the message shape (provider error text when
+      // the body is JSON, excerpt otherwise) and always throws on non-2xx.
+      decodeJsonBody(http.Response(body, response.statusCode),
+          apiName: 'Google GenAI stream');
+      throw LLMApiException(
+          'Google GenAI stream request failed: ${response.statusCode}',
+          statusCode: response.statusCode);
     }
 
     logger?.call('Stream connection established, waiting for chunks...', level: 'DEBUG');
@@ -175,26 +157,7 @@ class GeminiChatProtocol implements ChatProtocol {
           await LLMDebugLogger.appendLine(debugFile, line);
         }
 
-        String dataLine = line;
-        if (line.startsWith('data: ')) {
-          dataLine = line.substring(6);
-        }
-
-        try {
-          final chunkData = jsonDecode(dataLine);
-
-          // Check for error in chunk
-          if (chunkData['error'] != null) {
-            final err = chunkData['error'];
-            logger?.call('Stream Chunk Error: ${err['message']}', level: 'ERROR');
-            throw Exception(err['message']);
-          }
-
-          yield* Stream.fromIterable(parseGoogleChunks(chunkData, logger: logger));
-        } catch (e) {
-          if (e is Exception) rethrow;
-          // Ignore parse errors for empty/non-json lines
-        }
+        yield* Stream.fromIterable(geminiChunksFromSseLine(line, logger: logger));
       }
     } finally {
       client.close();
@@ -202,6 +165,46 @@ class GeminiChatProtocol implements ChatProtocol {
 
     yield LLMResponseChunk(isDone: true);
   }
+}
+
+/// The chunks carried by one SSE line of a Gemini stream — empty for lines
+/// with no payload.
+///
+/// Line handling follows the shared SSE rules ([sseDataPayload]): the space
+/// after `data:` is optional, `:` keep-alives and `[DONE]` carry nothing, and
+/// named `event:` lines are skipped here (the helper passes unprefixed lines
+/// through for relays that stream bare JSON). A line that then fails to parse
+/// as JSON is relay noise and is *ignored* — the previous inline version
+/// rethrew the `FormatException` (it implements `Exception`), so a single
+/// `data:{…}` without a space or one keep-alive comment killed the whole
+/// stream while the code's own comment claimed the line would be skipped.
+///
+/// An in-chunk error envelope still throws: that is the request failing, not
+/// the line being noise, so it is checked *after* the tolerant decode.
+@visibleForTesting
+Iterable<LLMResponseChunk> geminiChunksFromSseLine(String line,
+    {LLMLogger? logger}) {
+  if (line.startsWith('event:')) return const [];
+  final payload = sseDataPayload(line);
+  if (payload == null) return const [];
+
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(payload);
+  } on FormatException {
+    return const [];
+  }
+  if (decoded is! Map) return const [];
+  final chunkData = decoded.cast<String, dynamic>();
+
+  final err = chunkData['error'];
+  if (err != null) {
+    final msg = err is Map ? err['message'] : err;
+    logger?.call('Stream Chunk Error: $msg', level: 'ERROR');
+    throw LLMApiException('Google GenAI stream error: $msg', isEnvelope: true);
+  }
+
+  return parseGoogleChunks(chunkData, logger: logger);
 }
 
 /// Gemini `GET /models` discovery listing.

--- a/lib/services/llm/protocols/gemini_imagen_protocol.dart
+++ b/lib/services/llm/protocols/gemini_imagen_protocol.dart
@@ -61,17 +61,7 @@ class GeminiImagenProtocol implements ImageGenProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      final data = jsonDecode(response.body);
-      if (data['error'] != null) {
-        final err = data['error'];
-        final msg = 'Imagen Error: [${err['code']}] ${err['message']} (${err['status']})';
-        logger?.call(msg, level: 'ERROR');
-        throw Exception(msg);
-      }
-
-      if (response.statusCode != 200) {
-        throw Exception('Imagen Request failed: ${response.statusCode} - ${response.body}');
-      }
+      final data = decodeJsonBody(response, apiName: 'Imagen');
 
       final List<Uint8List> images = [];
       final predictions = data['predictions'] as List?;
@@ -86,8 +76,25 @@ class GeminiImagenProtocol implements ImageGenProtocol {
         }
       }
 
+      if (images.isEmpty) {
+        // Mirrors the OpenAI/xAI images surfaces: a 200 that carries no
+        // decodable image (missing predictions, filtered prompt) is a
+        // failure, not an empty success the caller reads as "nothing to do".
+        final body = response.body;
+        throw LLMApiException('Imagen returned no image data: '
+            '${body.length > 500 ? '${body.substring(0, 500)}…' : body}');
+      }
+
       logger?.call('Imagen parse complete. Images: ${images.length}', level: 'DEBUG');
-      return LLMResponse(text: '', generatedImages: images, metadata: {});
+      // Imagen's :predict reports no token usage; a non-empty metadata still
+      // matters — LLMService only records usage (request-count billing
+      // included) when there is some, so `{}` made every Imagen call
+      // invisible to the metrics page.
+      return LLMResponse(
+        text: '',
+        generatedImages: images,
+        metadata: {'prediction_count': images.length},
+      );
     } finally {
       client.close();
     }

--- a/lib/services/llm/protocols/gemini_veo_protocol.dart
+++ b/lib/services/llm/protocols/gemini_veo_protocol.dart
@@ -64,17 +64,7 @@ class GeminiVeoProtocol implements VideoJobProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      final data = jsonDecode(response.body);
-      if (data['error'] != null) {
-        final err = data['error'];
-        final msg = 'Google LRO Error: [${err['code']}] ${err['message']}';
-        logger?.call(msg, level: 'ERROR');
-        throw Exception(msg);
-      }
-
-      if (response.statusCode != 200) {
-        throw Exception('Google LRO failed: ${response.statusCode} - ${response.body}');
-      }
+      final data = decodeJsonBody(response, apiName: 'Google LRO');
 
       final name = data['name'] as String?;
       if (name == null) {
@@ -105,9 +95,15 @@ class GeminiVeoProtocol implements VideoJobProtocol {
       final response = await client.get(url, headers: headers);
 
       if (response.statusCode != 200) {
-        throw Exception('Failed to check operation: ${response.statusCode} - ${response.body}');
+        throw LLMApiException(
+            'Failed to check operation: ${response.statusCode} - ${response.body}',
+            statusCode: response.statusCode);
       }
 
+      // Deliberately not [decodeJsonBody]: a *failed operation* is reported
+      // inside a 200 as `{done: true, error: {...}}`, and the task executor
+      // consumes that envelope — the shared decoder would turn it into a
+      // thrown exception and change the poll contract.
       return jsonDecode(response.body);
     } finally {
       client.close();

--- a/lib/services/llm/protocols/openai_chat_protocol.dart
+++ b/lib/services/llm/protocols/openai_chat_protocol.dart
@@ -356,7 +356,9 @@ class OpenAIChatProtocol implements ChatProtocol {
 
       if (response.statusCode != 200) {
         logger?.call('Request failed with status: ${response.statusCode}', level: 'ERROR');
-        throw Exception('OpenAI API Request failed: ${response.statusCode} - ${response.body}');
+        throw LLMApiException(
+            'OpenAI API Request failed: ${response.statusCode} - ${response.body}',
+            statusCode: response.statusCode);
       }
 
       logger?.call('Response received, parsing data...', level: 'DEBUG');
@@ -522,7 +524,9 @@ class OpenAIChatProtocol implements ChatProtocol {
       }
       logger?.call('Stream request failed with status: ${response.statusCode}', level: 'ERROR');
       client.close();
-      throw Exception('OpenAI API Stream Request failed: ${response.statusCode}');
+      throw LLMApiException(
+          'OpenAI API Stream Request failed: ${response.statusCode}',
+          statusCode: response.statusCode);
     }
 
     logger?.call('Stream connection established, waiting for chunks...', level: 'DEBUG');

--- a/lib/services/llm/protocols/protocol.dart
+++ b/lib/services/llm/protocols/protocol.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
 
 import '../llm_types.dart';
 import '../model_descriptor.dart';
@@ -138,16 +141,81 @@ void throwIfEnvelopeError(Map<String, dynamic> data) {
   final err = data['error'];
   if (err != null) {
     final msg = err is Map ? (err['message'] ?? err.toString()) : err.toString();
-    throw Exception('API error in response body: $msg');
+    throw LLMApiException('API error in response body: $msg',
+        isEnvelope: true);
   }
   final baseResp = data['base_resp'];
   if (baseResp is Map) {
     final code = baseResp['status_code'];
     if (code is num && code != 0) {
-      throw Exception(
-          'API error (base_resp $code): ${baseResp['status_msg'] ?? 'unknown'}');
+      throw LLMApiException(
+          'API error (base_resp $code): ${baseResp['status_msg'] ?? 'unknown'}',
+          isEnvelope: true);
     }
   }
+}
+
+/// Decodes a JSON API response in the one safe order: status first, then
+/// JSON, then shape, then in-body error envelopes. Returns the body as a map.
+///
+/// The order matters. The Gemini protocols used to `jsonDecode` before
+/// checking the status code, so a gateway's HTML 502 surfaced as
+/// `FormatException: Unexpected character` — the real status never appeared
+/// anywhere and the retry policy could not see the 5xx. Checking the status
+/// first keeps the code in the error; decoding second turns "the base URL
+/// points at something that is not this API" (nginx 404 pages, login pages,
+/// CDN errors) into words instead of a parser crash; the envelope check last
+/// catches relays that deliver failures inside a 200 (protocol.dart
+/// [throwIfEnvelopeError]).
+///
+/// On a non-2xx status the body is still probed for a JSON `error.message` so
+/// the thrown message leads with the provider's own words when there are any.
+Map<String, dynamic> decodeJsonBody(http.Response response,
+    {String apiName = 'API'}) {
+  final status = response.statusCode;
+  if (status < 200 || status >= 300) {
+    String detail = _bodyExcerpt(response.body);
+    final decoded = _tryJsonDecode(response.body);
+    if (decoded is Map) {
+      final err = decoded['error'];
+      if (err is Map && err['message'] != null) {
+        detail = '${err['message']}'
+            '${err['status'] != null ? ' (${err['status']})' : ''}';
+      }
+    }
+    throw LLMApiException('$apiName request failed: $status - $detail',
+        statusCode: status);
+  }
+
+  final decoded = _tryJsonDecode(response.body);
+  if (decoded == null) {
+    throw LLMApiException(
+        '$apiName returned a non-JSON body (HTML error page?) — the base URL '
+        'may point at something that is not this API. Body: '
+        '${_bodyExcerpt(response.body)}');
+  }
+  if (decoded is! Map) {
+    throw LLMApiException(
+        '$apiName returned an unexpected body shape '
+        '(${decoded.runtimeType}): ${_bodyExcerpt(response.body)}');
+  }
+
+  final data = decoded.cast<String, dynamic>();
+  throwIfEnvelopeError(data);
+  return data;
+}
+
+Object? _tryJsonDecode(String body) {
+  try {
+    return jsonDecode(body);
+  } on FormatException {
+    return null;
+  }
+}
+
+String _bodyExcerpt(String body) {
+  final s = body.trim();
+  return s.length > 500 ? '${s.substring(0, 500)}…' : s;
 }
 
 /// The payload of one SSE line, or null when the line carries none.

--- a/test/llm_error_handling_test.dart
+++ b/test/llm_error_handling_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:joycai_image_ai_toolkits/services/llm/llm_service.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/protocols/gemini_chat_protocol.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/protocols/protocol.dart';
+
+/// Pins the M1 error-handling fixes (docs/reviews/2026-08-ai-capability-review.md
+/// B1/B2/B5): the Gemini SSE line rules, the status-first response decode, and
+/// the structured retry decision.
+void main() {
+  group('geminiChunksFromSseLine (B1)', () {
+    const chunk =
+        '{"candidates":[{"content":{"parts":[{"text":"hi"}],"role":"model"}}]}';
+
+    test('data: with a space parses', () {
+      final chunks = geminiChunksFromSseLine('data: $chunk').toList();
+      expect(chunks, hasLength(1));
+      expect(chunks.single.textPart, 'hi');
+    });
+
+    test('data: without a space parses — SSE makes the space optional', () {
+      // The old inline parser only stripped "data: " (with space); a relay
+      // emitting "data:{...}" fed the whole prefixed line to jsonDecode.
+      final chunks = geminiChunksFromSseLine('data:$chunk').toList();
+      expect(chunks, hasLength(1));
+      expect(chunks.single.textPart, 'hi');
+    });
+
+    test('keep-alive comments, [DONE] and event: lines are ignored, not fatal',
+        () {
+      // Every one of these used to kill the stream: jsonDecode threw a
+      // FormatException, which implements Exception, which the old catch
+      // rethrew — while its comment claimed the line would be skipped.
+      expect(geminiChunksFromSseLine(': keep-alive'), isEmpty);
+      expect(geminiChunksFromSseLine('data: [DONE]'), isEmpty);
+      expect(geminiChunksFromSseLine('event: message'), isEmpty);
+      expect(geminiChunksFromSseLine('not json at all'), isEmpty);
+      expect(geminiChunksFromSseLine(''), isEmpty);
+    });
+
+    test('an in-chunk error envelope still throws', () {
+      expect(
+        () => geminiChunksFromSseLine(
+                'data: {"error":{"code":429,"message":"quota"}}')
+            .toList(),
+        throwsA(isA<LLMApiException>()
+            .having((e) => e.isEnvelope, 'isEnvelope', isTrue)),
+      );
+    });
+  });
+
+  group('decodeJsonBody (B2)', () {
+    test('non-2xx throws with the status code — even for an HTML body', () {
+      // The old Gemini order (jsonDecode first) turned a gateway's HTML 502
+      // into "FormatException: Unexpected character"; the real status never
+      // appeared and the retry policy could not see the 5xx.
+      final response = http.Response('<html>502 Bad Gateway</html>', 502);
+      expect(
+        () => decodeJsonBody(response, apiName: 'Test'),
+        throwsA(isA<LLMApiException>()
+            .having((e) => e.statusCode, 'statusCode', 502)
+            .having((e) => e.message, 'message', contains('502'))),
+      );
+    });
+
+    test('non-2xx with a JSON error body surfaces the provider message', () {
+      final response = http.Response(
+          '{"error":{"code":400,"message":"Invalid argument","status":"INVALID_ARGUMENT"}}',
+          400);
+      expect(
+        () => decodeJsonBody(response),
+        throwsA(isA<LLMApiException>()
+            .having((e) => e.statusCode, 'statusCode', 400)
+            .having((e) => e.message, 'message', contains('Invalid argument'))),
+      );
+    });
+
+    test('2xx non-JSON body names the real problem instead of crashing', () {
+      final response = http.Response('<html>login page</html>', 200);
+      expect(
+        () => decodeJsonBody(response),
+        throwsA(isA<LLMApiException>()
+            .having((e) => e.message, 'message', contains('non-JSON'))),
+      );
+    });
+
+    test('2xx JSON array body is a shape error, not a NoSuchMethodError', () {
+      final response = http.Response('[1,2,3]', 200);
+      expect(() => decodeJsonBody(response), throwsA(isA<LLMApiException>()));
+    });
+
+    test('200 with an error envelope throws (envelope, no status code)', () {
+      final response = http.Response('{"error":{"message":"expired key"}}', 200);
+      expect(
+        () => decodeJsonBody(response),
+        throwsA(isA<LLMApiException>()
+            .having((e) => e.isEnvelope, 'isEnvelope', isTrue)
+            .having((e) => e.statusCode, 'statusCode', isNull)),
+      );
+    });
+
+    test('a clean 200 returns the decoded map', () {
+      final response = http.Response('{"candidates":[]}', 200);
+      expect(decodeJsonBody(response), {'candidates': []});
+    });
+  });
+
+  group('LLMService.isRetryable (B5)', () {
+    test('structured 5xx and 429 retry; other codes do not', () {
+      expect(LLMService.isRetryable(LLMApiException('x', statusCode: 502)),
+          isTrue);
+      expect(LLMService.isRetryable(LLMApiException('x', statusCode: 429)),
+          isTrue);
+      expect(LLMService.isRetryable(LLMApiException('x', statusCode: 400)),
+          isFalse);
+      expect(LLMService.isRetryable(LLMApiException('x', statusCode: 401)),
+          isFalse);
+    });
+
+    test('envelope errors never retry — the transport succeeded', () {
+      expect(
+          LLMService.isRetryable(
+              LLMApiException('API error in response body: quota',
+                  isEnvelope: true)),
+          isFalse);
+    });
+
+    test('numbers in error prose are not status codes', () {
+      // The old regex grabbed the first three-digit number anywhere, so this
+      // 400-class message was retried as if it were a 5xx.
+      expect(
+          LLMService.isRetryable(Exception(
+              'API error in response body: rate limited, retry after 500ms')),
+          isFalse);
+      expect(
+          LLMService.isRetryable(
+              Exception('model "gpt-500-turbo" does not exist')),
+          isFalse);
+    });
+
+    test('legacy "... failed: <status>" prose still recognized', () {
+      expect(
+          LLMService.isRetryable(
+              Exception('xAI Images API failed: 503 - upstream down')),
+          isTrue);
+      expect(
+          LLMService.isRetryable(
+              Exception('xAI Images API failed: 422 - bad prompt')),
+          isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

Fixes the P0 findings from the AI capability review (`docs/reviews/2026-08-ai-capability-review.md`, included in this PR together with the review baseline `docs/ai-agent-playbook/` and the roadmap `docs/plans/2026-08-ai-improvement-plan.md`).

**New shared mechanisms** (`protocols/protocol.dart`, `llm_types.dart`) — the seeds of the M2 refactor:
- `LLMApiException` — structured API error carrying the HTTP status code (or `isEnvelope` for 200-with-error bodies).
- `decodeJsonBody()` — enforces the one safe decode order: status first → JSON → shape guard → error envelope.

**Fixes** (review IDs in parentheses):
- **Gemini streaming no longer dies on relay SSE noise (B1)** — line handling moved to the shared `sseDataPayload` helper and extracted as testable `geminiChunksFromSseLine`. No-space `data:`, keep-alive comments, `[DONE]` and `event:` lines are now ignored; previously each of them killed the whole stream because the catch rethrew `FormatException`.
- **Gemini decode order (B2)** — all three Gemini protocols use `decodeJsonBody`; an HTML 502 now reports the real status instead of a bare `FormatException`, and non-Map bodies can't `NoSuchMethodError`.
- **Imagen silent empty success (B3)** — a 200 with no decodable image now throws (mirrors the OpenAI/xAI images surfaces) and returns non-empty metadata.
- **Billing coverage (B4)** — Imagen calls and video-job submissions (Veo/Sora/xAI) now record a usage row; they were previously invisible to the metrics page and request billing.
- **Retry policy (B5)** — `isRetryable` reads `LLMApiException.statusCode` (5xx/429 only, envelopes never retry); the legacy regex is anchored to `failed: <status>` prose instead of grabbing the first three-digit number anywhere (`retry after 500ms` was treated as a 5xx).
- **Midjourney non-streaming timeout (B7)** — the dispatcher supplies an 11-minute timeout for MJ, whose `generate()` contains a full submit→poll cycle; the flat 120 s guard failed every non-streaming call.
- **Rename-agent pairing (B10)** — mid-batch cancellation now stubs remaining tool calls, matching the invariant `PromptOptimizerAgent` enforces.
- **Debug log hygiene (B9)** — `LLMDebugLogger` truncates any >2048-char string protocol-agnostically, so base64 image payloads no longer land in `api_logs/`.

## Reviewer notes

- `gemini_veo_protocol.dart` `poll()` deliberately does **not** use `decodeJsonBody`: a failed operation arrives inside a 200 as `{done, error: {...}}` and the task executor consumes that envelope — the comment in the code records this.
- Behavior change: previously-silent failures (Imagen empty results, Gemini malformed bodies) now surface as errors — that is the point, but it means tasks that used to "succeed with nothing" will now show as failed.

## Testing

- `flutter analyze` — no issues.
- New `test/llm_error_handling_test.dart` (14 cases) pins the SSE line rules, the decode order and the retry decision.
- Full unit-test suite passes (589 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)