### PR TITLE
feat: sub-agent notes store and read_note (M3.2)

### DIFF
--- a/lib/services/database_migrations.dart
+++ b/lib/services/database_migrations.dart
@@ -58,6 +58,7 @@ class DatabaseMigration {
     if (oldVersion < 31) await _createV31Tables(db);
     if (oldVersion < 32) await _createV32Tables(db);
     if (oldVersion < 33) await _createV33Tables(db);
+    if (oldVersion < 34) await _createV34Tables(db);
   }
 
   static Future<void> onCreate(Database db) async {
@@ -91,7 +92,30 @@ class DatabaseMigration {
     await _createV31Tables(db);
     await _createV32Tables(db);
     await _createV33Tables(db);
+    await _createV34Tables(db);
     // Presets are synchronized in DatabaseService
+  }
+
+  /// Knowledge sub-agent research notes, scoped to the assistant session that
+  /// commissioned them. The delegate tool stores the sub-agent's full
+  /// findings here and hands the model only a digest + note id; `read_note`
+  /// pages the full text back on demand. Deleted together with the session
+  /// (no FK — session deletion is manual, matching assistant_messages).
+  static Future<void> _createV34Tables(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS assistant_notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        slug TEXT NOT NULL,
+        title TEXT NOT NULL,
+        content TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    ''');
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_assistant_notes_session '
+      'ON assistant_notes (session_id, id)',
+    );
   }
 
   /// Per-task logs, as a JSON array of already-timestamped lines.

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -53,7 +53,7 @@ class DatabaseService {
 
   /// Schema version of this build. Also stamped into full backups so a file
   /// from a newer app can be rejected instead of failing mid-restore.
-  static const int dbVersion = 33;
+  static const int dbVersion = 34;
 
   /// Settings holding absolute paths from the machine that made the backup.
   /// Excluded when the user opts out of directories.

--- a/lib/services/llm/llm_service.dart
+++ b/lib/services/llm/llm_service.dart
@@ -97,7 +97,7 @@ class LLMService {
 
           // Record usage
           if (response.metadata.isNotEmpty) {
-            _recordUsage(config.modelId, config, response.metadata, modelDbId: modelIdentifier is int ? modelIdentifier : null);
+            _recordUsage(config.modelId, config, response.metadata, modelDbId: modelIdentifier is int ? modelIdentifier : null, taskTag: options?['usageTag']?.toString());
           }
 
           // Update session
@@ -124,7 +124,7 @@ class LLMService {
 
           // Record usage
           if (response.metadata.isNotEmpty) {
-            _recordUsage(config.modelId, config, response.metadata, modelDbId: modelIdentifier is int ? modelIdentifier : null);
+            _recordUsage(config.modelId, config, response.metadata, modelDbId: modelIdentifier is int ? modelIdentifier : null, taskTag: options?['usageTag']?.toString());
           }
 
           // Update session
@@ -267,7 +267,7 @@ class LLMService {
     }
   }
 
-  Future<void> _recordUsage(String modelId, LLMModelConfig config, Map<String, dynamic> metadata, {int? modelDbId}) async {
+  Future<void> _recordUsage(String modelId, LLMModelConfig config, Map<String, dynamic> metadata, {int? modelDbId, String? taskTag}) async {
     final db = DatabaseService();
 
     // Standardize metadata keys. Three spellings are in play: Google
@@ -284,7 +284,10 @@ class LLMService {
     final cacheTokens = _extractCacheTokens(metadata, promptTokens);
 
     await db.recordTokenUsage({
-      'task_id': 'req_${DateTime.now().millisecondsSinceEpoch}',
+      // The tag makes delegated work distinguishable in the usage table
+      // (e.g. `task_id LIKE 'subagent:%'`) — a sub-agent's spend should be
+      // attributable to delegation, not blended into ordinary requests.
+      'task_id': '${taskTag ?? 'req'}_${DateTime.now().millisecondsSinceEpoch}',
       'model_id': modelId,
       'model_pk': modelDbId,
       'timestamp': DateTime.now().toIso8601String(),

--- a/lib/services/prompt_optimizer_agent.dart
+++ b/lib/services/prompt_optimizer_agent.dart
@@ -10,6 +10,7 @@ import 'knowledge_base_service.dart';
 import 'llm/context_budget.dart';
 import 'llm/llm_service.dart';
 import 'llm/llm_types.dart';
+import 'repositories/assistant_note_repository.dart';
 import 'repositories/assistant_session_repository.dart';
 import 'sub_agent_runner.dart';
 
@@ -573,6 +574,24 @@ class PromptOptimizerSession extends ChangeNotifier {
                   text: '',
                   toolName: 'list_knowledge_files',
                 ));
+              case 'delegate':
+                // A plain chip: the note (if one was stored) lives in the DB
+                // keyed by session, so read_note keeps working after a
+                // restart — nothing else to rebuild.
+                final delegatedTask = call.arguments['task']?.toString() ?? '';
+                entries.add(OptimizerChatEntry(
+                  kind: OptimizerEntryKind.tool,
+                  text: delegatedTask.length > 120
+                      ? '${delegatedTask.substring(0, 120)}…'
+                      : delegatedTask,
+                  toolName: 'delegate',
+                ));
+              case 'read_note':
+                entries.add(OptimizerChatEntry(
+                  kind: OptimizerEntryKind.tool,
+                  text: '#${call.arguments['note_id'] ?? ''}',
+                  toolName: 'read_note',
+                ));
               case 'list_reference_images':
                 entries.add(OptimizerChatEntry(
                   kind: OptimizerEntryKind.tool,
@@ -984,6 +1003,27 @@ class PromptOptimizerAgent {
         'required': ['kind', 'task'],
       },
     ),
+    LLMTool(
+      name: 'read_note',
+      description: 'Read back the full findings of an earlier delegate run in '
+          'this conversation. Large notes are paged — request further pages '
+          'only when needed. The summary you already have is usually enough; '
+          'read the note when you need exact wording or details it omitted.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'note_id': {
+            'type': 'integer',
+            'description': 'The note_id a delegate result returned.',
+          },
+          'page': {
+            'type': 'integer',
+            'description': '1-based page number, defaults to 1.',
+          },
+        },
+        'required': ['note_id'],
+      },
+    ),
   ];
 
   /// The toolset for one request, assembled from the session's mode and the
@@ -1321,6 +1361,24 @@ class PromptOptimizerAgent {
               result = {
                 'status': 'error',
                 'message': 'Tool delegate failed: $e',
+              };
+            }
+          } else if (call.name == 'read_note') {
+            // Async (note store lives in SQLite), so alongside delegate
+            // rather than in the synchronous _executeTool switch.
+            try {
+              result = await _executeReadNote(
+                call,
+                session,
+                systemPrompt: systemPromptText,
+                contextWindow: contextWindow,
+                onLog: onLog,
+              );
+            } catch (e) {
+              onLog?.call('Tool read_note failed: $e');
+              result = {
+                'status': 'error',
+                'message': 'Tool read_note failed: $e',
               };
             }
           } else {
@@ -1701,9 +1759,15 @@ class PromptOptimizerAgent {
     ];
   }
 
+  @visibleForTesting
+  static LLMMessage elideForTest(LLMMessage m) => _elide(m);
+
   static LLMMessage _elide(LLMMessage m) {
+    // read_note results elide exactly like knowledge reads: both are bulk
+    // text the model pulled in on demand and can pull in again — notes even
+    // more safely, since nothing ever rewrites a stored note.
     if (m.role == LLMRole.tool &&
-        m.toolName == 'read_knowledge_file' &&
+        (m.toolName == 'read_knowledge_file' || m.toolName == 'read_note') &&
         m.content.length > 300) {
       return LLMMessage(
         role: LLMRole.tool,
@@ -1898,10 +1962,11 @@ class PromptOptimizerAgent {
     return buffer.toString();
   }
 
-  /// Digest cap for what a delegate run reports back into the main context.
-  /// Enough to judge the findings; deliberately not enough to be the whole
-  /// research (M3.2 adds notes so the full findings stay retrievable).
-  static const int _delegateSummaryChars = 2000;
+  /// Digest cap for what a delegate run reports back into the main context —
+  /// enough to judge the findings, deliberately not enough to substitute for
+  /// reading the note (the playbook's 800-char rule: a digest that could
+  /// stand in for the note would just move the flooding one level up).
+  static const int _delegateSummaryChars = 800;
 
   /// Per-read cap for the sub-agent's knowledge reads. A constant rather than
   /// the main loop's live budget arithmetic: the sub-run starts from a fresh
@@ -2003,6 +2068,7 @@ class PromptOptimizerAgent {
       isCancelled: isCancelled,
       onLog: (m) => onLog?.call('[KB sub-agent] $m'),
       contextId: contextId,
+      usageTag: 'subagent:knowledge',
     );
 
     if (result.cancelled) {
@@ -2024,11 +2090,104 @@ class PromptOptimizerAgent {
     }
     onLog?.call('Sub-agent finished in ${result.turnsUsed} turn(s), '
         '${output.length} chars of findings.');
+
+    // Full findings go to the session's note store; the main context gets a
+    // digest and the note id. Best-effort: a storage failure downgrades to
+    // digest-only rather than failing a research run that already succeeded.
+    AssistantNote? note;
+    try {
+      note = await AssistantNoteRepository().insert(
+        sessionId: session.id,
+        title: task.length > 80 ? task.substring(0, 80) : task,
+        content: output,
+      );
+    } catch (e) {
+      onLog?.call('Note storage failed (returning digest only): $e');
+    }
+
+    final truncated = output.length > _delegateSummaryChars;
     return {
       'status': 'ok',
-      'summary': output.length > _delegateSummaryChars
-          ? '${output.substring(0, _delegateSummaryChars)}…(truncated)'
+      if (note != null) 'note_id': note.id,
+      'summary': truncated
+          ? '${output.substring(0, _delegateSummaryChars)}…'
           : output,
+      if (note != null && truncated)
+        'hint': 'Full findings (${output.length} chars) are saved as note '
+            '${note.id} — call read_note with that note_id when you need the '
+            'detail.',
+    };
+  }
+
+  /// Runs one `read_note` call: pages a stored sub-agent note back into the
+  /// conversation. Session-scoped (a foreign note id reads as not-found) and
+  /// behind the same read-cap gate as knowledge reads — its results are
+  /// elided by [_elide] later, exactly like a knowledge read, and can simply
+  /// be re-read then (notes have no staleness: nothing rewrites them).
+  static Future<Map<String, dynamic>> _executeReadNote(
+    LLMToolCall call,
+    PromptOptimizerSession session, {
+    required String systemPrompt,
+    required int? contextWindow,
+    void Function(String message)? onLog,
+  }) async {
+    final rawId = call.arguments['note_id'];
+    final noteId = rawId is int ? rawId : int.tryParse(rawId?.toString() ?? '');
+    if (noteId == null) {
+      return {
+        'status': 'error',
+        'message':
+            'Pass note_id — the integer id a delegate result returned.',
+      };
+    }
+    final rawPage = call.arguments['page'];
+    final page =
+        rawPage is int ? rawPage : int.tryParse(rawPage?.toString() ?? '') ?? 1;
+    onLog?.call('Tool call: read_note #$noteId (page $page)');
+
+    final cap = _readCapNow(session, systemPrompt, contextWindow);
+    if (cap < _minReadChars) {
+      return {
+        'status': 'error',
+        'message': 'Not enough context left to read the note — work with the '
+            'summary you already have.',
+      };
+    }
+
+    final note =
+        await AssistantNoteRepository().get(noteId, sessionId: session.id);
+    if (note == null) {
+      return {
+        'status': 'error',
+        'message': 'No note $noteId in this conversation. Use the note_id a '
+            'delegate result returned.',
+      };
+    }
+    session._addEntry(OptimizerChatEntry(
+      kind: OptimizerEntryKind.tool,
+      text: '#$noteId ${note.title}',
+      toolName: 'read_note',
+    ));
+
+    // Paged like knowledge reads: a fixed page size keeps page numbers
+    // stable across reads; only a window tighter than one page shrinks it.
+    final pageSize = cap < KnowledgeBaseService.pageSize
+        ? cap
+        : KnowledgeBaseService.pageSize;
+    final content = note.content;
+    final bounds = KnowledgeBaseService.pageBoundaries(content, pageSize);
+    final total = bounds.length;
+    final idx = page < 1 ? 1 : (page > total ? total : page);
+    final start = bounds[idx - 1];
+    final end = idx < total ? bounds[idx] : content.length;
+    return {
+      'note_id': noteId,
+      'page': idx,
+      'total_pages': total,
+      'content': content.substring(start, end),
+      if (total > idx)
+        'note': 'Note continues — request the next page only if this part '
+            'is not enough.',
     };
   }
 

--- a/lib/services/repositories/assistant_note_repository.dart
+++ b/lib/services/repositories/assistant_note_repository.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/foundation.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../database_service.dart';
+
+/// One stored sub-agent research note.
+class AssistantNote {
+  final int id;
+  final String sessionId;
+  final String slug;
+  final String title;
+  final String content;
+  final DateTime createdAt;
+
+  const AssistantNote({
+    required this.id,
+    required this.sessionId,
+    required this.slug,
+    required this.title,
+    required this.content,
+    required this.createdAt,
+  });
+
+  static AssistantNote fromRow(Map<String, dynamic> row) => AssistantNote(
+        id: row['id'] as int,
+        sessionId: row['session_id'] as String,
+        slug: row['slug'] as String? ?? '',
+        title: row['title'] as String? ?? '',
+        content: row['content'] as String? ?? '',
+        createdAt:
+            DateTime.fromMillisecondsSinceEpoch(row['created_at'] as int? ?? 0),
+      );
+}
+
+/// SQLite store for knowledge sub-agent findings (`assistant_notes`, v34).
+///
+/// Notes are **session-scoped**: they are commissioned by one conversation,
+/// read back only by that conversation, and die with it. This is the app's
+/// form of the playbook's "findings go to disk, the tool result carries a
+/// digest + a reference" — SQLite session scope instead of an on-disk task
+/// workspace because there is no pause/resume to survive yet; the two designs
+/// are compatible if that ever changes.
+class AssistantNoteRepository {
+  /// [dbProvider] exists for tests (an in-memory database); production code
+  /// uses the default [DatabaseService].
+  AssistantNoteRepository({Future<Database> Function()? dbProvider})
+      : _dbProvider = dbProvider;
+
+  final Future<Database> Function()? _dbProvider;
+
+  Future<Database> _getDb() async =>
+      _dbProvider != null ? await _dbProvider() : await DatabaseService().database;
+
+  /// Hard cap on stored note content. Sub-agent digests are typically a few
+  /// KB; anything beyond this is stored truncated **with a visible marker**
+  /// rather than rejected — the note is derived data (the knowledge base
+  /// itself remains re-readable), so losing its tail is an acceptable cost
+  /// while silently failing to store anything is not.
+  static const int maxContentChars = 64000;
+
+  /// Keeps letters/digits in any script plus `-`; everything else becomes
+  /// `-`. An ASCII whitelist here would collapse every CJK title into the
+  /// same empty slug. Truncated by code points so a surrogate pair is never
+  /// split.
+  @visibleForTesting
+  static String sanitizeSlug(String raw) {
+    final cleaned = raw
+        .replaceAll(RegExp(r'[^\p{L}\p{N}-]+', unicode: true), '-')
+        .replaceAll(RegExp(r'-{2,}'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    final runes = cleaned.runes.toList();
+    final capped = runes.length > 60 ? String.fromCharCodes(runes.take(60)) : cleaned;
+    return capped.isEmpty ? 'note' : capped;
+  }
+
+  /// Stores a note and returns it (with its assigned id and final slug).
+  ///
+  /// Slug collisions within the session get a `-2` / `-3` suffix — never an
+  /// overwrite, and the caller sees the name that actually stuck.
+  Future<AssistantNote> insert({
+    required String sessionId,
+    required String title,
+    required String content,
+  }) async {
+    final db = await _getDb();
+    final base = sanitizeSlug(title);
+    final existing = await db.query(
+      'assistant_notes',
+      columns: ['slug'],
+      where: 'session_id = ?',
+      whereArgs: [sessionId],
+    );
+    final taken = {for (final row in existing) row['slug'] as String};
+    var slug = base;
+    for (var n = 2; taken.contains(slug); n++) {
+      slug = '$base-$n';
+    }
+
+    final storedContent = content.length > maxContentChars
+        ? '${content.substring(0, maxContentChars)}\n\n'
+            '[note truncated at $maxContentChars characters]'
+        : content;
+
+    final now = DateTime.now();
+    final id = await db.insert('assistant_notes', {
+      'session_id': sessionId,
+      'slug': slug,
+      'title': title,
+      'content': storedContent,
+      'created_at': now.millisecondsSinceEpoch,
+    });
+    return AssistantNote(
+      id: id,
+      sessionId: sessionId,
+      slug: slug,
+      title: title,
+      content: storedContent,
+      createdAt: now,
+    );
+  }
+
+  /// The note with [id] — but only if it belongs to [sessionId]. A note id
+  /// pointing into another session returns null rather than content: reading
+  /// a note nobody in this conversation commissioned is worse than not
+  /// finding it (same rule the playbook applies to cross-task note refs).
+  Future<AssistantNote?> get(int id, {required String sessionId}) async {
+    final db = await _getDb();
+    final rows = await db.query(
+      'assistant_notes',
+      where: 'id = ? AND session_id = ?',
+      whereArgs: [id, sessionId],
+      limit: 1,
+    );
+    return rows.isEmpty ? null : AssistantNote.fromRow(rows.first);
+  }
+
+  /// Notes of one session, oldest first (stable order for listings).
+  Future<List<AssistantNote>> listForSession(String sessionId) async {
+    final db = await _getDb();
+    final rows = await db.query(
+      'assistant_notes',
+      where: 'session_id = ?',
+      whereArgs: [sessionId],
+      orderBy: 'id ASC',
+    );
+    return rows.map(AssistantNote.fromRow).toList();
+  }
+
+  /// Removes a session's notes. Called by
+  /// `AssistantSessionRepository.deleteSession` so retention GC covers notes
+  /// without a second policy.
+  Future<void> deleteForSession(String sessionId) async {
+    final db = await _getDb();
+    await db.delete('assistant_notes',
+        where: 'session_id = ?', whereArgs: [sessionId]);
+  }
+}

--- a/lib/services/repositories/assistant_session_repository.dart
+++ b/lib/services/repositories/assistant_session_repository.dart
@@ -66,9 +66,15 @@ class StoredAssistantMessage {
 /// compaction summary keep `compacted = 1` so the full history stays
 /// inspectable while replay skips them.
 class AssistantSessionRepository {
-  final DatabaseService _dbService = DatabaseService();
+  /// [dbProvider] exists for tests (an in-memory database); production code
+  /// uses the default [DatabaseService].
+  AssistantSessionRepository({Future<Database> Function()? dbProvider})
+      : _dbProvider = dbProvider;
 
-  Future<Database> _getDb() async => await _dbService.database;
+  final Future<Database> Function()? _dbProvider;
+
+  Future<Database> _getDb() async =>
+      _dbProvider != null ? await _dbProvider() : await DatabaseService().database;
 
   Future<void> upsertSession({
     required String id,
@@ -218,6 +224,9 @@ class AssistantSessionRepository {
   Future<void> deleteSession(String id) async {
     final db = await _getDb();
     await db.delete('assistant_messages', where: 'session_id = ?', whereArgs: [id]);
+    // Sub-agent notes are session-scoped and die with the session (v34; no
+    // FK, deletion is manual like assistant_messages).
+    await db.delete('assistant_notes', where: 'session_id = ?', whereArgs: [id]);
     await db.delete('assistant_sessions', where: 'id = ?', whereArgs: [id]);
   }
 

--- a/lib/services/sub_agent_runner.dart
+++ b/lib/services/sub_agent_runner.dart
@@ -75,13 +75,20 @@ class SubAgentRunner {
     bool Function()? isCancelled,
     void Function(String message)? onLog,
     String? contextId,
+
+    /// Tags this run's usage rows (e.g. `subagent:knowledge`) so delegated
+    /// spend stays attributable in the usage table.
+    String? usageTag,
     @visibleForTesting SubAgentRequestFn? request,
   }) async {
     final requestFn = request ??
         (messages, tools) => LLMService().request(
               modelIdentifier: modelIdentifier,
               messages: messages,
-              options: const {'retryCount': 2},
+              options: {
+                'retryCount': 2,
+                'usageTag': ?usageTag,
+              },
               tools: tools,
               contextId: contextId,
               useStream: false,

--- a/test/assistant_note_repository_test.dart
+++ b/test/assistant_note_repository_test.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joycai_image_ai_toolkits/services/database_migrations.dart';
+import 'package:joycai_image_ai_toolkits/services/database_service.dart';
+import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
+import 'package:joycai_image_ai_toolkits/services/prompt_optimizer_agent.dart';
+import 'package:joycai_image_ai_toolkits/services/repositories/assistant_note_repository.dart';
+import 'package:joycai_image_ai_toolkits/services/repositories/assistant_session_repository.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// Pins the M3.2 note store (assistant_notes, v34): slug hygiene, session
+/// scoping, collision handling, the retention path, and the elide rule that
+/// keeps read_note results from re-flooding the context they exist to spare.
+void main() {
+  sqfliteFfiInit();
+  final factory = databaseFactoryFfi;
+
+  late Database db;
+  late AssistantNoteRepository notes;
+
+  Future<Database> provider() async => db;
+
+  setUp(() async {
+    db = await factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: DatabaseService.dbVersion,
+        onCreate: (db, version) => DatabaseMigration.onCreate(db),
+      ),
+    );
+    notes = AssistantNoteRepository(dbProvider: provider);
+  });
+
+  tearDown(() async => db.close());
+
+  group('sanitizeSlug', () {
+    test('keeps letters and digits of any script', () {
+      // An ASCII whitelist would collapse every CJK title into ''.
+      expect(AssistantNoteRepository.sanitizeSlug('角色设定 规则 v2'),
+          '角色设定-规则-v2');
+    });
+
+    test('collapses runs and trims edge dashes', () {
+      expect(AssistantNoteRepository.sanitizeSlug('  a//b__c  '), 'a-b-c');
+    });
+
+    test('caps at 60 code points and never returns empty', () {
+      expect(AssistantNoteRepository.sanitizeSlug('好' * 80).runes.length, 60);
+      expect(AssistantNoteRepository.sanitizeSlug('!!!'), 'note');
+    });
+  });
+
+  group('insert / get', () {
+    test('round-trips a note within its session', () async {
+      final note = await notes.insert(
+          sessionId: 's1', title: '查一下构图规则', content: 'findings text');
+      expect(note.id, greaterThan(0));
+      final loaded = await notes.get(note.id, sessionId: 's1');
+      expect(loaded!.content, 'findings text');
+      expect(loaded.slug, '查一下构图规则');
+    });
+
+    test('a note id from another session reads as not-found', () async {
+      // Reading a note nobody in this conversation commissioned is worse
+      // than not finding it.
+      final note = await notes.insert(
+          sessionId: 's1', title: 't', content: 'secret');
+      expect(await notes.get(note.id, sessionId: 's2'), isNull);
+    });
+
+    test('slug collisions get suffixes, never an overwrite', () async {
+      final a = await notes.insert(sessionId: 's1', title: '规则', content: 'a');
+      final b = await notes.insert(sessionId: 's1', title: '规则', content: 'b');
+      final c = await notes.insert(sessionId: 's1', title: '规则', content: 'c');
+      expect(a.slug, '规则');
+      expect(b.slug, '规则-2');
+      expect(c.slug, '规则-3');
+      expect((await notes.get(a.id, sessionId: 's1'))!.content, 'a');
+    });
+
+    test('oversize content is truncated with a visible marker', () async {
+      final note = await notes.insert(
+        sessionId: 's1',
+        title: 'big',
+        content: 'x' * (AssistantNoteRepository.maxContentChars + 100),
+      );
+      expect(note.content.length,
+          lessThan(AssistantNoteRepository.maxContentChars + 100));
+      expect(note.content, contains('[note truncated'));
+    });
+
+    test('listForSession returns only that session, oldest first', () async {
+      await notes.insert(sessionId: 's1', title: 'a', content: '1');
+      await notes.insert(sessionId: 's2', title: 'x', content: '2');
+      await notes.insert(sessionId: 's1', title: 'b', content: '3');
+      final list = await notes.listForSession('s1');
+      expect([for (final n in list) n.title], ['a', 'b']);
+    });
+  });
+
+  group('retention', () {
+    test('deleteSession removes the session\'s notes with it', () async {
+      final sessions = AssistantSessionRepository(dbProvider: provider);
+      await sessions.upsertSession(
+          id: 's1', mode: AssistantMode.knowledgeBase, refImages: const []);
+      final note =
+          await notes.insert(sessionId: 's1', title: 't', content: 'c');
+      await notes.insert(sessionId: 'other', title: 't', content: 'kept');
+
+      await sessions.deleteSession('s1');
+
+      expect(await notes.get(note.id, sessionId: 's1'), isNull);
+      expect(await notes.listForSession('other'), hasLength(1));
+    });
+  });
+
+  group('read_note elision', () {
+    test('bulky read_note results elide exactly like knowledge reads', () {
+      final elided = PromptOptimizerAgent.elideForTest(LLMMessage(
+        role: LLMRole.tool,
+        content: jsonEncode({'note_id': 1, 'content': 'x' * 500}),
+        toolCallId: 'c1',
+        toolName: 'read_note',
+      ));
+      expect(elided.content, contains('Content elided'));
+      // Pairing survives: only the content is swapped.
+      expect(elided.toolCallId, 'c1');
+      expect(elided.toolName, 'read_note');
+    });
+
+    test('small results and other tools pass through untouched', () {
+      final small = LLMMessage(
+        role: LLMRole.tool,
+        content: '{"status":"ok"}',
+        toolCallId: 'c1',
+        toolName: 'read_note',
+      );
+      expect(PromptOptimizerAgent.elideForTest(small).content, small.content);
+    });
+  });
+}


### PR DESCRIPTION
## What

Second slice of the **M3 milestone** (`docs/plans/2026-08-ai-improvement-plan.md` §3.7/§3.11), building on #97. Delegate runs now persist their full findings; the main context gets a digest plus a cheap way back to the detail — the playbook's "findings go to disk, the tool result carries a summary + a reference", implemented as **SQLite session scope** rather than an on-disk task workspace (no pause/resume exists to justify one; the designs are compatible if that changes).

- **`assistant_notes` table (schema v34) + `AssistantNoteRepository`.** Notes are session-scoped and die with the session (`deleteSession`/retention covers them — pinned by a test). Slugs are Unicode-sanitized (`\p{L}\p{N}-`; an ASCII whitelist would collapse every CJK title into one slug), collisions get `-2`/`-3` suffixes — never an overwrite — and oversize content truncates **with a visible marker**.
- **delegate stores a note** and returns `{note_id, summary ≤800, hint}`. The digest cap drops from M3.1's 2000 to the playbook's 800: a summary that could substitute for the note would just move the context flooding one level up.
- **New `read_note` tool**: pages a stored note back using the same `pageBoundaries` paging and read-cap gate as knowledge reads. A note id from another session reads as **not-found** (reading a note nobody in this conversation commissioned is worse than not finding it). Results are elided by the existing Layer-1 rule exactly like knowledge reads — and are always safely re-readable, since nothing ever rewrites a note.
- **Restore**: delegate/read_note calls rebuild as plain tool chips; notes live in the DB, so `read_note` keeps working across app restarts.
- **Usage attribution**: sub-agent requests tag their `token_usage` rows (`task_id` prefix `subagent:knowledge`) via a `usageTag` option threaded `SubAgentRunner → LLMService` — delegated spend stays queryable (`task_id LIKE 'subagent:%'`).
- Repositories accept an injectable `dbProvider` so the store is tested against a real in-memory schema.

## Reviewer notes

- One deliberate deviation from the playbook's note rules: oversize content is stored **truncated with a marker** instead of rejected — the note is derived data (the KB remains re-readable), so losing the tail beats silently storing nothing. Rationale in the repository dartdoc.
- The sub-agent's fixed per-read cap and the dedicated model binding remain open (tracked as the M3 leftovers, together with M3.3's `draft` kind).

## Testing

`flutter analyze` clean; **623 tests pass** (11 new in `test/assistant_note_repository_test.dart`: slug hygiene incl. CJK, session scoping, collision suffixes, truncation marker, retention cascade, read_note elision + pairing survival).

🤖 Generated with [Claude Code](https://claude.com/claude-code)