### PR TITLE
refactor: LLM protocol hardening — shared mechanisms, discipline zeroing, thinking-block replay (M2)

### DIFF
--- a/docs/architecture/llm-three-layer.md
+++ b/docs/architecture/llm-three-layer.md
@@ -93,10 +93,10 @@ review 时用下面的模式全仓库 grep 一遍即可：
 
 | 红线模式（grep） | 为什么禁止 | 正确位置 |
 |----------------|-----------|---------|
-| `modelId.contains(` / `modelId.startsWith(` / `id.contains(` 出现在 `model_family.dart`、`model_descriptor.dart` 之外 | 模型分类只能有一个事实来源；散点嗅探曾导致 30+ 条规则互相踩（顺序敏感、改一处漏一处） | 加进 `ModelFamilyClassifier` 的规则表，消费方读 `ModelDescriptor.of(id)` |
+| `modelId.contains(` / `modelId.startsWith(` / `id.contains(` 出现在 `model_family.dart`、`model_capabilities.dart`、`model_descriptor.dart` 之外 | 模型分类只能有一个事实来源；散点嗅探曾导致 30+ 条规则互相踩（顺序敏感、改一处漏一处） | 加进 `ModelFamilyClassifier` 的规则表（含 `isNijiVariant` / `isTextOnlyChat` / `isMockModel` 这类具名谓词），消费方读 `ModelDescriptor.of(id)` |
 | `vendor.id ==` 任何位置 | 协议一旦认识具体厂商，厂商差异就会重新散落 | `VendorProfile` 加声明式字段（参考 `usesXaiNativeSurfaces`），dispatcher 据此选协议 |
 | `channelType ==` / `channel.type ==` 出现在 `vendors/`、`llm_dispatcher.dart` 之外 | 这是重构前 `isXai`/`isNewApiGemini` 散点判断的复活形态 | 语义抬升为 `Vendors.byId(...)` 后读 profile 字段 |
-| UI/state 里出现 `'openai-api-rest'` 这类裸字符串字面量 | 拼错静默失效；重命名时漏改 | 引用 `Vendors.openAIRest` 等常量 |
+| UI/state 里出现 `'openai-api-rest'` 这类裸字符串字面量 | 拼错静默失效；重命名时漏改（`Vendors.byId` 对未知 id 静默回退 openAIRest，错拼永远不报错） | 引用 `Vendors.openAIRest` 等常量。**两条豁免**：`database_migrations.dart`（迁移代码按当时的字面量冻结，改成常量反而会让未来的常量重命名悄悄改写历史迁移）；`channel_wizard_dialog.dart` 的 `_ProviderPreset.id`（那是向导自己的预设命名空间，与 vendor id 拼写雷同但语义无关——真正进 `llm_channels.type` 的是 `preset.channelType` 字段，它已全部引用 `Vendors.*`） |
 | `if (family == ...)` 路由分支出现在 `llm_dispatcher.dart` 和 Layer 3 之外 | 路由规则必须单点可审计 | 挪进 dispatcher 对应 switch，加注释说明规则来源 |
 | 给 DB 表新增"由其他表推导出来的"列（如当年的 `llm_models.type`） | 冗余副本没有级联更新，就是 bug 面；v32 迁移专门为删它而生 | 运行时解析（`channel → vendor → protocol`），不落库 |
 | 协议文件里写死某厂商的 endpoint 路径差异 | endpoint 形状属于协议，*选择哪个* endpoint 属于 vendor | 独立协议类 + vendor 覆写，由 dispatcher 组合 |
@@ -104,6 +104,36 @@ review 时用下面的模式全仓库 grep 一遍即可：
 新增代码的自检口诀：**"这行代码回答的是哪一层的问题？"** ——
 线上格式 → protocols/；谁在供货/怎么认证 → vendors/；这个模型是什么 → Layer 3；
 选哪条路 → dispatcher。回答不出来的，先别写。
+
+## 协议实现的共享机制（2026-08 M2 加固，新协议照抄）
+
+写一个新协议（或改既有协议的解码路径）时，以下机制**必须复用而不是手写**，
+它们各自对应一类踩过的静默失败（`test/llm_error_handling_test.dart` 钉住）：
+
+- **`decodeJsonBody(response, apiName: …)`**（`protocols/protocol.dart`）——
+  唯一安全的解码顺序：状态码 → JSON → 形状 → 错误信封。手写这四步曾让
+  Gemini 把网关的 HTML 502 报成裸 `FormatException`（真实状态码永不现身）。
+  异步任务的 **poll** 面传 `checkEnvelope: false`：失败的任务以
+  `{status:"failed", error:{…}}` 形式装在 200 里，由 poll 自己的状态机报错
+  （带上 operation 名），通用信封检查会先一步抢走并丢掉这个上下文。
+- **`LLMApiException`**（`llm_types.dart`）—— 非 2xx 与信封错误一律抛它。
+  `LLMService.isRetryable` 读它的 `statusCode` 决定重试（仅 5xx/429）；
+  抛裸 `Exception` 的老路径靠一条锚定 `failed: <status>` 的 legacy 正则兜底，
+  新代码不许依赖它。
+- **`sseDataPayload(line)`** —— SSE 行解析（`data:` 后空格可选、注释行、
+  `[DONE]`）。调用前自行跳过 `event:` 行；解析失败的行**忽略**，不许把
+  `FormatException` 重抛成整条流的死刑（gemini 踩过，见
+  `geminiChunksFromSseLine` 的 dartdoc）。
+- **`redactUrl(url)`**（经 `protocol.dart` 转出口）—— 任何写进 debug 日志的
+  请求 URL 必须先过它：Google 系 vendor 的 URL 带 `?key=`，靠日志落盘层的
+  正则兜底等于把一个机制的 bug 变成凭证泄漏。
+- **`VendorProfile.downloadHeaders(apiKey)`** —— 下载生成产物（视频/图片 URI）
+  时用什么认证头是 Layer 2 知识，executor 只消费；按协议族分支写在调用方
+  曾是红线违规（错头会被静默忽略，下一个非 bearer vendor 只会得到一个 403）。
+- **`VideoJobProtocol.poll` / dispatcher `checkOperation` 的返回契约**是
+  Veo 信封（`{name, done, response|progress}`），四个家族一致 —— 包括 MJ
+  分支（dispatcher 内翻译）。唯一豁免：`gemini_veo` 的 poll 返回原始
+  operation JSON 里的 `{done, error}` 由 executor 消费，注释已说明。
 
 ## ④ Anthropic 的六条不变量（会静默错，不会报错）
 

--- a/docs/reviews/2026-08-ai-capability-review.md
+++ b/docs/reviews/2026-08-ai-capability-review.md
@@ -186,9 +186,9 @@ else if (id.contains('gemini')) { _modelTag = 'multimodal'; }
 
 直接违反红线一，且 `ModelFamilyClassifier` 已有推断逻辑——这是会独立漂移的第二套规则。修复：调用 Layer 3 的既有推断（models 屏的对应逻辑），删除本地 contains 链。
 
-### V4 · channel wizard/edit dialog 成片裸 vendor id 字面量【建议修】
+### V4 · channel edit dialog 裸 vendor id 字面量【建议修】
 
-`channel_wizard_dialog.dart` 15 处、`channel_edit_dialog.dart:53` 直接写 `'newapi-openai'`/`'newapi-gemini'`/`'midjourney-proxy'`/`'google-genai-rest'` 字符串（红线四：vendor id 引用应使用 `Vendors.*` 常量）。拼写错误只能在运行时暴露（`Vendors.byId` 对未知 id 静默回退 `openAIRest`，错误会被吞掉）。`database_migrations.dart` 中的裸串属迁移代码需冻结，可豁免但建议在红线文档补一条豁免说明。
+**（2026-08 M2 核实后修订）** 初版报告称 `channel_wizard_dialog.dart` 有 15 处裸 vendor id——复核为误报：那些是 `_ProviderPreset.id`（向导自己的预设命名空间，拼写与部分 vendor id 雷同但语义无关），真正写入 `llm_channels.type` 的 `channelType` 字段已全部引用 `Vendors.*` 常量。真实违规仅 `channel_edit_dialog.dart:53` 的 `'google-genai-rest'` 一处（M2 已修）。`database_migrations.dart` 中的裸串属迁移代码冻结豁免——两条豁免均已写入红线文档。
 
 ### V5 · `task_executors.dart:459-463` 认证逻辑写在 Layer 2 之外【建议修】
 

--- a/lib/screens/wizard/setup_wizard.dart
+++ b/lib/screens/wizard/setup_wizard.dart
@@ -9,6 +9,7 @@ import '../../l10n/app_localizations.dart';
 import '../../services/database_service.dart';
 import '../../services/llm/llm_types.dart';
 import '../../services/llm/model_discovery_service.dart';
+import '../../services/llm/model_family.dart';
 import '../../services/llm/vendors/vendors.dart';
 import '../../state/app_state.dart';
 import '../../widgets/api_key_field.dart';
@@ -495,15 +496,10 @@ class _SetupWizardState extends State<SetupWizard> {
         setState(() {
           _modelIdController.text = selected.modelId;
           _modelNameController.text = selected.displayName;
-          // Infer tag
-          final id = selected.modelId.toLowerCase();
-          if (id.contains('vision') || id.contains('image')) {
-            _modelTag = 'multimodal';
-          } else if (id.contains('gemini')) {
-            _modelTag = 'multimodal';
-          } else {
-            _modelTag = 'chat';
-          }
+          // Layer 3 owns model-id inference — this used to be a second,
+          // divergent contains() chain (the discovery dialog already tags
+          // through the classifier).
+          _modelTag = ModelFamilyClassifier.inferTag(selected.modelId);
         });
       }
     } catch (e) {

--- a/lib/services/ai_rename_agent.dart
+++ b/lib/services/ai_rename_agent.dart
@@ -193,6 +193,8 @@ class AiRenameAgent {
         reasoningContent: response.reasoningContent,
         reasoningFieldName: response.reasoningFieldName,
         reasoningSignature: response.reasoningSignature,
+        rawThinkingBlocks: response.rawThinkingBlocks,
+        rawThinkingModelId: response.rawThinkingModelId,
         toolCalls: response.toolCalls,
       ));
 

--- a/lib/services/llm/llm_dispatcher.dart
+++ b/lib/services/llm/llm_dispatcher.dart
@@ -206,7 +206,7 @@ class LLMDispatcher {
           return protocol.submit(target, history, options: options, logger: logger);
         }
 
-        final isSimulation = options?['simulation'] == true || config.modelId.startsWith('mock-');
+        final isSimulation = options?['simulation'] == true || target.model.isMockModel;
         if (isSimulation) {
           logger?.call('Simulating long-running operation for OpenAI-style model: ${config.modelId}', level: 'INFO');
           return 'openai_lro_sim_${DateTime.now().millisecondsSinceEpoch}';
@@ -227,7 +227,39 @@ class LLMDispatcher {
     final target = resolveTarget(config);
     switch (target.vendor.family) {
       case ProtocolFamily.midjourney:
-        return _midjourney.fetchTaskStatus(target, operationName);
+        // Translated into the same Veo-shaped envelope every other family's
+        // poll returns — the only caller (the videoGenerate executor) speaks
+        // that envelope, and this used to be the one branch handing back the
+        // raw /mj/task JSON instead. Midjourney models classify as an image
+        // family, so the branch is defensive rather than routine; all the
+        // more reason for it to honor the contract when it does fire.
+        final mjTask = await _midjourney.fetchTaskStatus(target, operationName);
+        final mjStatus = mjTask['status']?.toString() ?? '';
+        if (mjStatus == 'FAILURE') {
+          throw LLMApiException(
+              'Midjourney task $operationName failed: ${mjTask['failReason'] ?? mjTask}');
+        }
+        if (mjStatus == 'SUCCESS') {
+          return {
+            'name': operationName,
+            'done': true,
+            'response': {
+              'generateVideoResponse': {
+                'generatedSamples': [
+                  {
+                    'video': {'uri': mjTask['imageUrl']?.toString() ?? ''},
+                  }
+                ],
+              },
+            },
+          };
+        }
+        return {
+          'name': operationName,
+          'done': false,
+          'progress': mjTask['progress'] ?? 0,
+          'status': mjStatus,
+        };
 
       case ProtocolFamily.anthropic:
         throw UnsupportedError(

--- a/lib/services/llm/llm_types.dart
+++ b/lib/services/llm/llm_types.dart
@@ -164,6 +164,19 @@ class LLMMessage {
   /// stays null there, so the ① payload builder never invents a field for it.
   final String? reasoningSignature;
 
+  /// ④'s thinking-class blocks **verbatim** (sealed `thinking` +
+  /// `redacted_thinking`, original order), for replay into a tool-calling
+  /// conversation. [reasoningContent]/[reasoningSignature] stay the display
+  /// carriers; this exists because a redacted block has no text to
+  /// reconstruct from, and ④ answers an incomplete thinking history by
+  /// *silently disabling thinking* (while billing it) rather than erroring.
+  final List<Map<String, dynamic>>? rawThinkingBlocks;
+
+  /// The model that produced [rawThinkingBlocks]. Replay is model-scoped:
+  /// another model silently ignores foreign blocks and still bills them as
+  /// input, so the payload builder drops the group on mismatch.
+  final String? rawThinkingModelId;
+
   /// Tool calls carried by an assistant message (echoed back into history
   /// during an agent loop).
   final List<LLMToolCall> toolCalls;
@@ -182,6 +195,8 @@ class LLMMessage {
     this.reasoningContent,
     this.reasoningFieldName,
     this.reasoningSignature,
+    this.rawThinkingBlocks,
+    this.rawThinkingModelId,
     this.toolCalls = const [],
     this.toolCallId,
     this.toolName,
@@ -195,6 +210,9 @@ class LLMMessage {
         if (reasoningContent != null) 'reasoningContent': reasoningContent,
         if (reasoningFieldName != null) 'reasoningFieldName': reasoningFieldName,
         if (reasoningSignature != null) 'reasoningSignature': reasoningSignature,
+        if (rawThinkingBlocks != null && rawThinkingBlocks!.isNotEmpty)
+          'rawThinkingBlocks': rawThinkingBlocks,
+        if (rawThinkingModelId != null) 'rawThinkingModelId': rawThinkingModelId,
         if (attachments.isNotEmpty)
           'attachments': attachments.map((a) => a.toJson()).whereType<Map<String, dynamic>>().toList(),
         if (toolCalls.isNotEmpty) 'toolCalls': toolCalls.map((c) => c.toJson()).toList(),
@@ -208,6 +226,13 @@ class LLMMessage {
         reasoningContent: json['reasoningContent'] as String?,
         reasoningFieldName: json['reasoningFieldName'] as String?,
         reasoningSignature: json['reasoningSignature'] as String?,
+        rawThinkingBlocks: json['rawThinkingBlocks'] is List
+            ? [
+                for (final b in json['rawThinkingBlocks'] as List)
+                  if (b is Map) b.cast<String, dynamic>(),
+              ]
+            : null,
+        rawThinkingModelId: json['rawThinkingModelId'] as String?,
         attachments: [
           for (final a in (json['attachments'] as List? ?? []))
             if (a is Map && LLMAttachment.fromJson(a.cast<String, dynamic>()) != null)
@@ -353,6 +378,12 @@ class LLMResponse {
   /// request in a tool-calling conversation is rejected.
   final String? reasoningSignature;
 
+  /// ④'s thinking-class blocks verbatim — see [LLMMessage.rawThinkingBlocks].
+  final List<Map<String, dynamic>>? rawThinkingBlocks;
+
+  /// Producer of [rawThinkingBlocks] — see [LLMMessage.rawThinkingModelId].
+  final String? rawThinkingModelId;
+
   /// Tool calls requested by the model (empty when it answered directly).
   final List<LLMToolCall> toolCalls;
 
@@ -365,6 +396,8 @@ class LLMResponse {
     this.reasoningContent,
     this.reasoningFieldName,
     this.reasoningSignature,
+    this.rawThinkingBlocks,
+    this.rawThinkingModelId,
     this.toolCalls = const [],
   });
 }

--- a/lib/services/llm/model_descriptor.dart
+++ b/lib/services/llm/model_descriptor.dart
@@ -39,7 +39,7 @@ class ModelDescriptor {
 
   /// True when this id is a Niji variant of Midjourney (drives the proxy's
   /// `botType` field).
-  bool get isNijiVariant => modelId.toLowerCase().contains('niji');
+  bool get isNijiVariant => ModelFamilyClassifier.isNijiVariant(modelId);
 
   /// Whether the model accepts image *input* (multimodal understanding), as
   /// opposed to the generation-side capabilities in [capabilities].
@@ -49,7 +49,11 @@ class ModelDescriptor {
   /// gets silently dropped, so the model answers as if it saw the image.
   ///
   /// Default is true (the historical behavior); only families/ids known to be
-  /// text-only opt out. DeepSeek's chat/completions endpoint takes text only —
-  /// its multimodal models are not served there (as of 2026-08).
-  bool get acceptsImageInput => !modelId.toLowerCase().contains('deepseek');
+  /// text-only opt out — the rule itself lives in the classifier's table.
+  bool get acceptsImageInput => !ModelFamilyClassifier.isTextOnlyChat(modelId);
+
+  /// True for the `mock-*` ids the simulated long-running-operation path
+  /// accepts. Here rather than in the dispatcher because model-id sniffing is
+  /// this layer's monopoly.
+  bool get isMockModel => ModelFamilyClassifier.isMockModel(modelId);
 }

--- a/lib/services/llm/model_family.dart
+++ b/lib/services/llm/model_family.dart
@@ -58,7 +58,7 @@ class ModelFamilyClassifier {
     if (id.startsWith('mj_') ||
         id == 'mj' ||
         id.contains('midjourney') ||
-        id.contains('niji')) {
+        isNijiVariant(id)) {
       return ModelFamily.midjourney;
     }
 
@@ -113,6 +113,23 @@ class ModelFamilyClassifier {
   static bool _isOpenAIReasoning(String id) {
     return RegExp(r'(^|[^a-z])o[1-9](-|$)').hasMatch(id);
   }
+
+  /// True when this id is a Niji variant of Midjourney. A variant *within*
+  /// the midjourney family (it drives the proxy's `botType`), which is why it
+  /// is a named predicate here rather than another [ModelFamily] value. Lives
+  /// in this rule table so the string rule exists exactly once.
+  static bool isNijiVariant(String modelId) =>
+      modelId.toLowerCase().contains('niji');
+
+  /// Ids whose chat surface takes text only — image parts either 400 or,
+  /// worse, get silently dropped. DeepSeek's chat/completions endpoint does
+  /// not serve its multimodal models (as of 2026-08).
+  static bool isTextOnlyChat(String modelId) =>
+      modelId.toLowerCase().contains('deepseek');
+
+  /// Mock ids used by the simulated long-running-operation path
+  /// (`mock-*`). A Layer 3 fact so the dispatcher never sniffs a model id.
+  static bool isMockModel(String modelId) => modelId.startsWith('mock-');
 
   /// True for any Gemini/Google-served family. These need the OpenAI-compat
   /// Gemini extensions when routed through an OpenAI-style relay.

--- a/lib/services/llm/protocols/anthropic_chat_protocol.dart
+++ b/lib/services/llm/protocols/anthropic_chat_protocol.dart
@@ -64,7 +64,8 @@ class AnthropicHistory {
 ///    tool calls arrives as N tool messages, and all N results have to travel
 ///    in *one* user message immediately after the assistant turn that asked
 ///    for them.
-AnthropicHistory buildAnthropicHistory(List<LLMMessage> history) {
+AnthropicHistory buildAnthropicHistory(List<LLMMessage> history,
+    {String? modelId}) {
   final systemParts = <String>[];
   final messages = <Map<String, dynamic>>[];
 
@@ -101,13 +102,25 @@ AnthropicHistory buildAnthropicHistory(List<LLMMessage> history) {
 
     if (msg.role == LLMRole.assistant) {
       final blocks = <Map<String, dynamic>>[];
-      // Thinking goes back first, and only sealed. With thinking on, ④
-      // rejects a replayed tool-calling turn whose thinking block is missing
-      // or unsigned — and it must precede the text and tool_use blocks it
-      // led to. An unsigned one is dropped rather than sent: the API would
-      // refuse it anyway, and a refused request is worse than a turn the
-      // model has to re-derive.
-      if (msg.reasoningContent != null && msg.reasoningSignature != null) {
+      // Thinking goes back first, verbatim when the raw blocks were captured
+      // (thinking + redacted_thinking, original order and content — the only
+      // history ④ accepts as complete). Replay is model-scoped: blocks from
+      // a different model are not rejected upstream, they are silently
+      // ignored and still billed as input, so a mismatch drops the group.
+      final rawBlocks = msg.rawThinkingBlocks;
+      if (rawBlocks != null && rawBlocks.isNotEmpty) {
+        if (modelId == null || msg.rawThinkingModelId == modelId) {
+          blocks.addAll(rawBlocks);
+        }
+      } else if (msg.reasoningContent != null &&
+          msg.reasoningSignature != null) {
+        // Legacy path (histories persisted before raw-block capture): a
+        // sealed thinking block reconstructed from the display fields. With
+        // thinking on, ④ rejects a replayed tool-calling turn whose thinking
+        // block is missing or unsigned — and it must precede the text and
+        // tool_use blocks it led to. An unsigned one is dropped rather than
+        // sent: the API would refuse it anyway, and a refused request is
+        // worse than a turn the model has to re-derive.
         blocks.add({
           'type': 'thinking',
           'thinking': msg.reasoningContent,
@@ -217,7 +230,8 @@ Map<String, dynamic> prepareAnthropicPayload(
   List<LLMTool>? tools,
   required bool isStreaming,
 }) {
-  final converted = buildAnthropicHistory(history);
+  final converted =
+      buildAnthropicHistory(history, modelId: target.config.modelId);
   final maxTokens = anthropicMaxTokens(options);
   final payload = <String, dynamic>{
     'model': target.config.modelId,
@@ -290,13 +304,24 @@ class AnthropicContent {
   /// reply to a call the model never made.
   final List<ServerToolRun> serverToolRuns;
 
+  /// The turn's thinking-class blocks **verbatim, in original order**: sealed
+  /// `thinking` blocks and opaque `redacted_thinking` blocks. This is the
+  /// replay carrier — reconstructing a thinking block from [thinking] +
+  /// [thinkingSignature] loses exactly the blocks that have no text to
+  /// reconstruct from, and ④'s reaction to an incomplete thinking history is
+  /// not a 400 but *silently disabling thinking for the turn* (while still
+  /// billing it). [thinking]/[thinkingSignature] remain the display/legacy
+  /// carriers.
+  final List<Map<String, dynamic>> rawThinkingBlocks;
+
   const AnthropicContent(
     this.text,
     this.thinking,
     this.thinkingSignature,
     this.toolCalls,
-    this.serverToolRuns,
-  );
+    this.serverToolRuns, {
+    this.rawThinkingBlocks = const [],
+  });
 }
 
 /// Reads a `content` block array. Unknown block types contribute nothing —
@@ -306,6 +331,7 @@ AnthropicContent parseAnthropicContent(Object? rawContent) {
   final text = StringBuffer();
   final thinking = StringBuffer();
   String? signature;
+  final rawThinkingBlocks = <Map<String, dynamic>>[];
   final toolCalls = <LLMToolCall>[];
   final serverToolRuns = <ServerToolRun>[];
   // `server_tool_use` and its result are separate blocks tied by an id, and
@@ -330,7 +356,20 @@ AnthropicContent parseAnthropicContent(Object? rawContent) {
         final value = block['thinking'];
         if (value is String) thinking.write(value);
         final seal = block['signature'];
-        if (seal is String && seal.isNotEmpty) signature = seal;
+        if (seal is String && seal.isNotEmpty) {
+          signature = seal;
+          // Only sealed blocks are kept for replay — the API refuses an
+          // unsigned one, and refusing the whole request is worse than the
+          // model re-deriving a thought.
+          rawThinkingBlocks.add(block.cast<String, dynamic>());
+        }
+      } else if (type == 'redacted_thinking') {
+        // Opaque encrypted blob: nothing to show, nothing to count — but it
+        // MUST survive for replay. A tool-calling turn replayed without its
+        // redacted_thinking block is an incomplete thinking history, which ④
+        // silently strips (thinking stops, billing continues) rather than
+        // rejects.
+        rawThinkingBlocks.add(block.cast<String, dynamic>());
       } else if (type == 'tool_use') {
         final input = block['input'];
         toolCalls.add(LLMToolCall(
@@ -380,6 +419,7 @@ AnthropicContent parseAnthropicContent(Object? rawContent) {
     signature,
     toolCalls,
     serverToolRuns,
+    rawThinkingBlocks: rawThinkingBlocks,
   );
 }
 
@@ -539,6 +579,11 @@ class AnthropicChatProtocol implements ChatProtocol {
         // null is what keeps the ① payload builder from inventing a key for
         // it if this history is ever replayed against an ① endpoint.
         reasoningSignature: content.thinkingSignature,
+        rawThinkingBlocks: content.rawThinkingBlocks.isEmpty
+            ? null
+            : content.rawThinkingBlocks,
+        rawThinkingModelId:
+            content.rawThinkingBlocks.isEmpty ? null : config.modelId,
         toolCalls: content.toolCalls,
       );
     } finally {

--- a/lib/services/llm/protocols/anthropic_chat_protocol.dart
+++ b/lib/services/llm/protocols/anthropic_chat_protocol.dart
@@ -477,7 +477,7 @@ class AnthropicChatProtocol implements ChatProtocol {
       File? debugFile;
       if (appState.enableApiDebug) {
         debugFile = await LLMDebugLogger.startLog(config.modelId, 'Anthropic (Standard)', {
-          'url': url.toString(),
+          'url': redactUrl(url),
           'headers': headers,
           'body': payload,
         });
@@ -490,23 +490,14 @@ class AnthropicChatProtocol implements ChatProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      if (response.statusCode != 200) {
-        logger?.call('Request failed with status: ${response.statusCode}', level: 'ERROR');
-        throw LLMApiException(
-            'Anthropic API Request failed: ${response.statusCode} - ${response.body}',
-            statusCode: response.statusCode);
-      }
-
       logger?.call('Response received, parsing data...', level: 'DEBUG');
-      final data = jsonDecode(response.body);
-      if (data is Map<String, dynamic>) {
-        // ④ delivers errors as `{"type":"error","error":{…}}`, which the
-        // shared check already recognizes by its `error` field — and a relay
-        // can serve one behind a 200.
-        throwIfEnvelopeError(data);
-      }
+      // Status → JSON → shape → envelope, in that order (decodeJsonBody). ④
+      // delivers errors as `{"type":"error","error":{…}}`, which the shared
+      // envelope check recognizes by its `error` field — and a relay can
+      // serve one behind a 200.
+      final data = decodeJsonBody(response, apiName: 'Anthropic API');
 
-      final rawContent = data is Map ? data['content'] : null;
+      final rawContent = data['content'];
       if (rawContent is! List || rawContent.isEmpty) {
         // Same rule the other two families now follow: a body carrying no
         // content is a failed request, not a model that chose to say nothing.
@@ -578,7 +569,7 @@ class AnthropicChatProtocol implements ChatProtocol {
     File? debugFile;
     if (appState.enableApiDebug) {
       debugFile = await LLMDebugLogger.startLog(config.modelId, 'Anthropic (Stream)', {
-        'url': url.toString(),
+        'url': redactUrl(url),
         'headers': headers,
         'body': payload,
       });
@@ -731,12 +722,9 @@ class AnthropicDiscoveryProtocol implements DiscoveryProtocol {
 
     final response = await http.get(url, headers: headers);
 
-    if (response.statusCode != 200) {
-      throw Exception('Failed to fetch Anthropic models: ${response.statusCode} - ${response.body}');
-    }
-
-    final data = jsonDecode(response.body);
-    final List<dynamic> modelsJson = (data is Map ? data['data'] : null) ?? [];
+    final data = decodeJsonBody(response, apiName: 'Anthropic models');
+    final rawModels = data['data'];
+    final List<dynamic> modelsJson = rawModels is List ? rawModels : const [];
 
     return modelsJson.whereType<Map>().map((m) {
       final id = m['id']?.toString() ?? '';

--- a/lib/services/llm/protocols/gemini_chat_protocol.dart
+++ b/lib/services/llm/protocols/gemini_chat_protocol.dart
@@ -40,7 +40,7 @@ class GeminiChatProtocol implements ChatProtocol {
       File? debugFile;
       if (appState.enableApiDebug) {
         debugFile = await LLMDebugLogger.startLog(config.modelId, 'GoogleGenAI (Standard)', {
-          'url': url.toString(),
+          'url': redactUrl(url),
           'headers': headers,
           'body': payload,
         });
@@ -119,7 +119,7 @@ class GeminiChatProtocol implements ChatProtocol {
     File? debugFile;
     if (appState.enableApiDebug) {
       debugFile = await LLMDebugLogger.startLog(config.modelId, 'GoogleGenAI (Stream)', {
-        'url': url.toString(),
+        'url': redactUrl(url),
         'headers': headers,
         'body': payload,
       });
@@ -219,12 +219,9 @@ class GeminiDiscoveryProtocol implements DiscoveryProtocol {
 
     final response = await http.get(url, headers: headers);
 
-    if (response.statusCode != 200) {
-      throw Exception('Failed to fetch models: ${response.statusCode} - ${response.body}');
-    }
-
-    final data = jsonDecode(response.body);
-    final List<dynamic> modelsJson = data['models'] ?? [];
+    final data = decodeJsonBody(response, apiName: 'Gemini models');
+    final rawModels = data['models'];
+    final List<dynamic> modelsJson = rawModels is List ? rawModels : const [];
 
     return modelsJson.map((m) => DiscoveredModel(
       modelId: m['name']?.toString().replaceFirst('models/', '') ?? '',

--- a/lib/services/llm/protocols/gemini_imagen_protocol.dart
+++ b/lib/services/llm/protocols/gemini_imagen_protocol.dart
@@ -48,7 +48,7 @@ class GeminiImagenProtocol implements ImageGenProtocol {
       File? debugFile;
       if (appState.enableApiDebug) {
         debugFile = await LLMDebugLogger.startLog(config.modelId, 'GoogleImagen (Predict)', {
-          'url': url.toString(),
+          'url': redactUrl(url),
           'headers': headers,
           'body': getSafePayload(payload),
         });

--- a/lib/services/llm/protocols/gemini_veo_protocol.dart
+++ b/lib/services/llm/protocols/gemini_veo_protocol.dart
@@ -5,7 +5,6 @@ import '../../../core/safety_settings.dart';
 import '../../../state/app_state.dart';
 import '../llm_debug_logger.dart';
 import '../llm_types.dart';
-import '../vendors/vendor_profile.dart';
 import 'gemini_payload.dart';
 import 'protocol.dart';
 
@@ -51,7 +50,7 @@ class GeminiVeoProtocol implements VideoJobProtocol {
       File? debugFile;
       if (appState.enableApiDebug) {
         debugFile = await LLMDebugLogger.startLog(config.modelId, 'GoogleVeo (LRO Start)', {
-          'url': url.toString(),
+          'url': redactUrl(url),
           'headers': headers,
           'body': payload,
         });

--- a/lib/services/llm/protocols/midjourney_protocol.dart
+++ b/lib/services/llm/protocols/midjourney_protocol.dart
@@ -182,11 +182,8 @@ class MidjourneyProtocol implements ChatProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${submitResp.body}');
       }
 
-      if (submitResp.statusCode != 200) {
-        throw Exception('Midjourney submit failed: ${submitResp.statusCode} - ${submitResp.body}');
-      }
-
-      final submitData = jsonDecode(submitResp.body) as Map<String, dynamic>;
+      final submitData =
+          decodeJsonBody(submitResp, apiName: 'Midjourney submit');
       final submitCode = submitData['code'];
       // code 1 = success, 22 = queued (also acceptable — task is created).
       if (submitCode != 1 && submitCode != 22) {
@@ -254,10 +251,11 @@ class MidjourneyProtocol implements ChatProtocol {
     final baseUrl = trimBaseUrl(target.config.endpoint);
     final url = Uri.parse('$baseUrl/mj/task/$taskId/fetch');
     final resp = await client.get(url, headers: target.headers());
-    if (resp.statusCode != 200) {
-      throw Exception('Midjourney fetch failed: ${resp.statusCode} - ${resp.body}');
-    }
-    return jsonDecode(resp.body) as Map<String, dynamic>;
+    // checkEnvelope: false — the task JSON is a status record
+    // (status/progress/failReason), and FAILURE is handled by the polling
+    // loop with the task id in its message.
+    return decodeJsonBody(resp,
+        apiName: 'Midjourney fetch', checkEnvelope: false);
   }
 
   Future<Uint8List> _downloadImage(http.Client client, String url) async {

--- a/lib/services/llm/protocols/openai_chat_protocol.dart
+++ b/lib/services/llm/protocols/openai_chat_protocol.dart
@@ -341,7 +341,7 @@ class OpenAIChatProtocol implements ChatProtocol {
       File? debugFile;
       if (appState.enableApiDebug) {
         debugFile = await LLMDebugLogger.startLog(config.modelId, 'OpenAI (Standard)', {
-          'url': url.toString(),
+          'url': redactUrl(url),
           'headers': headers,
           'body': payload,
         });
@@ -354,27 +354,16 @@ class OpenAIChatProtocol implements ChatProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      if (response.statusCode != 200) {
-        logger?.call('Request failed with status: ${response.statusCode}', level: 'ERROR');
-        throw LLMApiException(
-            'OpenAI API Request failed: ${response.statusCode} - ${response.body}',
-            statusCode: response.statusCode);
-      }
-
       logger?.call('Response received, parsing data...', level: 'DEBUG');
-      final data = jsonDecode(response.body);
-      if (data is Map<String, dynamic>) {
-        // 200 does not mean success on compat layers — check both known
-        // in-body error spellings before trusting the shape.
-        throwIfEnvelopeError(data);
-      }
+      // Status → JSON → shape → envelope, in that order (decodeJsonBody).
+      final data = decodeJsonBody(response, apiName: 'OpenAI API');
       String text = "";
       List<Uint8List> images = [];
       final List<LLMToolCall> toolCalls = [];
       String? reasoningContent;
       String? reasoningFieldName;
 
-      final choice = data is Map<String, dynamic> ? firstChoice(data) : null;
+      final choice = firstChoice(data);
       final rawMessage = choice?['message'];
       final message =
           rawMessage is Map ? rawMessage.cast<String, dynamic>() : null;
@@ -508,7 +497,7 @@ class OpenAIChatProtocol implements ChatProtocol {
     File? debugFile;
     if (appState.enableApiDebug) {
       debugFile = await LLMDebugLogger.startLog(config.modelId, 'OpenAI (Stream)', {
-        'url': url.toString(),
+        'url': redactUrl(url),
         'headers': headers,
         'body': payload,
       });
@@ -927,12 +916,9 @@ class OpenAIDiscoveryProtocol implements DiscoveryProtocol {
 
     final response = await http.get(url, headers: headers);
 
-    if (response.statusCode != 200) {
-      throw Exception('Failed to fetch OpenAI models: ${response.statusCode} - ${response.body}');
-    }
-
-    final data = jsonDecode(response.body);
-    final List<dynamic> modelsJson = data['data'] ?? [];
+    final data = decodeJsonBody(response, apiName: 'OpenAI models');
+    final rawModels = data['data'];
+    final List<dynamic> modelsJson = rawModels is List ? rawModels : const [];
 
     return modelsJson.map((m) => DiscoveredModel(
       modelId: m['id']?.toString() ?? '',

--- a/lib/services/llm/protocols/openai_images_protocol.dart
+++ b/lib/services/llm/protocols/openai_images_protocol.dart
@@ -85,7 +85,7 @@ class OpenAIImagesProtocol implements ImageGenProtocol {
 
         if (appState.enableApiDebug) {
           debugFile = await LLMDebugLogger.startLog(config.modelId, 'OpenAI (Image Edit)', {
-            'url': url.toString(),
+            'url': redactUrl(url),
             'fields': request.fields,
             'files': request.files.map((f) => f.filename).toList(),
           });
@@ -105,7 +105,7 @@ class OpenAIImagesProtocol implements ImageGenProtocol {
 
         if (appState.enableApiDebug) {
           debugFile = await LLMDebugLogger.startLog(config.modelId, 'OpenAI (Image Generate)', {
-            'url': url.toString(),
+            'url': redactUrl(url),
             'headers': headers,
             'body': payload,
           });
@@ -119,19 +119,12 @@ class OpenAIImagesProtocol implements ImageGenProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      if (response.statusCode != 200) {
-        logger?.call('Images request failed with status: ${response.statusCode}', level: 'ERROR');
-        throw Exception('OpenAI Images API failed: ${response.statusCode} - ${response.body}');
-      }
-
-      final data = jsonDecode(response.body);
-      if (data is Map<String, dynamic>) {
-        // 200 does not mean success on a relay — an `{"error": …}` body used
-        // to parse as zero images and report the task as finished with
-        // nothing in it. Same check the chat surface makes.
-        throwIfEnvelopeError(data);
-      }
-      final rawItems = data is Map ? data['data'] : null;
+      // Status → JSON → shape → envelope, in that order (decodeJsonBody).
+      // 200 does not mean success on a relay — an `{"error": …}` body used
+      // to parse as zero images and report the task as finished with
+      // nothing in it.
+      final data = decodeJsonBody(response, apiName: 'OpenAI Images API');
+      final rawItems = data['data'];
       final List<dynamic> items = rawItems is List ? rawItems : const [];
       final List<Uint8List> images = [];
 
@@ -174,7 +167,7 @@ class OpenAIImagesProtocol implements ImageGenProtocol {
         generatedImages: images,
         // gpt-image-1 reports `input_tokens`/`output_tokens` here, not the
         // chat spelling — see LLMService._recordUsage, which reads both.
-        metadata: (data is Map ? data['usage'] : null) is Map
+        metadata: data['usage'] is Map
             ? (data['usage'] as Map).cast<String, dynamic>()
             : const {},
       );

--- a/lib/services/llm/protocols/openai_videos_protocol.dart
+++ b/lib/services/llm/protocols/openai_videos_protocol.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
@@ -47,7 +46,15 @@ class OpenAIVideosProtocol implements VideoJobProtocol {
     final quality = readStringOption(options, 'videoQuality');
 
     final request = http.MultipartRequest('POST', url);
-    request.headers['Authorization'] = 'Bearer ${config.apiKey}';
+    // Auth comes from the vendor profile (layer 2) like every other surface —
+    // this was the last protocol with a hardcoded bearer header, which worked
+    // only because today's OpenAI-family vendors all happen to use one.
+    // Content-Type is dropped: the multipart body sets its own with a
+    // boundary. Same fix openai_images_protocol.dart documents.
+    request.headers.addAll(
+      Map.of(target.headers())
+        ..removeWhere((k, _) => k.toLowerCase() == 'content-type'),
+    );
     request.fields['model'] = config.modelId;
     request.fields['prompt'] = prompt;
     if (seconds != null) request.fields['seconds'] = seconds;
@@ -100,7 +107,7 @@ class OpenAIVideosProtocol implements VideoJobProtocol {
     File? debugFile;
     if (appState.enableApiDebug) {
       debugFile = await LLMDebugLogger.startLog(config.modelId, 'OpenAI (Video Submit)', {
-        'url': url.toString(),
+        'url': redactUrl(url),
         'fields': request.fields,
         'files': request.files.map((f) => f.filename).toList(),
       });
@@ -116,14 +123,11 @@ class OpenAIVideosProtocol implements VideoJobProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      if (response.statusCode != 200 && response.statusCode != 201) {
-        throw Exception('OpenAI video submit failed: ${response.statusCode} - ${response.body}');
-      }
-
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final data = decodeJsonBody(response, apiName: 'OpenAI video submit');
       final id = data['id']?.toString();
       if (id == null || id.isEmpty) {
-        throw Exception('OpenAI video submit returned no id: ${response.body}');
+        throw LLMApiException(
+            'OpenAI video submit returned no id: ${response.body}');
       }
       logger?.call('OpenAI video task id: $id', level: 'DEBUG');
       return id;
@@ -150,10 +154,11 @@ class OpenAIVideosProtocol implements VideoJobProtocol {
     final client = config.createClient();
     try {
       final response = await client.get(url, headers: headers);
-      if (response.statusCode != 200) {
-        throw Exception('OpenAI video fetch failed: ${response.statusCode} - ${response.body}');
-      }
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      // checkEnvelope: false — a failed job arrives as a 200 with an `error`
+      // field beside `status`; the status machine below owns that case and
+      // names the operation in its message.
+      final data = decodeJsonBody(response,
+          apiName: 'OpenAI video fetch', checkEnvelope: false);
       final status = data['status']?.toString() ?? '';
 
       if (status == 'succeeded') {

--- a/lib/services/llm/protocols/protocol.dart
+++ b/lib/services/llm/protocols/protocol.dart
@@ -8,6 +8,13 @@ import '../llm_types.dart';
 import '../model_descriptor.dart';
 import '../vendors/vendor_profile.dart';
 
+// Every debug-log line that prints a request URL must redact it first —
+// Google-keyed vendors carry `?key=<API_KEY>` in the URL (VendorProfile
+// .decorateUrl), and relying on the log sink's regex to catch it made one
+// mechanism's bug a credential leak. Re-exported here so protocols need no
+// extra import.
+export '../vendors/vendor_profile.dart' show redactUrl;
+
 /// **Layer 1 — the protocol.**
 ///
 /// A protocol is one *wire format*: an endpoint shape, a request payload, a
@@ -170,8 +177,14 @@ void throwIfEnvelopeError(Map<String, dynamic> data) {
 ///
 /// On a non-2xx status the body is still probed for a JSON `error.message` so
 /// the thrown message leads with the provider's own words when there are any.
+///
+/// [checkEnvelope] exists for the async-job *poll* surfaces, which must pass
+/// false: a failed job arrives inside a 200 as `{status: "failed", error:
+/// {...}}` and the poller's own status machine turns that into an error that
+/// names the operation — the generic envelope check would fire first and
+/// discard that context. Every request/submit surface keeps the default.
 Map<String, dynamic> decodeJsonBody(http.Response response,
-    {String apiName = 'API'}) {
+    {String apiName = 'API', bool checkEnvelope = true}) {
   final status = response.statusCode;
   if (status < 200 || status >= 300) {
     String detail = _bodyExcerpt(response.body);
@@ -201,7 +214,7 @@ Map<String, dynamic> decodeJsonBody(http.Response response,
   }
 
   final data = decoded.cast<String, dynamic>();
-  throwIfEnvelopeError(data);
+  if (checkEnvelope) throwIfEnvelopeError(data);
   return data;
 }
 

--- a/lib/services/llm/protocols/xai_images_protocol.dart
+++ b/lib/services/llm/protocols/xai_images_protocol.dart
@@ -88,7 +88,7 @@ class XaiImagesProtocol implements ImageGenProtocol {
     File? debugFile;
     if (appState.enableApiDebug) {
       debugFile = await LLMDebugLogger.startLog(config.modelId, 'xAI (Image ${isEdit ? 'Edit' : 'Generate'})', {
-        'url': url.toString(),
+        'url': redactUrl(url),
         'body': {
           ...payload,
           if (payload.containsKey('image')) 'image': '[base64 data]',
@@ -110,23 +110,23 @@ class XaiImagesProtocol implements ImageGenProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      if (response.statusCode != 200 && response.statusCode != 201) {
-        logger?.call('xAI Images request failed with status: ${response.statusCode}', level: 'ERROR');
-        throw Exception('xAI Images API failed: ${response.statusCode} - ${response.body}');
-      }
-
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
-      final List<dynamic> items = data['data'] ?? [];
+      // Status → JSON → shape → envelope, in that order (decodeJsonBody) —
+      // this surface previously checked none of the body spellings, so a
+      // relay's 200-with-error parsed as "no image data" and hid the cause.
+      final data = decodeJsonBody(response, apiName: 'xAI Images API');
+      final rawItems = data['data'];
+      final List<dynamic> items = rawItems is List ? rawItems : const [];
       final List<Uint8List> images = [];
 
       for (final item in items) {
-        final b64 = item['b64_json'] as String?;
-        if (b64 != null) {
+        if (item is! Map) continue;
+        final b64 = item['b64_json'];
+        if (b64 is String && b64.isNotEmpty) {
           images.add(base64Decode(b64));
           continue;
         }
-        final imgUrl = item['url'] as String?;
-        if (imgUrl != null) {
+        final imgUrl = item['url'];
+        if (imgUrl is String && imgUrl.isNotEmpty) {
           try {
             final imgResp = await client.get(Uri.parse(imgUrl));
             if (imgResp.statusCode == 200) images.add(imgResp.bodyBytes);
@@ -144,7 +144,9 @@ class XaiImagesProtocol implements ImageGenProtocol {
       return LLMResponse(
         text: '',
         generatedImages: images,
-        metadata: data['usage'] ?? {},
+        metadata: data['usage'] is Map
+            ? (data['usage'] as Map).cast<String, dynamic>()
+            : const {},
       );
     } finally {
       client.close();

--- a/lib/services/llm/protocols/xai_videos_protocol.dart
+++ b/lib/services/llm/protocols/xai_videos_protocol.dart
@@ -103,7 +103,7 @@ class XaiVideosProtocol implements VideoJobProtocol {
     File? debugFile;
     if (appState.enableApiDebug) {
       debugFile = await LLMDebugLogger.startLog(config.modelId, 'xAI (Video Submit)', {
-        'url': url.toString(),
+        'url': redactUrl(url),
         'payload': {
           ...payload,
           if (payload.containsKey('image')) 'image': '[base64 data]',
@@ -126,14 +126,11 @@ class XaiVideosProtocol implements VideoJobProtocol {
         await LLMDebugLogger.appendLine(debugFile, 'Body: ${response.body}');
       }
 
-      if (response.statusCode != 200 && response.statusCode != 201) {
-        throw Exception('xAI video submit failed: ${response.statusCode} - ${response.body}');
-      }
-
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final data = decodeJsonBody(response, apiName: 'xAI video submit');
       final requestId = data['request_id']?.toString();
       if (requestId == null || requestId.isEmpty) {
-        throw Exception('xAI video submit returned no request_id: ${response.body}');
+        throw LLMApiException(
+            'xAI video submit returned no request_id: ${response.body}');
       }
       logger?.call('xAI video request id: $requestId', level: 'DEBUG');
       return requestId;
@@ -158,11 +155,12 @@ class XaiVideosProtocol implements VideoJobProtocol {
     final client = config.createClient();
     try {
       final response = await client.get(url, headers: target.headers());
-      // 200 = terminal result; 202 = accepted / still pending.
-      if (response.statusCode != 200 && response.statusCode != 202) {
-        throw Exception('xAI video fetch failed: ${response.statusCode} - ${response.body}');
-      }
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      // 200 = terminal result; 202 = accepted / still pending — both inside
+      // decodeJsonBody's 2xx window. checkEnvelope: false because a failed
+      // job carries an `error` field beside `status`, owned by the status
+      // machine below (which names the request in its message).
+      final data = decodeJsonBody(response,
+          apiName: 'xAI video fetch', checkEnvelope: false);
       final status = data['status']?.toString() ?? '';
 
       switch (status) {

--- a/lib/services/llm/vendors/vendor_profile.dart
+++ b/lib/services/llm/vendors/vendor_profile.dart
@@ -155,6 +155,28 @@ class VendorProfile {
     }
   }
 
+  /// Headers for downloading a vendor-hosted asset — the video/image URI a
+  /// generation job hands back, fetched with a plain GET from a CDN or relay
+  /// rather than an API surface (so [headers]' Content-Type would be wrong
+  /// and the full auth ritual unnecessary).
+  ///
+  /// Keyed off the auth scheme so the decision lives on this layer: the task
+  /// executor used to branch on the protocol family itself, and since each
+  /// side silently ignores the header it doesn't recognize, the next
+  /// non-bearer vendor would have sent the wrong header with no error
+  /// anywhere — just a 403 on download.
+  Map<String, String> downloadHeaders(String apiKey) {
+    if (apiKey.isEmpty) return const {};
+    switch (auth) {
+      case AuthScheme.googleApiKey:
+      case AuthScheme.googleApiKeyWithBearerFallback:
+        return {'x-goog-api-key': apiKey};
+      case AuthScheme.bearer:
+      case AuthScheme.anthropicApiKeyWithBearerFallback:
+        return {'Authorization': 'Bearer $apiKey'};
+    }
+  }
+
   /// Vendor-specific URL decoration. Google-keyed vendors append the
   /// documented `?key=` query parameter (preserving existing parameters such
   /// as `alt=sse`); every other scheme returns the URL untouched so the key

--- a/lib/services/prompt_optimizer_agent.dart
+++ b/lib/services/prompt_optimizer_agent.dart
@@ -1128,6 +1128,8 @@ class PromptOptimizerAgent {
               reasoningContent: response.reasoningContent,
               reasoningFieldName: response.reasoningFieldName,
               reasoningSignature: response.reasoningSignature,
+              rawThinkingBlocks: response.rawThinkingBlocks,
+              rawThinkingModelId: response.rawThinkingModelId,
             ));
             session._addEntry(OptimizerChatEntry(kind: OptimizerEntryKind.assistant, text: text));
           }
@@ -1145,6 +1147,8 @@ class PromptOptimizerAgent {
           reasoningContent: response.reasoningContent,
           reasoningFieldName: response.reasoningFieldName,
           reasoningSignature: response.reasoningSignature,
+          rawThinkingBlocks: response.rawThinkingBlocks,
+          rawThinkingModelId: response.rawThinkingModelId,
           toolCalls: response.toolCalls,
         ));
         if (response.text.trim().isNotEmpty) {
@@ -1625,10 +1629,13 @@ class PromptOptimizerAgent {
         content: m.content,
         // Reasoning must survive verbatim: eliding or editing it would break
         // the ① family echo-back contract the same way dropping a
-        // thoughtSignature breaks Gemini's.
+        // thoughtSignature breaks Gemini's — and ④'s raw thinking blocks the
+        // same way (an incomplete replay silently disables thinking).
         reasoningContent: m.reasoningContent,
         reasoningFieldName: m.reasoningFieldName,
         reasoningSignature: m.reasoningSignature,
+        rawThinkingBlocks: m.rawThinkingBlocks,
+        rawThinkingModelId: m.rawThinkingModelId,
         toolCalls: [
           for (final c in m.toolCalls)
             if (c.name == 'write_knowledge_file' &&
@@ -2147,6 +2154,8 @@ class PromptOptimizerAgent {
         reasoningContent: owning.reasoningContent,
         reasoningFieldName: owning.reasoningFieldName,
         reasoningSignature: owning.reasoningSignature,
+        rawThinkingBlocks: owning.rawThinkingBlocks,
+        rawThinkingModelId: owning.rawThinkingModelId,
         toolCalls: [
           for (final c in owning.toolCalls)
             if (c.id != callId) c,

--- a/lib/services/task_executors.dart
+++ b/lib/services/task_executors.dart
@@ -437,7 +437,7 @@ extension TaskExecutors on TaskQueueService {
     try {
       final db = DatabaseService();
       String? apiKey;
-      ProtocolFamily? vendorFamily;
+      VendorProfile? vendor;
       if (task.modelDbId != null) {
         final models = await db.getModels();
         final model = models.cast<LLMModel?>().firstWhere((m) => m?.id == task.modelDbId, orElse: () => null);
@@ -445,22 +445,17 @@ extension TaskExecutors on TaskQueueService {
           final channel = await db.getChannel(model.channelId!);
           if (channel != null) {
             apiKey = channel.apiKey;
-            vendorFamily = Vendors.byId(channel.type).family;
+            vendor = Vendors.byId(channel.type);
           }
         }
       }
 
       final request = await client.getUrl(Uri.parse(url));
-      if (apiKey != null) {
-        // Veo URIs sit on Google's CDN and want `x-goog-api-key`; OpenAI/Sora
-        // URIs sit on the relay and want `Authorization: Bearer`. The header
-        // each side doesn't recognise is silently ignored, so we key off the
-        // channel's vendor family rather than try to sniff the URL host.
-        if (vendorFamily == ProtocolFamily.gemini) {
-          request.headers.add('x-goog-api-key', apiKey);
-        } else {
-          request.headers.add('Authorization', 'Bearer $apiKey');
-        }
+      if (apiKey != null && vendor != null) {
+        // Which header the asset host wants (Google CDN: x-goog-api-key,
+        // relays: bearer) is Layer 2 knowledge — the vendor profile answers,
+        // this executor just applies it.
+        vendor.downloadHeaders(apiKey).forEach(request.headers.add);
       }
 
       final response = await request.close();

--- a/lib/services/web_scraper_service.dart
+++ b/lib/services/web_scraper_service.dart
@@ -380,6 +380,13 @@ Call select_images with the id numbers of the images that match the requirement.
       messages.add(LLMMessage(
         role: LLMRole.assistant,
         content: response.text,
+        // Echo obligations ride with tool-calling turns on every family:
+        // ①'s reasoning field by original name, ④'s thinking blocks verbatim.
+        reasoningContent: response.reasoningContent,
+        reasoningFieldName: response.reasoningFieldName,
+        reasoningSignature: response.reasoningSignature,
+        rawThinkingBlocks: response.rawThinkingBlocks,
+        rawThinkingModelId: response.rawThinkingModelId,
         toolCalls: response.toolCalls,
       ));
 

--- a/lib/widgets/models/channel_edit_dialog.dart
+++ b/lib/widgets/models/channel_edit_dialog.dart
@@ -50,7 +50,7 @@ class _ChannelEditDialogState extends State<ChannelEditDialog> {
     keyCtrl = TextEditingController(text: channel?.apiKey ?? '');
     tagCtrl = TextEditingController(text: channel?.tag ?? '');
 
-    type = channel?.type ?? 'google-genai-rest';
+    type = channel?.type ?? Vendors.googleRest;
     discovery = channel?.enableDiscovery ?? true;
     tagColor = channel?.tagColor ?? AppConstants.tagColors.first.toARGB32();
   }

--- a/test/anthropic_chat_test.dart
+++ b/test/anthropic_chat_test.dart
@@ -619,4 +619,109 @@ void main() {
       );
     });
   });
+
+  group('raw thinking blocks (verbatim replay)', () {
+    final sealed = {
+      'type': 'thinking',
+      'thinking': 'let me check',
+      'signature': 'sig-1',
+    };
+    final redacted = {'type': 'redacted_thinking', 'data': 'opaque-blob'};
+
+    test('parse keeps sealed thinking and redacted_thinking, in order', () {
+      final content = parseAnthropicContent([
+        sealed,
+        redacted,
+        {'type': 'text', 'text': 'hi'},
+      ]);
+      // redacted_thinking still shows nothing and counts nothing…
+      expect(content.thinking, 'let me check');
+      // …but it must survive for replay: ④ answers an incomplete thinking
+      // history by silently disabling thinking, not by erroring.
+      expect(content.rawThinkingBlocks, [sealed, redacted]);
+    });
+
+    test('an unsigned thinking block is not kept for replay', () {
+      final content = parseAnthropicContent([
+        {'type': 'thinking', 'thinking': 'unsealed'},
+        redacted,
+      ]);
+      expect(content.rawThinkingBlocks, [redacted]);
+    });
+
+    test('replayed verbatim, before text and tool_use, on a model match', () {
+      final p = payload([
+        LLMMessage(role: LLMRole.user, content: 'go'),
+        LLMMessage(
+          role: LLMRole.assistant,
+          content: 'calling',
+          rawThinkingBlocks: [sealed, redacted],
+          rawThinkingModelId: 'claude-opus-5',
+          toolCalls: [LLMToolCall(id: 't1', name: 'f', arguments: {})],
+        ),
+        LLMMessage(
+            role: LLMRole.tool, content: 'ok', toolCallId: 't1', toolName: 'f'),
+      ]);
+      final assistant = (p['messages'] as List)[1] as Map;
+      final blocks = assistant['content'] as List;
+      expect(blocks[0], sealed);
+      expect(blocks[1], redacted);
+      expect((blocks[2] as Map)['type'], 'text');
+      expect((blocks[3] as Map)['type'], 'tool_use');
+    });
+
+    test('a different model drops the whole group — no reconstruction', () {
+      // Foreign blocks are not rejected upstream; they are silently ignored
+      // and still billed as input.
+      final p = payload([
+        LLMMessage(role: LLMRole.user, content: 'go'),
+        LLMMessage(
+          role: LLMRole.assistant,
+          content: 'calling',
+          reasoningContent: 'let me check',
+          reasoningSignature: 'sig-1',
+          rawThinkingBlocks: [sealed, redacted],
+          rawThinkingModelId: 'claude-haiku-4-5',
+          toolCalls: [LLMToolCall(id: 't1', name: 'f', arguments: {})],
+        ),
+      ]);
+      final assistant = (p['messages'] as List)[1] as Map;
+      final types =
+          [for (final b in assistant['content'] as List) (b as Map)['type']];
+      expect(types, isNot(contains('thinking')));
+      expect(types, isNot(contains('redacted_thinking')));
+    });
+
+    test('legacy histories without raw blocks still reconstruct a sealed one',
+        () {
+      final p = payload([
+        LLMMessage(role: LLMRole.user, content: 'go'),
+        LLMMessage(
+          role: LLMRole.assistant,
+          content: '',
+          reasoningContent: 'old turn',
+          reasoningSignature: 'sig-old',
+          toolCalls: [LLMToolCall(id: 't1', name: 'f', arguments: {})],
+        ),
+      ]);
+      final assistant = (p['messages'] as List)[1] as Map;
+      expect((assistant['content'] as List).first, {
+        'type': 'thinking',
+        'thinking': 'old turn',
+        'signature': 'sig-old',
+      });
+    });
+
+    test('raw blocks survive an LLMMessage JSON round-trip', () {
+      final msg = LLMMessage(
+        role: LLMRole.assistant,
+        content: 'x',
+        rawThinkingBlocks: [sealed, redacted],
+        rawThinkingModelId: 'claude-opus-5',
+      );
+      final revived = LLMMessage.fromJson(msg.toJson());
+      expect(revived.rawThinkingBlocks, [sealed, redacted]);
+      expect(revived.rawThinkingModelId, 'claude-opus-5');
+    });
+  });
 }

--- a/test/llm_error_handling_test.dart
+++ b/test/llm_error_handling_test.dart
@@ -2,8 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:joycai_image_ai_toolkits/services/llm/llm_service.dart';
 import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/model_family.dart';
 import 'package:joycai_image_ai_toolkits/services/llm/protocols/gemini_chat_protocol.dart';
 import 'package:joycai_image_ai_toolkits/services/llm/protocols/protocol.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/vendors/vendors.dart';
 
 /// Pins the M1 error-handling fixes (docs/reviews/2026-08-ai-capability-review.md
 /// B1/B2/B5): the Gemini SSE line rules, the status-first response decode, and
@@ -103,6 +105,55 @@ void main() {
     test('a clean 200 returns the decoded map', () {
       final response = http.Response('{"candidates":[]}', 200);
       expect(decodeJsonBody(response), {'candidates': []});
+    });
+
+    test('201/202 are inside the success window (submit/poll surfaces)', () {
+      expect(decodeJsonBody(http.Response('{"id":"v1"}', 201)), {'id': 'v1'});
+      expect(decodeJsonBody(http.Response('{"status":"pending"}', 202)),
+          {'status': 'pending'});
+    });
+
+    test('checkEnvelope: false hands a failed-job body to the caller', () {
+      // Poll surfaces own the {status: failed, error: {...}} case — their
+      // status machine names the operation; the generic envelope check would
+      // fire first and discard that context.
+      final response =
+          http.Response('{"status":"failed","error":{"message":"boom"}}', 200);
+      expect(decodeJsonBody(response, checkEnvelope: false),
+          containsPair('status', 'failed'));
+      expect(() => decodeJsonBody(response), throwsA(isA<LLMApiException>()));
+    });
+  });
+
+  group('VendorProfile.downloadHeaders', () {
+    test('google-keyed vendors get x-goog-api-key, bearer vendors a bearer',
+        () {
+      expect(Vendors.byId(Vendors.officialGoogle).downloadHeaders('k'),
+          {'x-goog-api-key': 'k'});
+      expect(Vendors.byId(Vendors.googleRest).downloadHeaders('k'),
+          {'x-goog-api-key': 'k'});
+      expect(Vendors.byId(Vendors.openAIRest).downloadHeaders('k'),
+          {'Authorization': 'Bearer k'});
+      // newapi-gemini serves the Gemini family behind bearer auth — keying
+      // off the *protocol family* (the old executor branch) would have sent
+      // it x-goog-api-key, which the relay silently ignores → 403.
+      expect(Vendors.byId(Vendors.newApiGemini).downloadHeaders('k'),
+          {'Authorization': 'Bearer k'});
+    });
+
+    test('an empty key sends no auth header at all', () {
+      expect(Vendors.byId(Vendors.openAIRest).downloadHeaders(''), isEmpty);
+    });
+  });
+
+  group('ModelFamilyClassifier named predicates', () {
+    test('niji / text-only / mock rules live in the rule table', () {
+      expect(ModelFamilyClassifier.isNijiVariant('Niji-6'), isTrue);
+      expect(ModelFamilyClassifier.isNijiVariant('mj_fast'), isFalse);
+      expect(ModelFamilyClassifier.isTextOnlyChat('deepseek-chat'), isTrue);
+      expect(ModelFamilyClassifier.isTextOnlyChat('gpt-4o'), isFalse);
+      expect(ModelFamilyClassifier.isMockModel('mock-video'), isTrue);
+      expect(ModelFamilyClassifier.isMockModel('sora-2'), isFalse);
     });
   });
 


### PR DESCRIPTION
## What

Completes the **M2 milestone** from `docs/plans/2026-08-ai-improvement-plan.md` §2. M1 (#95) established the hardened patterns; this PR makes them the only way to write a protocol, so implementations can no longer drift. Two commits, reviewable separately:

### Commit 1 — `refactor: consolidate LLM protocol hardening into shared mechanisms`

**Shared-decode sweep (M2-A)** — all ten protocols (chat sync paths, images, video submit/poll, Midjourney submit/fetch, all four discovery listings) now decode through `decodeJsonBody` (status → JSON → shape → envelope). Poll surfaces pass `checkEnvelope: false`: a failed job arrives as a 200 with an `error` field beside `status`, and the poller's status machine owns that case so the operation id stays in the message. `xai_images` gains the envelope check and Map guards it never had.

**Discipline zeroing (M2-B)** — review §4 items:
- V1: `openai_videos` submit uses `target.headers()` instead of a hardcoded bearer (last protocol bypassing the vendor profile).
- V2: `mock-` sniffing moved into Layer 3 (`ModelDescriptor.isMockModel`); niji/deepseek string rules consolidated as named predicates on `ModelFamilyClassifier`.
- V3: `setup_wizard` tags fetched models via `ModelFamilyClassifier.inferTag` instead of a second, divergent `contains()` chain.
- V4 (**corrected during implementation**): the wizard's 15 "bare vendor ids" from the review were preset ids — a separate namespace whose `channelType` field already uses `Vendors.*`. The only real violation was `channel_edit_dialog`'s `'google-genai-rest'` literal, now a constant. The review doc is amended and both exemptions (frozen migrations, preset ids) are recorded in the red-line table.
- V5: new `VendorProfile.downloadHeaders(apiKey)` — which auth header an asset download needs is Layer 2 knowledge. The old executor branch keyed off the *protocol family*, which sends `x-goog-api-key` to bearer-authenticated Gemini relays (newapi-gemini): silently ignored upstream, 403 on download. A test pins that exact case.

**Contract unification (M2-C)** — the dispatcher's Midjourney `checkOperation` branch now translates raw `/mj/task` JSON into the Veo-shaped envelope every other family returns; all 13 debug-log URL sites go through `redactUrl` (re-exported via `protocol.dart`) instead of relying on the log sink's regex to strip `?key=`.

**Docs (M2-D)** — `docs/architecture/llm-three-layer.md` gains a "shared mechanisms" section (the template for future protocols) and an updated red-line grep table.

### Commit 2 — `fix: preserve Anthropic thinking blocks verbatim for replay (B6)`

Reconstructing the thinking block from `reasoningContent` + signature lost exactly the blocks with no text to rebuild from: `redacted_thinking`. A tool-calling turn replayed without it is an incomplete thinking history, which the Messages API answers by **silently disabling thinking while still billing it** — not by erroring.

- `LLMMessage`/`LLMResponse` gain `rawThinkingBlocks` (sealed `thinking` + `redacted_thinking`, verbatim, original order) and `rawThinkingModelId`, persisted through the session JSON round-trip.
- Replay is model-scoped: matching model → blocks go back verbatim ahead of text/tool_use; model switch → the whole group is dropped (foreign blocks are silently ignored and billed as input); histories persisted before this change fall back to the old reconstruction.
- All assistant-echo sites carry the new fields — including the web scraper, whose echo previously carried no reasoning fields at all (same silent-strip risk on a thinking-enabled Anthropic channel).

## Reviewer notes

- `gemini_veo` `poll()` keeps its documented exemption from `decodeJsonBody` (failed operations arrive as `{done, error}` inside a 200 and the executor consumes that envelope).
- The MJ `checkOperation` branch is currently unreachable in practice (MJ classifies as an image family; only the video executor polls) — the translation is contract alignment, commented as such.
- Behavior change: `checkEnvelope` defaults to true, so images/submit surfaces that previously ignored 200-with-error bodies now throw with the provider's message.

## Testing

- `flutter analyze` — no issues.
- 600 tests pass; new coverage: `decodeJsonBody` 2xx window + `checkEnvelope: false`, `downloadHeaders` (incl. the newapi-gemini case), classifier predicates, and six raw-thinking tests in `test/anthropic_chat_test.dart` (parse order, unsigned exclusion, verbatim replay position, model-mismatch drop, legacy fallback, JSON round-trip).
- Red-line greps from `llm-three-layer.md` run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)