### PR TITLE
feat: draft delegate kind for per-image prompt drafting (M3.3)

### DIFF
--- a/docs/plans/2026-08-ai-improvement-plan.md
+++ b/docs/plans/2026-08-ai-improvement-plan.md
@@ -236,12 +236,30 @@ static Future<bool> knowledgeDelegateAvailable(sessionModelId) …
 - **transcript**：新 entry kind `subagent`（折叠卡：task 摘要 → 运行中 spinner → 完成后摘要 + 笔记 chip）；子循环的 onLog 以 `[KB 子代理]` 前缀并入任务日志。恰好落在审查 §5.7 可观测性改进的同一批 UI 工作里，建议同期做停止按钮。
 - **失败呈现**：子代理 LLM 报错 → error 结果回主模型（含「可自行用 read_knowledge_file 继续」的指引，playbook 8.9 错误写成下一步动作）；不中断主 turn。
 
-### 3.10 展望：任务拆分（M3.3，本期只留接口）
+### 3.10 M3.3：`draft` kind（2026-08 定稿）
 
-`kind` 枚举的扩展方向（每个都是「加数据行」）：
-- `draft`：批处理场景按参考图逐张起草 prewrite prompt（主模型只做终审合成）——最对症的第二个 kind，因为批量草稿正是「上下文灾难型」工作。
-- `longread`：通读单个超长 KB 文件出结构化提要。
-扩展前提：M3.1/3.2 的 SubAgentRunner 与笔记存储已稳定。**不做**并行编排——同轮多个 delegate 顺序执行（playbook 9.63）。
+批量参考图场景的「上下文灾难」是图片本身：每张 `view_image` 都把 base64 附件塞进主
+历史（估价 `_attachmentChars=2000`/张，真实成本更高）。`draft` kind 把「看一张图、
+按 brief 起草」整个搬进子代理的独立上下文——**每次委托恰好一张图**，主模型只收
+文字草稿并负责终审合成，主上下文可以全程不装图。
+
+设计要点：
+
+- **工具形状**：`delegate` 的 `kind` 枚举扩为按可用性动态组装（schema 在下发时
+  构造，playbook 8.11 的拷贝注入同理）：`paths` 字段仅 knowledge 可用时出现，
+  `image_id`（1-based，与 `view_image` 同一编号空间）仅 draft 可用时出现。
+- **可用性（每 kind 独立前置条件，playbook 9.44）**：`knowledge` = 开关 + 知识
+  模式；`draft` = 开关 + 会话有参考图 + **生效子代理模型接受图片输入**（Layer 3
+  `acceptsImageInput`；绑定模型由 executor 解析时判定，跟随会话则同会话模型）。
+  任一 kind 可用即挂 `delegate` + `read_note`。
+- **子代理运行形状**：无工具、`maxTurns: 1` 的单发——system（draft 专用 prompt：
+  先描述图中要素，再按 brief 给草稿片段，不得虚构图外内容）+ user（brief + 单图
+  附件，`viewOnly` 引用类型走既有压缩通道）。产出走与 knowledge 相同的
+  笔记 + ≤800 digest 收尾（`subagent:draft` usage 标签）。
+- **不改的东西**：`view_image` 仍在主模型工具集（主模型想亲自看图仍然可以）；
+  `forceViewAllImages` 铁轨不认草稿（该模式的语义就是主模型亲看，与委托互斥由
+  用户选择）；同轮多个 delegate 顺序执行（playbook 9.63）。
+- **展望（未立项）**：`longread` kind——通读单个超长 KB 文件出结构化提要。
 
 ### 3.11 分期与退出标准
 

--- a/lib/services/prompt_optimizer_agent.dart
+++ b/lib/services/prompt_optimizer_agent.dart
@@ -964,52 +964,69 @@ class PromptOptimizerAgent {
     ),
   ];
 
-  /// Research delegation, added in the knowledge modes when the user has
-  /// enabled the knowledge sub-agent (Settings, default off).
+  /// Delegation to a sub-agent, offered when the user has enabled it in
+  /// Settings (default off) and at least one kind's preconditions hold.
   ///
-  /// `kind` is an enum with a single value today — future kinds (batch
-  /// drafting, long reads) are new enum values, not new protocols. The
-  /// description teaches the zero-context-inheritance rule: the sub-agent
-  /// sees nothing of this conversation, so the brief must stand alone.
+  /// The schema is built per hand-out (never a mutated shared constant):
+  /// the `kind` enum lists only the kinds available to *this* session, and
+  /// each kind's private parameter (`paths` for knowledge, `image_id` for
+  /// draft) appears only when its kind does — a field describing an
+  /// unavailable capability reads as an instruction to try it.
   ///
-  /// Deliberately additive: `read_knowledge_file` stays in the main toolset.
-  /// Targeted single reads are day-to-day work (taking them away adds a
-  /// round-trip to everything), and the read-before-write rail is anchored
-  /// on the *main* history's live reads — sub-agent research never licenses
-  /// a write.
-  static final List<LLMTool> _delegateTools = [
-    LLMTool(
+  /// The description teaches the zero-context-inheritance rule: the
+  /// sub-agent sees nothing of this conversation, so the brief must stand
+  /// alone. Deliberately additive: `read_knowledge_file` and `view_image`
+  /// stay in the main toolset — targeted work is day-to-day, and the
+  /// read-before-write rail is anchored on the *main* history's live reads.
+  @visibleForTesting
+  static LLMTool delegateToolFor(Set<String> kinds) {
+    final hasKnowledge = kinds.contains('knowledge');
+    final hasDraft = kinds.contains('draft');
+    return LLMTool(
       name: 'delegate',
-      description: 'Hand a knowledge-base research task to a sub-agent. The '
-          'sub-agent sees NOTHING of this conversation — write everything it '
-          'needs to know into "task" (the question, relevant context, what '
-          'the answer will be used for). It will browse and read the '
-          'knowledge base in its own separate context and return a findings '
-          'summary, so use it for broad research across files; for reading '
-          'one specific file you already know, call read_knowledge_file '
-          'directly.',
+      description: 'Hand a task to a sub-agent that works in its own '
+          'separate context. The sub-agent sees NOTHING of this conversation '
+          '— write everything it needs to know into "task". '
+          '${hasKnowledge ? 'kind "knowledge": broad research across '
+              'knowledge-base files (for reading one specific file you '
+              'already know, call read_knowledge_file directly). ' : ''}'
+          '${hasDraft ? 'kind "draft": study ONE reference image (image_id) '
+              'and draft a prompt fragment for it per your brief — use it '
+              'to cover many reference images without viewing them all '
+              'yourself. ' : ''}'
+          'Returns a findings summary (full text retrievable via read_note).',
       parameters: {
         'type': 'object',
         'properties': {
           'kind': {
             'type': 'string',
-            'enum': ['knowledge'],
-            'description': 'The kind of sub-agent. Only "knowledge" exists.',
+            'enum': [if (hasDraft) 'draft', if (hasKnowledge) 'knowledge'],
+            'description': 'The kind of sub-agent.',
           },
           'task': {
             'type': 'string',
-            'description': 'The complete, self-contained research brief.',
+            'description': 'The complete, self-contained brief.',
           },
-          'paths': {
-            'type': 'array',
-            'items': {'type': 'string'},
-            'description': 'Optional: knowledge-base file paths (relative) '
-                'the sub-agent should start from.',
-          },
+          if (hasKnowledge)
+            'paths': {
+              'type': 'array',
+              'items': {'type': 'string'},
+              'description': 'knowledge only, optional: knowledge-base file '
+                  'paths (relative) the sub-agent should start from.',
+            },
+          if (hasDraft)
+            'image_id': {
+              'type': 'integer',
+              'description': 'draft only, required: the reference image id '
+                  '(same ids as list_reference_images / view_image).',
+            },
         },
         'required': ['kind', 'task'],
       },
-    ),
+    );
+  }
+
+  static final List<LLMTool> _noteTools = [
     LLMTool(
       name: 'read_note',
       description: 'Read back the full findings of an earlier delegate run in '
@@ -1037,7 +1054,11 @@ class PromptOptimizerAgent {
   /// turn's state. Pure so the routing rules are pinnable in tests:
   ///
   ///  * capability routing is a toolset change, never a prompt suggestion;
-  ///  * `delegate` is additive to the knowledge tools, not a replacement;
+  ///  * `delegate` is additive to the knowledge/image tools, never a
+  ///    replacement, and appears when any kind in [delegateKinds] is
+  ///    available (the kinds themselves are decided by the caller: knowledge
+  ///    needs a knowledge session, draft needs reference images and an
+  ///    image-capable sub-agent model);
   ///  * context exhaustion removes `read_knowledge_file` (each refused call
   ///    costs a full-window request) but keeps `delegate` — the sub-agent
   ///    researches in its own fresh context, so running out of room here is
@@ -1047,7 +1068,7 @@ class PromptOptimizerAgent {
     required bool acceptsImageInput,
     required bool knowledgeMode,
     required bool editMode,
-    bool delegateAvailable = false,
+    Set<String> delegateKinds = const {},
     bool contextExhausted = false,
   }) {
     final baseTools = acceptsImageInput
@@ -1060,7 +1081,10 @@ class PromptOptimizerAgent {
       ...baseTools,
       if (knowledgeMode || editMode) ..._knowledgeTools,
       if (editMode) ..._knowledgeWriteTools,
-      if (delegateAvailable && (knowledgeMode || editMode)) ..._delegateTools,
+      if (delegateKinds.isNotEmpty) ...[
+        delegateToolFor(delegateKinds),
+        ..._noteTools,
+      ],
     ];
     return contextExhausted
         ? [for (final t in tools) if (t.name != 'read_knowledge_file') t]
@@ -1091,6 +1115,7 @@ class PromptOptimizerAgent {
     bool kbSubAgentEnabled = false,
     dynamic kbSubAgentModelIdentifier,
     int? kbSubAgentContextWindow,
+    bool kbSubAgentAcceptsImages = true,
     void Function(String message)? onLog,
     bool Function()? isCancelled,
   }) async {
@@ -1113,7 +1138,16 @@ class PromptOptimizerAgent {
     final effectiveRefs =
         acceptsImageInput ? referenceImages : const <Map<String, String>>[];
     final effectiveForceView = forceViewAllImages && acceptsImageInput;
-    final delegateAvailable = kbSubAgentEnabled && knowledgeMode;
+    // Each delegate kind has its own precondition (playbook: enabled is not
+    // available): knowledge needs a knowledge session; draft needs reference
+    // images to draft from and a sub-agent model that can see them.
+    final delegateKinds = <String>{
+      if (kbSubAgentEnabled && knowledgeMode) 'knowledge',
+      if (kbSubAgentEnabled &&
+          effectiveRefs.isNotEmpty &&
+          kbSubAgentAcceptsImages)
+        'draft',
+    };
     // Weak local models tend to issue a single tool call per turn, so viewing
     // every reference image one by one needs list + N views + submit turns.
     // Knowledge mode needs extra headroom for file listing/reading rounds.
@@ -1190,7 +1224,7 @@ class PromptOptimizerAgent {
           acceptsImageInput: acceptsImageInput,
           knowledgeMode: knowledgeMode,
           editMode: editMode,
-          delegateAvailable: delegateAvailable,
+          delegateKinds: delegateKinds,
           contextExhausted: contextExhausted,
         );
 
@@ -1363,7 +1397,8 @@ class PromptOptimizerAgent {
                 session,
                 kbSubAgentModelIdentifier ?? modelIdentifier,
                 knowledgeRoot,
-                delegateAvailable: delegateAvailable,
+                availableKinds: delegateKinds,
+                referenceImages: effectiveRefs,
                 contextWindow: kbSubAgentModelIdentifier != null
                     ? kbSubAgentContextWindow
                     : contextWindow,
@@ -2024,30 +2059,26 @@ class PromptOptimizerAgent {
     PromptOptimizerSession session,
     dynamic modelIdentifier,
     String? knowledgeRoot, {
-    required bool delegateAvailable,
+    required Set<String> availableKinds,
+    required List<Map<String, String>> referenceImages,
     int? contextWindow,
     String? contextId,
     void Function(String message)? onLog,
     bool Function()? isCancelled,
   }) async {
     // Precondition checks first, with zero side effects: a refused delegate
-    // must not have sent a request or produced a transcript entry.
-    if (knowledgeRoot == null) return _kbUnavailable();
-    if (!delegateAvailable) {
-      // The model can hallucinate a tool it was never offered; what decides
-      // is the setting, not the tool list (same rule as write_knowledge_file).
-      return {
-        'status': 'error',
-        'message': 'The knowledge sub-agent is not enabled. Research the '
-            'knowledge base yourself with list_knowledge_files and '
-            'read_knowledge_file.',
-      };
-    }
+    // must not have sent a request or produced a transcript entry. The model
+    // can hallucinate a kind it was never offered; what decides is each
+    // kind's precondition, not the schema it happened to see (same rule as
+    // write_knowledge_file).
     final kind = call.arguments['kind']?.toString() ?? '';
-    if (kind != 'knowledge') {
+    if (!availableKinds.contains(kind)) {
       return {
         'status': 'error',
-        'message': 'Unknown delegate kind "$kind" — only "knowledge" exists.',
+        'message': 'Delegate kind "$kind" is not available here'
+            '${availableKinds.isEmpty ? '' : ' (available: ${availableKinds.join(', ')})'}. '
+            '"knowledge" needs a knowledge-base session; "draft" needs '
+            'reference images and an image-capable sub-agent model.',
       };
     }
     final task = call.arguments['task']?.toString().trim() ?? '';
@@ -2055,10 +2086,26 @@ class PromptOptimizerAgent {
       return {
         'status': 'error',
         'message': 'The task argument must not be empty. Write a '
-            'self-contained research brief — the sub-agent sees nothing of '
-            'this conversation.',
+            'self-contained brief — the sub-agent sees nothing of this '
+            'conversation.',
       };
     }
+
+    if (kind == 'draft') {
+      return _runDraftDelegate(
+        call,
+        session,
+        modelIdentifier,
+        task,
+        referenceImages,
+        contextId: contextId,
+        onLog: onLog,
+        isCancelled: isCancelled,
+      );
+    }
+
+    // kind == 'knowledge'
+    if (knowledgeRoot == null) return _kbUnavailable();
     final rawPaths = call.arguments['paths'];
     final paths = [
       if (rawPaths is List)
@@ -2066,12 +2113,10 @@ class PromptOptimizerAgent {
           if (p.toString().trim().isNotEmpty) p.toString().trim(),
     ];
 
-    final taskPreview =
-        task.length > 120 ? '${task.substring(0, 120)}…' : task;
-    onLog?.call('Tool call: delegate (knowledge) — $taskPreview');
+    onLog?.call('Tool call: delegate (knowledge) — ${_clipPreview(task)}');
     session._addEntry(OptimizerChatEntry(
       kind: OptimizerEntryKind.tool,
-      text: taskPreview,
+      text: _clipPreview(task),
       toolName: 'delegate',
     ));
 
@@ -2087,7 +2132,100 @@ class PromptOptimizerAgent {
       contextId: contextId,
       usageTag: 'subagent:knowledge',
     );
+    return _finishDelegateRun(session, task, result, onLog);
+  }
 
+  static String _clipPreview(String task) =>
+      task.length > 120 ? '${task.substring(0, 120)}…' : task;
+
+  /// System prompt of the drafting sub-agent — a code asset, like
+  /// [_kbSubAgentSystemPrompt].
+  static const String _draftSubAgentSystemPrompt =
+      'You are a drafting sub-agent. You receive ONE reference image and a '
+      'brief; you cannot see the conversation the brief came from.\n\n'
+      'Study the image, then answer in plain text:\n'
+      '1. What matters in the image for the brief: subject, style, '
+      'composition, lighting, palette, notable details.\n'
+      '2. A draft prompt fragment that captures it, following the brief\'s '
+      'instructions.\n'
+      'Describe only what is visible — never invent details the image does '
+      'not show.';
+
+  /// One `draft` run: a single-shot sub-agent over exactly one reference
+  /// image. No tools and one turn — the whole point is that the image and
+  /// its description live in the sub-agent's context, not the main one.
+  static Future<Map<String, dynamic>> _runDraftDelegate(
+    LLMToolCall call,
+    PromptOptimizerSession session,
+    dynamic modelIdentifier,
+    String task,
+    List<Map<String, String>> referenceImages, {
+    String? contextId,
+    void Function(String message)? onLog,
+    bool Function()? isCancelled,
+  }) async {
+    final rawImageId = call.arguments['image_id'];
+    final imageId =
+        rawImageId is int ? rawImageId : int.tryParse(rawImageId?.toString() ?? '');
+    if (imageId == null || imageId < 1 || imageId > referenceImages.length) {
+      return {
+        'status': 'error',
+        'message': 'Pass image_id between 1 and ${referenceImages.length} — '
+            'the ids list_reference_images shows. One image per draft run.',
+      };
+    }
+    final ref = referenceImages[imageId - 1];
+    final path = ref['path'];
+    if (path == null || !File(path).existsSync()) {
+      return {
+        'status': 'error',
+        'message': 'Reference image #$imageId is no longer available on disk.',
+      };
+    }
+
+    onLog?.call('Tool call: delegate (draft, image #$imageId) — ${_clipPreview(task)}');
+    session._addEntry(OptimizerChatEntry(
+      kind: OptimizerEntryKind.tool,
+      text: '[draft #$imageId] ${_clipPreview(task)}',
+      toolName: 'delegate',
+    ));
+
+    final result = await SubAgentRunner.run(
+      modelIdentifier: modelIdentifier,
+      systemPrompt: _draftSubAgentSystemPrompt,
+      task: task,
+      attachments: [
+        LLMAttachment.fromFile(
+          File(path),
+          _mimeTypeFor(path),
+          // viewOnly: eligible for lossy recompression when oversized — the
+          // sub-agent only describes it, nothing feeds back into generation.
+          referenceType: LLMReferenceType.viewOnly,
+        ),
+      ],
+      tools: const [],
+      executeTool: (_, _) => const {
+        'status': 'error',
+        'message': 'A draft run has no tools — answer in plain text.',
+      },
+      maxTurns: 1,
+      isCancelled: isCancelled,
+      onLog: (m) => onLog?.call('[draft sub-agent] $m'),
+      contextId: contextId,
+      usageTag: 'subagent:draft',
+    );
+    return _finishDelegateRun(session, task, result, onLog);
+  }
+
+  /// Shared tail of every delegate run: cancellation, the empty-output rule
+  /// (no note, no digest — an empty note would just relocate the nothing),
+  /// then note storage + digest.
+  static Future<Map<String, dynamic>> _finishDelegateRun(
+    PromptOptimizerSession session,
+    String task,
+    SubAgentResult result,
+    void Function(String message)? onLog,
+  ) async {
     if (result.cancelled) {
       return {
         'status': 'cancelled',
@@ -2097,12 +2235,10 @@ class PromptOptimizerAgent {
     }
     final output = result.output.trim();
     if (output.isEmpty) {
-      // No note, no digest — an empty file would just relocate the nothing.
       return {
         'status': 'error',
-        'message': 'The knowledge sub-agent returned nothing. Try a narrower '
-            'task, or research the knowledge base yourself with '
-            'list_knowledge_files and read_knowledge_file.',
+        'message': 'The sub-agent returned nothing. Try a narrower or more '
+            'specific task, or do the work yourself with your own tools.',
       };
     }
     onLog?.call('Sub-agent finished in ${result.turnsUsed} turn(s), '

--- a/lib/services/sub_agent_runner.dart
+++ b/lib/services/sub_agent_runner.dart
@@ -79,6 +79,11 @@ class SubAgentRunner {
     required dynamic modelIdentifier,
     required String systemPrompt,
     required String task,
+
+    /// Attached to the task message — e.g. the single reference image of a
+    /// `draft` run. The sub-agent's context is exactly these two messages,
+    /// so this is the only way anything binary reaches it.
+    List<LLMAttachment> attachments = const [],
     required List<LLMTool> tools,
     required SubAgentToolFn executeTool,
     int maxTurns = _defaultMaxTurns,
@@ -106,7 +111,7 @@ class SubAgentRunner {
 
     final messages = <LLMMessage>[
       LLMMessage(role: LLMRole.system, content: systemPrompt),
-      LLMMessage(role: LLMRole.user, content: task),
+      LLMMessage(role: LLMRole.user, content: task, attachments: attachments),
     ];
 
     var lastText = '';

--- a/lib/services/task_executors.dart
+++ b/lib/services/task_executors.dart
@@ -184,6 +184,10 @@ extension TaskExecutors on TaskQueueService {
       // the sub-agent on a model the user deliberately routed away from.
       dynamic kbSubAgentModel;
       int? kbSubAgentWindow;
+      // Whether the *effective* sub-agent model can see images decides the
+      // draft kind's availability — following the session means inheriting
+      // the session model's answer.
+      var kbSubAgentAcceptsImages = acceptsImageInput;
       if (kbSubAgentEnabled) {
         final boundRaw = await DatabaseService()
             .getSetting(PromptOptimizerAgent.kbSubAgentModelSettingKey);
@@ -201,6 +205,8 @@ extension TaskExecutors on TaskQueueService {
           } else {
             kbSubAgentModel = bound.id;
             kbSubAgentWindow = bound.contextWindow;
+            kbSubAgentAcceptsImages =
+                ModelDescriptor.of(bound.modelId).acceptsImageInput;
           }
         }
       }
@@ -238,6 +244,7 @@ extension TaskExecutors on TaskQueueService {
         kbSubAgentEnabled: kbSubAgentEnabled,
         kbSubAgentModelIdentifier: kbSubAgentModel,
         kbSubAgentContextWindow: kbSubAgentWindow,
+        kbSubAgentAcceptsImages: kbSubAgentAcceptsImages,
         onLog: (msg) {
           task.addLog(msg);
           refreshQueue();

--- a/test/sub_agent_runner_test.dart
+++ b/test/sub_agent_runner_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:joycai_image_ai_toolkits/services/llm/llm_types.dart';
@@ -203,35 +204,37 @@ void main() {
   group('toolsetFor routing', () {
     Iterable<String> names(List<LLMTool> tools) => tools.map((t) => t.name);
 
-    test('delegate appears only in knowledge modes with the opt-in', () {
+    test('delegate and read_note appear iff any kind is available', () {
       expect(
         names(PromptOptimizerAgent.toolsetFor(
           acceptsImageInput: true,
           knowledgeMode: true,
           editMode: false,
-          delegateAvailable: true,
+          delegateKinds: const {'knowledge'},
         )),
-        contains('delegate'),
+        containsAll(['delegate', 'read_note']),
       );
-      // Enabled but not a knowledge session: nothing to research.
-      expect(
-        names(PromptOptimizerAgent.toolsetFor(
-          acceptsImageInput: true,
-          knowledgeMode: false,
-          editMode: false,
-          delegateAvailable: true,
-        )),
-        isNot(contains('delegate')),
-      );
-      // Knowledge session but the setting is off: the tool does not exist.
-      expect(
-        names(PromptOptimizerAgent.toolsetFor(
-          acceptsImageInput: true,
-          knowledgeMode: true,
-          editMode: false,
-        )),
-        isNot(contains('delegate')),
-      );
+      // No available kind: neither tool exists.
+      final none = names(PromptOptimizerAgent.toolsetFor(
+        acceptsImageInput: true,
+        knowledgeMode: true,
+        editMode: false,
+      ));
+      expect(none, isNot(contains('delegate')));
+      expect(none, isNot(contains('read_note')));
+    });
+
+    test('draft kind works outside knowledge sessions', () {
+      // A system-prompt session with reference images and an image-capable
+      // sub-agent model still gets drafting delegation.
+      final tools = names(PromptOptimizerAgent.toolsetFor(
+        acceptsImageInput: true,
+        knowledgeMode: false,
+        editMode: false,
+        delegateKinds: const {'draft'},
+      ));
+      expect(tools, contains('delegate'));
+      expect(tools, isNot(contains('read_knowledge_file')));
     });
 
     test('delegate is additive — the direct read tool stays', () {
@@ -239,7 +242,7 @@ void main() {
         acceptsImageInput: true,
         knowledgeMode: true,
         editMode: false,
-        delegateAvailable: true,
+        delegateKinds: const {'knowledge'},
       ));
       expect(tools, contains('read_knowledge_file'));
       expect(tools, contains('delegate'));
@@ -252,7 +255,7 @@ void main() {
         acceptsImageInput: true,
         knowledgeMode: true,
         editMode: false,
-        delegateAvailable: true,
+        delegateKinds: const {'knowledge'},
         contextExhausted: true,
       ));
       expect(tools, isNot(contains('read_knowledge_file')));
@@ -264,12 +267,63 @@ void main() {
         acceptsImageInput: false,
         knowledgeMode: true,
         editMode: true,
-        delegateAvailable: true,
+        delegateKinds: const {'knowledge'},
       ));
       expect(tools, contains('write_knowledge_file'));
       expect(tools, contains('delegate'));
       expect(tools, isNot(contains('view_image')));
       expect(tools, isNot(contains('list_reference_images')));
+    });
+  });
+
+  group('delegateToolFor schema shaping', () {
+    Map<String, dynamic> props(LLMTool t) =>
+        (t.parameters['properties'] as Map).cast<String, dynamic>();
+
+    test('the kind enum lists exactly the available kinds', () {
+      final both =
+          PromptOptimizerAgent.delegateToolFor(const {'knowledge', 'draft'});
+      expect((props(both)['kind'] as Map)['enum'], ['draft', 'knowledge']);
+
+      final only = PromptOptimizerAgent.delegateToolFor(const {'knowledge'});
+      expect((props(only)['kind'] as Map)['enum'], ['knowledge']);
+    });
+
+    test("each kind's private field appears only with its kind", () {
+      // A field describing an unavailable capability reads as an
+      // instruction to try it.
+      final knowledge =
+          PromptOptimizerAgent.delegateToolFor(const {'knowledge'});
+      expect(props(knowledge), contains('paths'));
+      expect(props(knowledge), isNot(contains('image_id')));
+
+      final draft = PromptOptimizerAgent.delegateToolFor(const {'draft'});
+      expect(props(draft), contains('image_id'));
+      expect(props(draft), isNot(contains('paths')));
+      expect(draft.description, contains('image_id'));
+      expect(draft.description, isNot(contains('read_knowledge_file')));
+    });
+  });
+
+  group('runner attachments', () {
+    test('attachments ride on the task message only', () async {
+      List<LLMMessage>? seen;
+      await SubAgentRunner.run(
+        modelIdentifier: 'm',
+        systemPrompt: 'sys',
+        task: 'brief',
+        attachments: [
+          LLMAttachment.fromBytes(Uint8List.fromList([1, 2, 3]), 'image/png'),
+        ],
+        tools: const [],
+        executeTool: (_, _) => {},
+        request: (messages, tools) async {
+          seen = List.of(messages);
+          return LLMResponse(text: 'done');
+        },
+      );
+      expect(seen![0].attachments, isEmpty);
+      expect(seen![1].attachments, hasLength(1));
     });
   });
 }


### PR DESCRIPTION
## What

The final **M3 slice** (`docs/plans/2026-08-ai-improvement-plan.md` §3.10 — the design was detailed in this change, as the plan required). The batch-reference "context disaster" is the images themselves: every `view_image` puts a base64 attachment into the main history. The **`draft` kind** moves "study one image, draft a prompt fragment per the brief" into the sub-agent's separate context — exactly one image per delegation, the main model receives text drafts and composes the final prompt **without ever loading the images itself**.

- **Per-hand-out schema** (`delegateToolFor`): the `kind` enum lists only the kinds available to this session; each kind's private field (`paths` for knowledge, `image_id` for draft) appears only with its kind. A field describing an unavailable capability reads as an instruction to try it.
- **Per-kind availability** ("enabled is not available", per kind): `knowledge` = knowledge session; `draft` = reference images present **and** the effective sub-agent model accepts image input (Layer 3 `acceptsImageInput`; for bound models resolved by the executor). Draft therefore also works in plain system-prompt sessions — delegation is no longer knowledge-only.
- **Run shape**: a draft run is a single-shot, tool-less `SubAgentRunner` turn — dedicated system prompt (describe what's visible, never invent) + brief + one `viewOnly` attachment (oversize images take the existing recompression path). Same note + ≤800 digest tail as knowledge runs (shared `_finishDelegateRun`), usage-tagged `subagent:draft`.
- **Unchanged on purpose**: `view_image` stays in the main toolset (the main model may still look for itself); the `forceViewAllImages` rail does not accept drafts — that mode's meaning is the main model seeing with its own eyes, and choosing between it and delegation belongs to the user; same-batch delegates run sequentially (no parallel orchestration).
- `SubAgentRunner` gains an `attachments` parameter (task message only — the sub-agent's context is exactly two messages).

## Testing

`flutter analyze` clean; **628 tests pass**. New: schema shaping per kind set (enum contents, conditional fields), draft-available-outside-knowledge routing, runner attachment placement. Real-image drafting quality needs a live model — worth a quick manual pass alongside the M3.1 context-usage check.

With this, **M3 is complete** (M3.1 MVP → M3.2 notes → model binding → M3.3 draft kind). Remaining from the improvement plan: the two optional M2+ items (①-family reasoning effort control, channel probe button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)